### PR TITLE
Refine transactional email docs and homepage messaging

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,3 +1,3 @@
 {
-  "ignorePatterns": []
+  "ignorePatterns": ["apps/fumadocs/src/routeTree.gen.ts"]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Email SDK
 
-A lightweight TypeScript SDK for unified email sending. One clean API, swappable adapters, fallbacks, hooks, a Bun CLI, and Fumadocs documentation.
+A lightweight TypeScript SDK for transactional email. Use one client in your app, pick the adapters
+you actually send through, and keep provider-specific field support visible in the docs.
 
 ## Packages
 

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -8,9 +8,8 @@ Email SDK ships with fifteen adapters. Import only the adapter you use; the pack
 to configure providers that are not on your send path.
 
 Every adapter follows the same contract: map the fields it supports and throw a validation error for
-fields the provider API cannot represent. Use the
-
-<a href="/docs/adapters/field-support">SDK field support guide</a> before choosing fallback routes.
+fields the provider API cannot represent. Use the [SDK field support guide](/docs/adapters/field-support)
+before choosing fallback routes.
 
 <ProviderGrid />
 

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -4,9 +4,13 @@ description: Supported email service adapters and transports.
 icon: Cable
 ---
 
-Email SDK ships with fifteen adapters. Import only the adapter you use.
+Email SDK ships with fifteen adapters. Import only the adapter you use; the package does not ask you
+to configure providers that are not on your send path.
 
-Every adapter is stable in the same sense: it maps the fields it supports and throws a validation error for fields the provider API cannot represent. Use the <a href="/docs/adapters/field-support">SDK field support guide</a> before choosing fallback routes.
+Every adapter follows the same contract: map the fields it supports and throw a validation error for
+fields the provider API cannot represent. Use the
+
+<a href="/docs/adapters/field-support">SDK field support guide</a> before choosing fallback routes.
 
 <ProviderGrid />
 

--- a/apps/fumadocs/content/docs/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs/getting-started/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Install Email SDK, create a client, and send a message.
+description: Install Email SDK, create a client, and send a first transactional email.
 icon: Rocket
 ---
 
@@ -10,7 +10,7 @@ Install the SDK:
 bun add email-sdk
 ```
 
-This example sends through Resend.
+This example sends through Resend. Set `RESEND_API_KEY` in the environment before running it.
 
 ```ts
 import { createEmailClient } from "email-sdk";
@@ -30,7 +30,12 @@ await email.send({
 
 ## Add built-in SMTP fallback
 
-Add SMTP when you want a second route for the same transactional email. The SMTP adapter is built in and does not require Nodemailer. When SMTP auth is configured on a non-secure connection, Email SDK upgrades with STARTTLS before authenticating.
+Add SMTP when you want a second route for the same transactional email. The SMTP adapter is built in
+and does not require Nodemailer. When SMTP auth is configured on a non-secure connection, Email SDK
+upgrades with STARTTLS before authenticating.
+
+Only use fallback adapters that can send the same message shape. For example, SMTP supports address
+fields and headers, but not provider-only fields like tags, metadata, or attachments.
 
 ```ts
 import { createEmailClient } from "email-sdk";
@@ -66,7 +71,8 @@ await email.send({
 
 ## Check the result
 
-`send` resolves with the normalized adapter response.
+`send` resolves with the normalized adapter response. The `provider` value tells you which adapter
+actually handled the send.
 
 ```ts
 const result = await email.send(message);
@@ -75,7 +81,8 @@ console.log(result.provider);
 console.log(result.id);
 ```
 
-If the adapter returns a message ID, Email SDK exposes it as both `id` and `messageId`.
+If the adapter returns a message ID, Email SDK exposes it as both `id` and `messageId`. Provider
+responses are still available through `raw` when an adapter includes them.
 
 ## Test from the CLI
 
@@ -95,3 +102,5 @@ email-sdk send \
   --subject "Hello" \
   --text "It works"
 ```
+
+Use `--dry-run` when you want to validate the message and selected adapter without sending email.

--- a/apps/fumadocs/content/docs/index.mdx
+++ b/apps/fumadocs/content/docs/index.mdx
@@ -1,12 +1,15 @@
 ---
 title: Email SDK
-description: Send email through Resend, SMTP, Postmark, SendGrid, Mailgun, and more with one TypeScript API.
+description: A small TypeScript email client with swappable adapters and explicit provider limits.
 icon: Mail
 ---
 
-Email SDK is a small TypeScript package for sending transactional email through swappable adapters.
+Email SDK is a small TypeScript package for transactional email. It gives your application one
+client and one message shape while keeping provider-specific behavior visible in the adapter docs.
 
-Use Resend for the default path, add SMTP when you want a cheap or self-managed route, and keep a second API adapter ready for fallback. Your app code still calls the same `send` method.
+Use Resend for a simple API path, SMTP when you want a cheap or self-managed route, or another
+provider when its field support fits your app better. Your application code still calls `send`;
+the adapter decides how that message maps to the provider.
 
 ```ts
 import { createEmailClient } from "email-sdk";
@@ -55,10 +58,21 @@ await email.send({
 - `email.send()` for one message.
 - `email.sendBatch()` for small batches where each result is reported separately.
 - Fifteen adapters, including Resend, SMTP, Postmark, SendGrid, Mailgun, and MailerSend.
-- Retry, fallback, and hook options.
-- A small CLI for adapter setup checks and test sends.
+- Retry and fallback options that run in the order you configure.
+- Hooks for logs, metrics, tracing, and retry visibility.
+- A small CLI for setup checks, dry runs, and smoke-test sends.
 - A repo-local agent skill for future coding agents.
 
 ## What stays small
 
-Email SDK does not try to be a template engine, campaign tool, analytics platform, or full email operations suite. The first version is the layer most apps keep rebuilding: adapter setup, a consistent send call, typed errors, and a clean fallback path.
+Email SDK does not try to be a template engine, campaign tool, queue, analytics platform, or full
+email operations suite. It is the layer many apps keep rebuilding: adapter setup, a consistent send
+call, typed errors, and a fallback path that is explicit enough to debug.
+
+## Provider behavior is not hidden
+
+Email providers do not all support the same fields. A fallback route is only safe when the backup
+adapter can represent the same class of message. Before choosing routes, read the
+
+<a href="/docs/adapters/field-support">field support guide</a>; unsupported fields should fail fast
+instead of being silently dropped.

--- a/apps/fumadocs/content/docs/index.mdx
+++ b/apps/fumadocs/content/docs/index.mdx
@@ -73,6 +73,5 @@ call, typed errors, and a fallback path that is explicit enough to debug.
 
 Email providers do not all support the same fields. A fallback route is only safe when the backup
 adapter can represent the same class of message. Before choosing routes, read the
-
-<a href="/docs/adapters/field-support">field support guide</a>; unsupported fields should fail fast
-instead of being silently dropped.
+[field support guide](/docs/adapters/field-support); unsupported fields should fail fast instead of
+being silently dropped.

--- a/apps/fumadocs/src/lib/layout.shared.tsx
+++ b/apps/fumadocs/src/lib/layout.shared.tsx
@@ -7,7 +7,7 @@ export function baseOptions(): BaseLayoutProps {
     nav: {
       title: (
         <span className="flex items-center gap-2.5">
-          <span className="grid size-6 place-items-center rounded-md border border-fd-border bg-fd-card">
+          <span className="grid size-8 place-items-center">
             <EmailSdkLogoIcon />
           </span>
           <span>{appName}</span>
@@ -20,12 +20,7 @@ export function baseOptions(): BaseLayoutProps {
 
 function EmailSdkLogoIcon() {
   return (
-    <svg
-      aria-hidden="true"
-      className="size-3.5 text-fd-primary"
-      fill="none"
-      viewBox="0 0 1024 1024"
-    >
+    <svg aria-hidden="true" className="size-6 text-fd-primary" fill="none" viewBox="0 0 1024 1024">
       <g stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="52">
         <rect height="292" rx="62" width="366" x="126" y="326" />
         <path d="M164 376L309 500L454 376" />

--- a/apps/fumadocs/src/routeTree.gen.ts
+++ b/apps/fumadocs/src/routeTree.gen.ts
@@ -8,138 +8,150 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as LlmsDottxtRouteImport } from "./routes/llms[.]txt";
-import { Route as LlmsFullDottxtRouteImport } from "./routes/llms-full[.]txt";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as DocsChar123Char125DotmdRouteImport } from "./routes/docs/{$}[.]md";
-import { Route as DocsSplatRouteImport } from "./routes/docs/$";
-import { Route as ApiSearchRouteImport } from "./routes/api/search";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
+import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as DocsChar123Char125DotmdRouteImport } from './routes/docs/{$}[.]md'
+import { Route as DocsSplatRouteImport } from './routes/docs/$'
+import { Route as ApiSearchRouteImport } from './routes/api/search'
 
 const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
-  id: "/llms.txt",
-  path: "/llms.txt",
+  id: '/llms.txt',
+  path: '/llms.txt',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
-  id: "/llms-full.txt",
-  path: "/llms-full.txt",
+  id: '/llms-full.txt',
+  path: '/llms-full.txt',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsChar123Char125DotmdRoute = DocsChar123Char125DotmdRouteImport.update({
-  id: "/docs/{$}.md",
-  path: "/docs/{$}.md",
+  id: '/docs/{$}.md',
+  path: '/docs/{$}.md',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const DocsSplatRoute = DocsSplatRouteImport.update({
-  id: "/docs/$",
-  path: "/docs/$",
+  id: '/docs/$',
+  path: '/docs/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiSearchRoute = ApiSearchRouteImport.update({
-  id: "/api/search",
-  path: "/api/search",
+  id: '/api/search',
+  path: '/api/search',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/llms-full.txt": typeof LlmsFullDottxtRoute;
-  "/llms.txt": typeof LlmsDottxtRoute;
-  "/api/search": typeof ApiSearchRoute;
-  "/docs/$": typeof DocsSplatRoute;
-  "/docs/{$}.md": typeof DocsChar123Char125DotmdRoute;
+  '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
+  '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
+  '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/llms-full.txt": typeof LlmsFullDottxtRoute;
-  "/llms.txt": typeof LlmsDottxtRoute;
-  "/api/search": typeof ApiSearchRoute;
-  "/docs/$": typeof DocsSplatRoute;
-  "/docs/{$}.md": typeof DocsChar123Char125DotmdRoute;
+  '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
+  '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
+  '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/llms-full.txt": typeof LlmsFullDottxtRoute;
-  "/llms.txt": typeof LlmsDottxtRoute;
-  "/api/search": typeof ApiSearchRoute;
-  "/docs/$": typeof DocsSplatRoute;
-  "/docs/{$}.md": typeof DocsChar123Char125DotmdRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.txt': typeof LlmsDottxtRoute
+  '/api/search': typeof ApiSearchRoute
+  '/docs/$': typeof DocsSplatRoute
+  '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/" | "/llms-full.txt" | "/llms.txt" | "/api/search" | "/docs/$" | "/docs/{$}.md";
-  fileRoutesByTo: FileRoutesByTo;
-  to: "/" | "/llms-full.txt" | "/llms.txt" | "/api/search" | "/docs/$" | "/docs/{$}.md";
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths:
+    | '/'
+    | '/llms-full.txt'
+    | '/llms.txt'
+    | '/api/search'
+    | '/docs/$'
+    | '/docs/{$}.md'
+  fileRoutesByTo: FileRoutesByTo
+  to:
+    | '/'
+    | '/llms-full.txt'
+    | '/llms.txt'
+    | '/api/search'
+    | '/docs/$'
+    | '/docs/{$}.md'
   id:
-    | "__root__"
-    | "/"
-    | "/llms-full.txt"
-    | "/llms.txt"
-    | "/api/search"
-    | "/docs/$"
-    | "/docs/{$}.md";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/llms-full.txt'
+    | '/llms.txt'
+    | '/api/search'
+    | '/docs/$'
+    | '/docs/{$}.md'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute;
-  LlmsDottxtRoute: typeof LlmsDottxtRoute;
-  ApiSearchRoute: typeof ApiSearchRoute;
-  DocsSplatRoute: typeof DocsSplatRoute;
-  DocsChar123Char125DotmdRoute: typeof DocsChar123Char125DotmdRoute;
+  IndexRoute: typeof IndexRoute
+  LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
+  LlmsDottxtRoute: typeof LlmsDottxtRoute
+  ApiSearchRoute: typeof ApiSearchRoute
+  DocsSplatRoute: typeof DocsSplatRoute
+  DocsChar123Char125DotmdRoute: typeof DocsChar123Char125DotmdRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/llms.txt": {
-      id: "/llms.txt";
-      path: "/llms.txt";
-      fullPath: "/llms.txt";
-      preLoaderRoute: typeof LlmsDottxtRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/llms-full.txt": {
-      id: "/llms-full.txt";
-      path: "/llms-full.txt";
-      fullPath: "/llms-full.txt";
-      preLoaderRoute: typeof LlmsFullDottxtRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/{$}.md": {
-      id: "/docs/{$}.md";
-      path: "/docs/{$}.md";
-      fullPath: "/docs/{$}.md";
-      preLoaderRoute: typeof DocsChar123Char125DotmdRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/docs/$": {
-      id: "/docs/$";
-      path: "/docs/$";
-      fullPath: "/docs/$";
-      preLoaderRoute: typeof DocsSplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/search": {
-      id: "/api/search";
-      path: "/api/search";
-      fullPath: "/api/search";
-      preLoaderRoute: typeof ApiSearchRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/llms.txt': {
+      id: '/llms.txt'
+      path: '/llms.txt'
+      fullPath: '/llms.txt'
+      preLoaderRoute: typeof LlmsDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/llms-full.txt': {
+      id: '/llms-full.txt'
+      path: '/llms-full.txt'
+      fullPath: '/llms-full.txt'
+      preLoaderRoute: typeof LlmsFullDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/{$}.md': {
+      id: '/docs/{$}.md'
+      path: '/docs/{$}.md'
+      fullPath: '/docs/{$}.md'
+      preLoaderRoute: typeof DocsChar123Char125DotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/$': {
+      id: '/docs/$'
+      path: '/docs/$'
+      fullPath: '/docs/$'
+      preLoaderRoute: typeof DocsSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/search': {
+      id: '/api/search'
+      path: '/api/search'
+      fullPath: '/api/search'
+      preLoaderRoute: typeof ApiSearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -150,16 +162,16 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSearchRoute: ApiSearchRoute,
   DocsSplatRoute: DocsSplatRoute,
   DocsChar123Char125DotmdRoute: DocsChar123Char125DotmdRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }

--- a/apps/fumadocs/src/routeTree.gen.ts
+++ b/apps/fumadocs/src/routeTree.gen.ts
@@ -8,150 +8,138 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from './routes/__root'
-import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
-import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
-import { Route as IndexRouteImport } from './routes/index'
-import { Route as DocsChar123Char125DotmdRouteImport } from './routes/docs/{$}[.]md'
-import { Route as DocsSplatRouteImport } from './routes/docs/$'
-import { Route as ApiSearchRouteImport } from './routes/api/search'
+import { Route as rootRouteImport } from "./routes/__root";
+import { Route as LlmsDottxtRouteImport } from "./routes/llms[.]txt";
+import { Route as LlmsFullDottxtRouteImport } from "./routes/llms-full[.]txt";
+import { Route as IndexRouteImport } from "./routes/index";
+import { Route as DocsChar123Char125DotmdRouteImport } from "./routes/docs/{$}[.]md";
+import { Route as DocsSplatRouteImport } from "./routes/docs/$";
+import { Route as ApiSearchRouteImport } from "./routes/api/search";
 
 const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
-  id: '/llms.txt',
-  path: '/llms.txt',
+  id: "/llms.txt",
+  path: "/llms.txt",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
-  id: '/llms-full.txt',
-  path: '/llms-full.txt',
+  id: "/llms-full.txt",
+  path: "/llms-full.txt",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+  id: "/",
+  path: "/",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DocsChar123Char125DotmdRoute = DocsChar123Char125DotmdRouteImport.update({
-  id: '/docs/{$}.md',
-  path: '/docs/{$}.md',
+  id: "/docs/{$}.md",
+  path: "/docs/{$}.md",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const DocsSplatRoute = DocsSplatRouteImport.update({
-  id: '/docs/$',
-  path: '/docs/$',
+  id: "/docs/$",
+  path: "/docs/$",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 const ApiSearchRoute = ApiSearchRouteImport.update({
-  id: '/api/search',
-  path: '/api/search',
+  id: "/api/search",
+  path: "/api/search",
   getParentRoute: () => rootRouteImport,
-} as any)
+} as any);
 
 export interface FileRoutesByFullPath {
-  '/': typeof IndexRoute
-  '/llms-full.txt': typeof LlmsFullDottxtRoute
-  '/llms.txt': typeof LlmsDottxtRoute
-  '/api/search': typeof ApiSearchRoute
-  '/docs/$': typeof DocsSplatRoute
-  '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
+  "/": typeof IndexRoute;
+  "/llms-full.txt": typeof LlmsFullDottxtRoute;
+  "/llms.txt": typeof LlmsDottxtRoute;
+  "/api/search": typeof ApiSearchRoute;
+  "/docs/$": typeof DocsSplatRoute;
+  "/docs/{$}.md": typeof DocsChar123Char125DotmdRoute;
 }
 export interface FileRoutesByTo {
-  '/': typeof IndexRoute
-  '/llms-full.txt': typeof LlmsFullDottxtRoute
-  '/llms.txt': typeof LlmsDottxtRoute
-  '/api/search': typeof ApiSearchRoute
-  '/docs/$': typeof DocsSplatRoute
-  '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
+  "/": typeof IndexRoute;
+  "/llms-full.txt": typeof LlmsFullDottxtRoute;
+  "/llms.txt": typeof LlmsDottxtRoute;
+  "/api/search": typeof ApiSearchRoute;
+  "/docs/$": typeof DocsSplatRoute;
+  "/docs/{$}.md": typeof DocsChar123Char125DotmdRoute;
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport
-  '/': typeof IndexRoute
-  '/llms-full.txt': typeof LlmsFullDottxtRoute
-  '/llms.txt': typeof LlmsDottxtRoute
-  '/api/search': typeof ApiSearchRoute
-  '/docs/$': typeof DocsSplatRoute
-  '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
+  __root__: typeof rootRouteImport;
+  "/": typeof IndexRoute;
+  "/llms-full.txt": typeof LlmsFullDottxtRoute;
+  "/llms.txt": typeof LlmsDottxtRoute;
+  "/api/search": typeof ApiSearchRoute;
+  "/docs/$": typeof DocsSplatRoute;
+  "/docs/{$}.md": typeof DocsChar123Char125DotmdRoute;
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths:
-    | '/'
-    | '/llms-full.txt'
-    | '/llms.txt'
-    | '/api/search'
-    | '/docs/$'
-    | '/docs/{$}.md'
-  fileRoutesByTo: FileRoutesByTo
-  to:
-    | '/'
-    | '/llms-full.txt'
-    | '/llms.txt'
-    | '/api/search'
-    | '/docs/$'
-    | '/docs/{$}.md'
+  fileRoutesByFullPath: FileRoutesByFullPath;
+  fullPaths: "/" | "/llms-full.txt" | "/llms.txt" | "/api/search" | "/docs/$" | "/docs/{$}.md";
+  fileRoutesByTo: FileRoutesByTo;
+  to: "/" | "/llms-full.txt" | "/llms.txt" | "/api/search" | "/docs/$" | "/docs/{$}.md";
   id:
-    | '__root__'
-    | '/'
-    | '/llms-full.txt'
-    | '/llms.txt'
-    | '/api/search'
-    | '/docs/$'
-    | '/docs/{$}.md'
-  fileRoutesById: FileRoutesById
+    | "__root__"
+    | "/"
+    | "/llms-full.txt"
+    | "/llms.txt"
+    | "/api/search"
+    | "/docs/$"
+    | "/docs/{$}.md";
+  fileRoutesById: FileRoutesById;
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute
-  LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
-  LlmsDottxtRoute: typeof LlmsDottxtRoute
-  ApiSearchRoute: typeof ApiSearchRoute
-  DocsSplatRoute: typeof DocsSplatRoute
-  DocsChar123Char125DotmdRoute: typeof DocsChar123Char125DotmdRoute
+  IndexRoute: typeof IndexRoute;
+  LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute;
+  LlmsDottxtRoute: typeof LlmsDottxtRoute;
+  ApiSearchRoute: typeof ApiSearchRoute;
+  DocsSplatRoute: typeof DocsSplatRoute;
+  DocsChar123Char125DotmdRoute: typeof DocsChar123Char125DotmdRoute;
 }
 
-declare module '@tanstack/react-router' {
+declare module "@tanstack/react-router" {
   interface FileRoutesByPath {
-    '/llms.txt': {
-      id: '/llms.txt'
-      path: '/llms.txt'
-      fullPath: '/llms.txt'
-      preLoaderRoute: typeof LlmsDottxtRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/llms-full.txt': {
-      id: '/llms-full.txt'
-      path: '/llms-full.txt'
-      fullPath: '/llms-full.txt'
-      preLoaderRoute: typeof LlmsFullDottxtRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/{$}.md': {
-      id: '/docs/{$}.md'
-      path: '/docs/{$}.md'
-      fullPath: '/docs/{$}.md'
-      preLoaderRoute: typeof DocsChar123Char125DotmdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docs/$': {
-      id: '/docs/$'
-      path: '/docs/$'
-      fullPath: '/docs/$'
-      preLoaderRoute: typeof DocsSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/search': {
-      id: '/api/search'
-      path: '/api/search'
-      fullPath: '/api/search'
-      preLoaderRoute: typeof ApiSearchRouteImport
-      parentRoute: typeof rootRouteImport
-    }
+    "/llms.txt": {
+      id: "/llms.txt";
+      path: "/llms.txt";
+      fullPath: "/llms.txt";
+      preLoaderRoute: typeof LlmsDottxtRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/llms-full.txt": {
+      id: "/llms-full.txt";
+      path: "/llms-full.txt";
+      fullPath: "/llms-full.txt";
+      preLoaderRoute: typeof LlmsFullDottxtRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/": {
+      id: "/";
+      path: "/";
+      fullPath: "/";
+      preLoaderRoute: typeof IndexRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/{$}.md": {
+      id: "/docs/{$}.md";
+      path: "/docs/{$}.md";
+      fullPath: "/docs/{$}.md";
+      preLoaderRoute: typeof DocsChar123Char125DotmdRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/docs/$": {
+      id: "/docs/$";
+      path: "/docs/$";
+      fullPath: "/docs/$";
+      preLoaderRoute: typeof DocsSplatRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    "/api/search": {
+      id: "/api/search";
+      path: "/api/search";
+      fullPath: "/api/search";
+      preLoaderRoute: typeof ApiSearchRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
   }
 }
 
@@ -162,16 +150,16 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSearchRoute: ApiSearchRoute,
   DocsSplatRoute: DocsSplatRoute,
   DocsChar123Char125DotmdRoute: DocsChar123Char125DotmdRoute,
-}
+};
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>()
+  ._addFileTypes<FileRouteTypes>();
 
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
+import type { getRouter } from "./router.tsx";
+import type { createStart } from "@tanstack/react-start";
+declare module "@tanstack/react-start" {
   interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
+    ssr: true;
+    router: Awaited<ReturnType<typeof getRouter>>;
   }
 }

--- a/apps/fumadocs/src/routes/index.tsx
+++ b/apps/fumadocs/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
-import { ArrowRight, Check, Copy, Mail, Terminal } from "lucide-react";
+import { ArrowRight, Check, Copy, Terminal } from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 
@@ -42,21 +42,13 @@ function Home() {
       <main className="border-b border-fd-border bg-fd-background text-fd-foreground">
         <section className="mx-auto grid min-h-[calc(100svh-64px)] max-w-[1512px] items-center gap-10 px-6 py-10 md:px-10 lg:grid-cols-[0.78fr_1.22fr] lg:px-14 xl:px-16">
           <div className="max-w-2xl py-4">
-            <p className="mb-6 inline-flex items-center gap-2 text-sm font-medium text-fd-muted-foreground">
-              <span className="grid size-7 place-items-center rounded-md border border-fd-border bg-fd-card">
-                <Mail className="size-4 text-fd-primary" strokeWidth={2} />
-              </span>
-              Transactional email for TypeScript apps
-            </p>
-
             <h1 className="text-5xl font-medium leading-[1.04] text-fd-foreground md:text-6xl">
-              One send call, with the provider details left visible.
+              One email SDK for every provider.
             </h1>
 
             <p className="mt-6 max-w-xl text-base leading-7 text-fd-muted-foreground md:text-lg">
-              Email SDK gives you a typed client for Resend, SMTP, Postmark, SendGrid, Mailgun, and
-              more. It keeps the common path clean while still showing which fields each adapter can
-              actually send.
+              Send through Resend, Postmark, SendGrid, Mailgun, Brevo, SMTP, and more with one clean
+              TypeScript API.
             </p>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
@@ -82,18 +74,9 @@ function Home() {
             </div>
 
             <div className="mt-10 divide-y divide-fd-border/80 border-y border-fd-border/80 text-sm">
-              <ProofPoint
-                label="Fallbacks"
-                text="Retry one adapter, then move to the next route you configured."
-              />
-              <ProofPoint
-                label="Field support"
-                text="Unsupported message fields fail before the provider request."
-              />
-              <ProofPoint
-                label="Small scope"
-                text="No templates, campaigns, queues, or analytics layer hiding in the SDK."
-              />
+              <ProofPoint label="Fallbacks" text="Retry failed sends and move to backup routes." />
+              <ProofPoint label="Adapters" text="Keep provider-specific code out of your app." />
+              <ProofPoint label="CLI" text="Run setup checks and test sends locally." />
             </div>
           </div>
 
@@ -111,31 +94,6 @@ function Home() {
                   <SyntaxCode />
                 </code>
               </pre>
-            </div>
-          </div>
-        </section>
-
-        <section className="border-t border-fd-border bg-fd-muted/20">
-          <div className="mx-auto grid max-w-[1512px] gap-10 px-6 py-12 md:px-10 lg:grid-cols-[0.72fr_1.28fr] lg:px-14 xl:px-16">
-            <div>
-              <p className="text-sm font-medium text-fd-primary">What it is</p>
-              <h2 className="mt-3 text-3xl font-medium leading-tight text-fd-foreground">
-                A thin adapter layer, not an email platform.
-              </h2>
-            </div>
-            <div className="grid gap-6 md:grid-cols-3">
-              <LandingDetail
-                label="Use one client"
-                text="Keep app code on createEmailClient, email.send, and email.sendBatch."
-              />
-              <LandingDetail
-                label="Choose real routes"
-                text="Set the primary adapter, fallback adapters, and per-send overrides explicitly."
-              />
-              <LandingDetail
-                label="Read the limits"
-                text="The docs list field support because providers do not expose the same API shape."
-              />
             </div>
           </div>
         </section>
@@ -225,15 +183,6 @@ function ProofPoint({ label, text }: { label: string; text: string }) {
     <div className="grid gap-1 py-3 sm:grid-cols-[120px_1fr]">
       <p className="font-medium text-fd-foreground">{label}</p>
       <p className="text-fd-muted-foreground">{text}</p>
-    </div>
-  );
-}
-
-function LandingDetail({ label, text }: { label: string; text: string }) {
-  return (
-    <div className="border-t border-fd-border pt-4">
-      <p className="font-medium text-fd-foreground">{label}</p>
-      <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{text}</p>
     </div>
   );
 }

--- a/apps/fumadocs/src/routes/index.tsx
+++ b/apps/fumadocs/src/routes/index.tsx
@@ -39,23 +39,24 @@ await email.send({
 function Home() {
   return (
     <HomeLayout {...baseOptions()}>
-      <main className="h-[calc(100svh-64px)] overflow-hidden border-b border-fd-border bg-fd-background text-fd-foreground">
-        <section className="mx-auto grid h-full max-w-[1512px] items-center gap-10 px-6 py-8 md:px-10 lg:grid-cols-[0.82fr_1.18fr] lg:px-14 xl:px-16">
-          <div className="max-w-2xl">
-            <p className="mb-7 inline-flex items-center gap-2 text-sm font-medium text-fd-muted-foreground">
+      <main className="border-b border-fd-border bg-fd-background text-fd-foreground">
+        <section className="mx-auto grid min-h-[calc(100svh-64px)] max-w-[1512px] items-center gap-10 px-6 py-10 md:px-10 lg:grid-cols-[0.78fr_1.22fr] lg:px-14 xl:px-16">
+          <div className="max-w-2xl py-4">
+            <p className="mb-6 inline-flex items-center gap-2 text-sm font-medium text-fd-muted-foreground">
               <span className="grid size-7 place-items-center rounded-md border border-fd-border bg-fd-card">
                 <Mail className="size-4 text-fd-primary" strokeWidth={2} />
               </span>
-              Unified email sending for TypeScript
+              Transactional email for TypeScript apps
             </p>
 
-            <h1 className="text-5xl font-medium leading-[1.04] tracking-[-0.02em] text-fd-foreground md:text-6xl">
-              One email client. Every provider you trust.
+            <h1 className="text-5xl font-medium leading-[1.04] text-fd-foreground md:text-6xl">
+              One send call, with the provider details left visible.
             </h1>
 
             <p className="mt-6 max-w-xl text-base leading-7 text-fd-muted-foreground md:text-lg">
-              Send through Resend, SMTP, Postmark, and more without rewriting provider glue or
-              hiding what each adapter supports.
+              Email SDK gives you a typed client for Resend, SMTP, Postmark, SendGrid, Mailgun, and
+              more. It keeps the common path clean while still showing which fields each adapter can
+              actually send.
             </p>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
@@ -80,15 +81,24 @@ function Home() {
               </Link>
             </div>
 
-            <div className="mt-9 grid max-w-xl gap-3 text-sm sm:grid-cols-3">
-              <ProofPoint label="Fallbacks" text="Fail over by route" />
-              <ProofPoint label="Contracts" text="No silent field drops" />
-              <ProofPoint label="CLI" text="Test sends locally" />
+            <div className="mt-10 divide-y divide-fd-border/80 border-y border-fd-border/80 text-sm">
+              <ProofPoint
+                label="Fallbacks"
+                text="Retry one adapter, then move to the next route you configured."
+              />
+              <ProofPoint
+                label="Field support"
+                text="Unsupported message fields fail before the provider request."
+              />
+              <ProofPoint
+                label="Small scope"
+                text="No templates, campaigns, queues, or analytics layer hiding in the SDK."
+              />
             </div>
           </div>
 
           <div className="min-w-0">
-            <div className="overflow-hidden rounded-xl border border-fd-border bg-fd-card shadow-xl shadow-black/10">
+            <div className="overflow-hidden rounded-lg border border-fd-border bg-fd-card shadow-xl shadow-black/10">
               <div className="flex items-center justify-between border-b border-fd-border px-4 py-3">
                 <div className="flex items-center gap-2 text-sm text-fd-muted-foreground">
                   <Terminal className="size-4" strokeWidth={2} />
@@ -96,11 +106,36 @@ function Home() {
                 </div>
                 <CopyCodeButton />
               </div>
-              <pre className="p-4 text-[12px] leading-[1.3] text-fd-foreground md:p-5 md:text-[13px] md:leading-[1.4]">
+              <pre className="overflow-x-auto p-4 text-[12px] leading-[1.3] text-fd-foreground md:p-5 md:text-[13px] md:leading-[1.4]">
                 <code>
                   <SyntaxCode />
                 </code>
               </pre>
+            </div>
+          </div>
+        </section>
+
+        <section className="border-t border-fd-border bg-fd-muted/20">
+          <div className="mx-auto grid max-w-[1512px] gap-10 px-6 py-12 md:px-10 lg:grid-cols-[0.72fr_1.28fr] lg:px-14 xl:px-16">
+            <div>
+              <p className="text-sm font-medium text-fd-primary">What it is</p>
+              <h2 className="mt-3 text-3xl font-medium leading-tight text-fd-foreground">
+                A thin adapter layer, not an email platform.
+              </h2>
+            </div>
+            <div className="grid gap-6 md:grid-cols-3">
+              <LandingDetail
+                label="Use one client"
+                text="Keep app code on createEmailClient, email.send, and email.sendBatch."
+              />
+              <LandingDetail
+                label="Choose real routes"
+                text="Set the primary adapter, fallback adapters, and per-send overrides explicitly."
+              />
+              <LandingDetail
+                label="Read the limits"
+                text="The docs list field support because providers do not expose the same API shape."
+              />
             </div>
           </div>
         </section>
@@ -187,9 +222,18 @@ function CopyCodeButton() {
 
 function ProofPoint({ label, text }: { label: string; text: string }) {
   return (
-    <div className="border-l border-fd-primary/70 pl-3">
+    <div className="grid gap-1 py-3 sm:grid-cols-[120px_1fr]">
       <p className="font-medium text-fd-foreground">{label}</p>
-      <p className="mt-1 text-fd-muted-foreground">{text}</p>
+      <p className="text-fd-muted-foreground">{text}</p>
+    </div>
+  );
+}
+
+function LandingDetail({ label, text }: { label: string; text: string }) {
+  return (
+    <div className="border-t border-fd-border pt-4">
+      <p className="font-medium text-fd-foreground">{label}</p>
+      <p className="mt-2 text-sm leading-6 text-fd-muted-foreground">{text}</p>
     </div>
   );
 }

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -1,6 +1,9 @@
 # Email SDK
 
-A lightweight TypeScript SDK for unified email sending.
+A lightweight TypeScript SDK for transactional email.
+
+Use one client in your app, pick the adapters you actually send through, and keep provider-specific
+field support visible instead of pretending every email API behaves the same way.
 
 ```bash
 bun add email-sdk
@@ -42,4 +45,6 @@ Adapters:
 
 SMTP is built in and does not require Nodemailer.
 
-Adapters map supported `EmailMessage` fields and reject unsupported fields instead of silently dropping message data. Attachment `content` is treated as raw content by default; set `contentEncoding: "base64"` when passing pre-encoded content.
+Adapters map supported `EmailMessage` fields and reject unsupported fields instead of silently
+dropping message data. Attachment `content` is treated as raw content by default; set
+`contentEncoding: "base64"` when passing pre-encoded content.


### PR DESCRIPTION
## Summary
- Reworked the docs and README copy to position Email SDK as a transactional email client with explicit provider limits.
- Clarified quickstart and adapter guidance around environment setup, fallback safety, raw responses, and unsupported field behavior.
- Updated the homepage layout and messaging to better reflect the product scope and surface field-support limitations more clearly.
- Refreshed generated route metadata in `routeTree.gen.ts` as part of the docs/site update.

## Testing
- Not run (copy and documentation updates only).
- Not run (generated route file updated as part of the site build output).