### PR TITLE
Add AWS SES adapter and CLI/docs support

### DIFF
--- a/apps/fumadocs/content/docs/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs/adapters/field-support.mdx
@@ -17,7 +17,7 @@ Email SDK keeps one message shape, but email APIs do not all expose the same fea
 
 | Need                             | Start with                                         |
 | -------------------------------- | -------------------------------------------------- |
-| Most complete API field mapping  | Postmark, SendGrid, Mailgun, Brevo                 |
+| Most complete API field mapping  | Postmark, SendGrid, AWS SES, Mailgun, Brevo        |
 | Resend-style DX with attachments | Resend                                             |
 | Cheap or self-managed delivery   | SMTP                                               |
 | Product/event email              | Loops, Plunk                                       |
@@ -33,6 +33,7 @@ These adapters cover most transactional email fields. They are the best fit when
 | Resend                  | Yes | Yes | Yes      | Yes     | No       | Yes       | Yes         |
 | Postmark                | Yes | Yes | Yes      | Yes     | Yes      | First tag | Yes         |
 | SendGrid                | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
+| AWS SES                 | Yes | Yes | Yes      | Yes     | No       | Yes       | Yes         |
 | Mailgun                 | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
 | MailerSend              | Yes | Yes | Yes      | Yes     | No       | Values    | Yes         |
 | Brevo                   | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |

--- a/apps/fumadocs/content/docs/adapters/meta.json
+++ b/apps/fumadocs/content/docs/adapters/meta.json
@@ -6,6 +6,7 @@
     "resend",
     "postmark",
     "sendgrid",
+    "ses",
     "mailgun",
     "mailersend",
     "brevo",

--- a/apps/fumadocs/content/docs/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs/adapters/ses.mdx
@@ -1,0 +1,67 @@
+---
+title: AWS SES
+description: Configure the AWS SES v2 SendEmail adapter.
+icon: Cloud
+---
+
+The AWS SES adapter calls the SES v2 SendEmail API directly with SigV4-signed fetch requests. It does not add a runtime dependency on the AWS SDK.
+
+<ProviderBadge adapter="ses" />
+
+```ts
+import { createEmailClient } from "email-sdk";
+import { ses } from "email-sdk/ses";
+
+const email = createEmailClient({
+  adapters: [
+    ses({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+      region: process.env.AWS_REGION!,
+    }),
+  ],
+});
+```
+
+## Send
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
+  tags: [{ name: "type", value: "welcome" }],
+});
+```
+
+## Options
+
+| Option                 | Type           | Required | Notes                                                 |
+| ---------------------- | -------------- | -------- | ----------------------------------------------------- |
+| `accessKeyId`          | `string`       | Yes      | AWS access key ID.                                    |
+| `secretAccessKey`      | `string`       | Yes      | AWS secret access key.                                |
+| `region`               | `string`       | Yes      | SES region, for example `us-east-1`.                  |
+| `sessionToken`         | `string`       | No       | Required for temporary credentials.                   |
+| `baseUrl`              | `string`       | No       | Defaults to `https://email.{region}.amazonaws.com`.   |
+| `fetch`                | `typeof fetch` | No       | Useful for tests or custom runtimes.                  |
+| `charset`              | `string`       | No       | Defaults to `UTF-8`.                                  |
+| `configurationSetName` | `string`       | No       | SES configuration set for sends through this adapter. |
+
+## CLI
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_REGION=us-east-1 \
+email-sdk send --adapter ses \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Welcome" \
+  --html "<p>Your workspace is ready.</p>"
+```
+
+## Response
+
+The adapter returns the SES `MessageId` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs/concepts/adapter-model.mdx
+++ b/apps/fumadocs/content/docs/concepts/adapter-model.mdx
@@ -29,6 +29,7 @@ Each adapter registers a routing name. Email SDK uses that name for defaults, fa
 | SMTP                    | `smtp`       |
 | Postmark                | `postmark`   |
 | SendGrid                | `sendgrid`   |
+| AWS SES                 | `ses`        |
 | Mailgun                 | `mailgun`    |
 | MailerSend              | `mailersend` |
 | Brevo                   | `brevo`      |

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -75,6 +75,7 @@ email-sdk doctor --adapter resend
 | `--message-stream`      | Postmark  | Optional message stream.                               |
 | `--access-key-id`       | AWS SES   | Overrides `AWS_ACCESS_KEY_ID`.                         |
 | `--secret-access-key`   | AWS SES   | Overrides `AWS_SECRET_ACCESS_KEY`.                     |
+| `--region`              | AWS SES   | Overrides `AWS_REGION`.                                |
 | `--session-token`       | AWS SES   | Overrides `AWS_SESSION_TOKEN`.                         |
 | `--configuration-set`   | AWS SES   | Overrides `AWS_SES_CONFIGURATION_SET`.                 |
 | `--domain`              | Mailgun   | Overrides `MAILGUN_DOMAIN`.                            |

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -21,23 +21,24 @@ email-sdk send \
 email-sdk adapters
 ```
 
-| Adapter      | Required environment                              |
-| ------------ | ------------------------------------------------- |
-| `resend`     | `RESEND_API_KEY`                                  |
-| `postmark`   | `POSTMARK_SERVER_TOKEN`                           |
-| `sendgrid`   | `SENDGRID_API_KEY`                                |
-| `mailgun`    | `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`               |
-| `mailersend` | `MAILERSEND_API_KEY`                              |
-| `brevo`      | `BREVO_API_KEY`                                   |
-| `mailchimp`  | `MAILCHIMP_API_KEY`                               |
-| `sparkpost`  | `SPARKPOST_API_KEY`                               |
-| `loops`      | `LOOPS_API_KEY`, `LOOPS_TRANSACTIONAL_ID`         |
-| `plunk`      | `PLUNK_API_KEY`                                   |
-| `mailtrap`   | `MAILTRAP_API_KEY`                                |
-| `scaleway`   | `SCALEWAY_SECRET_KEY`, `SCALEWAY_PROJECT_ID`      |
-| `zeptomail`  | `ZEPTOMAIL_TOKEN`                                 |
-| `mailpace`   | `MAILPACE_API_KEY`                                |
-| `smtp`       | `SMTP_HOST`, plus SMTP auth variables when needed |
+| Adapter      | Required environment                                       |
+| ------------ | ---------------------------------------------------------- |
+| `resend`     | `RESEND_API_KEY`                                           |
+| `postmark`   | `POSTMARK_SERVER_TOKEN`                                    |
+| `sendgrid`   | `SENDGRID_API_KEY`                                         |
+| `ses`        | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| `mailgun`    | `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`                        |
+| `mailersend` | `MAILERSEND_API_KEY`                                       |
+| `brevo`      | `BREVO_API_KEY`                                            |
+| `mailchimp`  | `MAILCHIMP_API_KEY`                                        |
+| `sparkpost`  | `SPARKPOST_API_KEY`                                        |
+| `loops`      | `LOOPS_API_KEY`, `LOOPS_TRANSACTIONAL_ID`                  |
+| `plunk`      | `PLUNK_API_KEY`                                            |
+| `mailtrap`   | `MAILTRAP_API_KEY`                                         |
+| `scaleway`   | `SCALEWAY_SECRET_KEY`, `SCALEWAY_PROJECT_ID`               |
+| `zeptomail`  | `ZEPTOMAIL_TOKEN`                                          |
+| `mailpace`   | `MAILPACE_API_KEY`                                         |
+| `smtp`       | `SMTP_HOST`, plus SMTP auth variables when needed          |
 
 If `--adapter` is omitted, the CLI selects the first adapter with all required environment variables set.
 
@@ -72,6 +73,10 @@ email-sdk doctor --adapter resend
 | `--api-key`             | many      | Overrides the adapter API key variable.                |
 | `--server-token`        | Postmark  | Overrides `POSTMARK_SERVER_TOKEN`.                     |
 | `--message-stream`      | Postmark  | Optional message stream.                               |
+| `--access-key-id`       | AWS SES   | Overrides `AWS_ACCESS_KEY_ID`.                         |
+| `--secret-access-key`   | AWS SES   | Overrides `AWS_SECRET_ACCESS_KEY`.                     |
+| `--session-token`       | AWS SES   | Overrides `AWS_SESSION_TOKEN`.                         |
+| `--configuration-set`   | AWS SES   | Overrides `AWS_SES_CONFIGURATION_SET`.                 |
 | `--domain`              | Mailgun   | Overrides `MAILGUN_DOMAIN`.                            |
 | `--transactional-id`    | Loops     | Overrides `LOOPS_TRANSACTIONAL_ID`.                    |
 | `--project-id`          | Scaleway  | Overrides `SCALEWAY_PROJECT_ID`.                       |

--- a/apps/fumadocs/src/lib/providers.ts
+++ b/apps/fumadocs/src/lib/providers.ts
@@ -29,7 +29,7 @@ export const providers = [
     key: "ses",
     importPath: "email-sdk/ses",
     docs: "/docs/adapters/ses",
-    logo: "https://cdn.simpleicons.org/amazonaws",
+    logo: "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=64",
     category: "Infrastructure",
   },
   {

--- a/apps/fumadocs/src/lib/providers.ts
+++ b/apps/fumadocs/src/lib/providers.ts
@@ -25,6 +25,14 @@ export const providers = [
     category: "Popular APIs",
   },
   {
+    name: "AWS SES",
+    key: "ses",
+    importPath: "email-sdk/ses",
+    docs: "/docs/adapters/ses",
+    logo: "https://cdn.simpleicons.org/amazonaws",
+    category: "Infrastructure",
+  },
+  {
     name: "Mailgun",
     key: "mailgun",
     importPath: "@opencoredev/email-sdk/mailgun",

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -31,6 +31,7 @@ Adapters:
 - `@opencoredev/email-sdk/smtp`
 - `@opencoredev/email-sdk/postmark`
 - `@opencoredev/email-sdk/sendgrid`
+- `@opencoredev/email-sdk/ses`
 - `@opencoredev/email-sdk/mailgun`
 - `@opencoredev/email-sdk/mailersend`
 - `@opencoredev/email-sdk/brevo`

--- a/packages/email-sdk/package.json
+++ b/packages/email-sdk/package.json
@@ -38,6 +38,10 @@
       "types": "./dist/sendgrid.d.ts",
       "import": "./dist/sendgrid.js"
     },
+    "./ses": {
+      "types": "./dist/ses.d.ts",
+      "import": "./dist/ses.js"
+    },
     "./mailgun": {
       "types": "./dist/mailgun.d.ts",
       "import": "./dist/mailgun.js"

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -161,6 +161,7 @@ describe("provider payloads", () => {
     expect(capture.calls[0]?.headers.get("authorization")).toStartWith(
       "AWS4-HMAC-SHA256 Credential=access/",
     );
+    expect(capture.calls[0]?.headers.has("host")).toBe(false);
     expect(capture.calls[0]?.headers.get("x-amz-security-token")).toBe("session");
     expect(capture.calls[0]?.json).toMatchObject({
       FromEmailAddress: "Acme <hello@example.com>",
@@ -174,6 +175,10 @@ describe("provider payloads", () => {
       Content: {
         Simple: {
           Subject: { Data: "Welcome", Charset: "UTF-8" },
+          Body: {
+            Text: { Data: "Hello", Charset: "UTF-8" },
+            Html: { Data: "<p>Hello</p>", Charset: "UTF-8" },
+          },
           Headers: [{ Name: "X-Test", Value: "yes" }],
         },
       },

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -11,6 +11,7 @@ import { plunk } from "./plunk.js";
 import { postmark } from "./postmark.js";
 import { resend } from "./resend.js";
 import { scaleway } from "./scaleway.js";
+import { ses } from "./ses.js";
 import { sendgrid } from "./sendgrid.js";
 import { sparkpost } from "./sparkpost.js";
 import type { EmailMessage, EmailProviderContext } from "./types.js";
@@ -142,6 +143,49 @@ describe("provider payloads", () => {
     });
   });
 
+  test("SES signs and maps simple email payloads", async () => {
+    const capture = jsonCapture({ MessageId: "ses_123" });
+
+    const response = await ses({
+      accessKeyId: "access",
+      secretAccessKey: "secret",
+      sessionToken: "session",
+      region: "us-east-1",
+      fetch: capture.fetch,
+    }).send(messageWithoutMetadata, context);
+
+    expect(response.messageId).toBe("ses_123");
+    expect(capture.calls[0]?.url).toBe(
+      "https://email.us-east-1.amazonaws.com/v2/email/outbound-emails",
+    );
+    expect(capture.calls[0]?.headers.get("authorization")).toStartWith(
+      "AWS4-HMAC-SHA256 Credential=access/",
+    );
+    expect(capture.calls[0]?.headers.get("x-amz-security-token")).toBe("session");
+    expect(capture.calls[0]?.json).toMatchObject({
+      FromEmailAddress: "Acme <hello@example.com>",
+      Destination: {
+        ToAddresses: ["Ada <ada@example.com>"],
+        CcAddresses: ["cc@example.com"],
+        BccAddresses: ["bcc@example.com"],
+      },
+      ReplyToAddresses: ["reply@example.com"],
+      EmailTags: [{ Name: "kind", Value: "welcome" }],
+      Content: {
+        Simple: {
+          Subject: { Data: "Welcome", Charset: "UTF-8" },
+          Headers: [{ Name: "X-Test", Value: "yes" }],
+        },
+      },
+    });
+    expect(capture.calls[0]?.json.Content.Simple.Attachments[0]).toMatchObject({
+      FileName: "hello.txt",
+      RawContent: base64("hello"),
+      ContentType: "text/plain",
+      ContentTransferEncoding: "BASE64",
+    });
+  });
+
   test("Mailgun sends multipart form data with attachments", async () => {
     const capture = formCapture({ id: "<mailgun_123>" });
 
@@ -267,6 +311,15 @@ describe("provider payloads", () => {
         context,
       ),
     ).rejects.toThrow("resend does not support");
+
+    await expect(
+      ses({
+        accessKeyId: "access",
+        secretAccessKey: "secret",
+        region: "us-east-1",
+        fetch: jsonCapture({ MessageId: "ses_123" }).fetch,
+      }).send({ ...limitedMessage, metadata: { id: "nope" } }, context),
+    ).rejects.toThrow("ses does not support");
 
     await expect(
       mailersend({ apiKey: "key", fetch: jsonCapture({ id: "ms_123" }).fetch }).send(

--- a/packages/email-sdk/src/cli.ts
+++ b/packages/email-sdk/src/cli.ts
@@ -14,6 +14,7 @@ import { plunk } from "./plunk.js";
 import { postmark } from "./postmark.js";
 import { resend } from "./resend.js";
 import { scaleway } from "./scaleway.js";
+import { ses } from "./ses.js";
 import { sendgrid } from "./sendgrid.js";
 import { smtp } from "./smtp.js";
 import { sparkpost } from "./sparkpost.js";
@@ -38,6 +39,11 @@ const providerDocs: Array<{
   { name: "resend", env: ["RESEND_API_KEY"], note: "Resend Email API" },
   { name: "postmark", env: ["POSTMARK_SERVER_TOKEN"], note: "Postmark Email API" },
   { name: "sendgrid", env: ["SENDGRID_API_KEY"], note: "Twilio SendGrid Mail Send API" },
+  {
+    name: "ses",
+    env: ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_REGION"],
+    note: "AWS SES v2 SendEmail API",
+  },
   { name: "mailgun", env: ["MAILGUN_API_KEY", "MAILGUN_DOMAIN"], note: "Mailgun Messages API" },
   { name: "mailersend", env: ["MAILERSEND_API_KEY"], note: "MailerSend Email API" },
   { name: "brevo", env: ["BREVO_API_KEY"], note: "Brevo transactional email API" },
@@ -68,6 +74,16 @@ const factories: Record<string, ProviderFactory> = {
       messageStream: stringFlag(flags, "message-stream") ?? process.env.POSTMARK_MESSAGE_STREAM,
     }),
   sendgrid: (flags) => sendgrid({ apiKey: flagOrEnv(flags, "api-key", "SENDGRID_API_KEY") }),
+  ses: (flags) =>
+    ses({
+      accessKeyId: flagOrEnv(flags, "access-key-id", "AWS_ACCESS_KEY_ID"),
+      secretAccessKey: flagOrEnv(flags, "secret-access-key", "AWS_SECRET_ACCESS_KEY"),
+      sessionToken: stringFlag(flags, "session-token") ?? process.env.AWS_SESSION_TOKEN,
+      region: flagOrEnv(flags, "region", "AWS_REGION"),
+      baseUrl: stringFlag(flags, "base-url") ?? process.env.AWS_SES_BASE_URL,
+      configurationSetName:
+        stringFlag(flags, "configuration-set") ?? process.env.AWS_SES_CONFIGURATION_SET,
+    }),
   mailgun: (flags) =>
     mailgun({
       apiKey: flagOrEnv(flags, "api-key", "MAILGUN_API_KEY"),

--- a/packages/email-sdk/src/ses.ts
+++ b/packages/email-sdk/src/ses.ts
@@ -1,0 +1,230 @@
+import { createHash, createHmac } from "node:crypto";
+
+import { EmailProviderError } from "./errors.js";
+import {
+  base64Attachments,
+  commonHeadersArray,
+  formatAddress,
+  optionalStringAddresses,
+  stringAddresses,
+} from "./payloads.js";
+import type { EmailMessage, EmailProvider } from "./types.js";
+import {
+  assertSupportedMessageFields,
+  httpErrorMessage,
+  isRetryableStatus,
+  readErrorBody,
+} from "./utils.js";
+
+export type SesProviderOptions = {
+  accessKeyId: string;
+  secretAccessKey: string;
+  region: string;
+  sessionToken?: string;
+  baseUrl?: string;
+  fetch?: typeof fetch;
+  charset?: string;
+  configurationSetName?: string;
+};
+
+export function ses(
+  options: SesProviderOptions,
+): EmailProvider<{ baseUrl: string; region: string }> {
+  const baseUrl = options.baseUrl ?? `https://email.${options.region}.amazonaws.com`;
+
+  return {
+    name: "ses",
+    raw: { baseUrl, region: options.region },
+    async send(message, context) {
+      const fetcher = options.fetch ?? fetch;
+      const endpoint = new URL("/v2/email/outbound-emails", baseUrl);
+      const body = JSON.stringify(await toSesPayload(message, options));
+      const headers = signAwsRequest({
+        accessKeyId: options.accessKeyId,
+        secretAccessKey: options.secretAccessKey,
+        sessionToken: options.sessionToken,
+        region: options.region,
+        service: "ses",
+        method: "POST",
+        url: endpoint,
+        body,
+        headers: {
+          "content-type": "application/json",
+        },
+      });
+
+      const response = await fetcher(endpoint, {
+        method: "POST",
+        signal: context.signal,
+        headers,
+        body,
+      });
+
+      const responseBody = await readErrorBody(response);
+
+      if (!response.ok) {
+        throw new EmailProviderError(httpErrorMessage("ses", response.status, responseBody), {
+          provider: "ses",
+          status: response.status,
+          retryable: isRetryableStatus(response.status),
+          details: responseBody,
+        });
+      }
+
+      const record = responseBody as Record<string, unknown>;
+      const messageId = typeof record.MessageId === "string" ? record.MessageId : undefined;
+
+      return {
+        provider: "ses",
+        id: messageId,
+        messageId,
+        raw: responseBody,
+      };
+    },
+  };
+}
+
+async function toSesPayload(message: EmailMessage, options: SesProviderOptions) {
+  assertSupportedMessageFields("ses", message, {
+    cc: true,
+    bcc: true,
+    replyTo: true,
+    headers: true,
+    attachments: true,
+    tags: true,
+  });
+
+  const charset = options.charset ?? "UTF-8";
+  const attachments = await base64Attachments(message);
+
+  return {
+    ConfigurationSetName: options.configurationSetName,
+    FromEmailAddress: formatAddress(message.from),
+    Destination: {
+      ToAddresses: stringAddresses(message.to),
+      CcAddresses: optionalStringAddresses(message.cc),
+      BccAddresses: optionalStringAddresses(message.bcc),
+    },
+    ReplyToAddresses: optionalStringAddresses(message.replyTo),
+    EmailTags: message.tags?.map((tag) => ({
+      Name: tag.name,
+      Value: tag.value,
+    })),
+    Content: {
+      Simple: {
+        Subject: {
+          Data: message.subject,
+          Charset: charset,
+        },
+        Body: {
+          Text: message.text
+            ? {
+                Data: message.text,
+                Charset: charset,
+              }
+            : undefined,
+          Html: message.html
+            ? {
+                Data: message.html,
+                Charset: charset,
+              }
+            : undefined,
+        },
+        Headers: commonHeadersArray(message)?.map((header) => ({
+          Name: header.name,
+          Value: header.value,
+        })),
+        Attachments: attachments?.map((attachment) => ({
+          FileName: attachment.filename,
+          RawContent: attachment.content,
+          ContentType: attachment.contentType,
+          ContentId: attachment.contentId,
+          ContentDisposition: attachment.disposition?.toUpperCase(),
+          ContentTransferEncoding: "BASE64",
+        })),
+      },
+    },
+  };
+}
+
+function signAwsRequest(input: {
+  accessKeyId: string;
+  secretAccessKey: string;
+  sessionToken?: string;
+  region: string;
+  service: string;
+  method: string;
+  url: URL;
+  body: string;
+  headers: Record<string, string>;
+}) {
+  const now = new Date();
+  const amzDate = toAmzDate(now);
+  const dateStamp = amzDate.slice(0, 8);
+  const payloadHash = sha256Hex(input.body);
+  const headers = {
+    ...input.headers,
+    host: input.url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+    ...(input.sessionToken ? { "x-amz-security-token": input.sessionToken } : {}),
+  };
+  const canonicalHeaders = Object.entries(headers)
+    .map(([name, value]) => [name.toLowerCase(), value.trim()] as const)
+    .sort(([left], [right]) => left.localeCompare(right));
+  const signedHeaders = canonicalHeaders.map(([name]) => name).join(";");
+  const credentialScope = `${dateStamp}/${input.region}/${input.service}/aws4_request`;
+  const canonicalRequest = [
+    input.method,
+    input.url.pathname,
+    input.url.searchParams.toString(),
+    canonicalHeaders.map(([name, value]) => `${name}:${value}\n`).join(""),
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const signingKey = getSigningKey(input.secretAccessKey, dateStamp, input.region, input.service);
+  const signature = hmacHex(signingKey, stringToSign);
+
+  return {
+    ...headers,
+    Authorization: [
+      `AWS4-HMAC-SHA256 Credential=${input.accessKeyId}/${credentialScope}`,
+      `SignedHeaders=${signedHeaders}`,
+      `Signature=${signature}`,
+    ].join(", "),
+  };
+}
+
+function toAmzDate(date: Date) {
+  return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
+}
+
+function sha256Hex(value: string) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function hmac(key: string | Buffer, value: string) {
+  return createHmac("sha256", key).update(value).digest();
+}
+
+function hmacHex(key: string | Buffer, value: string) {
+  return createHmac("sha256", key).update(value).digest("hex");
+}
+
+function getSigningKey(
+  secretAccessKey: string,
+  dateStamp: string,
+  region: string,
+  service: string,
+) {
+  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const regionKey = hmac(dateKey, region);
+  const serviceKey = hmac(regionKey, service);
+  return hmac(serviceKey, "aws4_request");
+}

--- a/packages/email-sdk/src/ses.ts
+++ b/packages/email-sdk/src/ses.ts
@@ -1,5 +1,3 @@
-import { createHash, createHmac } from "node:crypto";
-
 import { EmailProviderError } from "./errors.js";
 import {
   base64Attachments,
@@ -39,7 +37,7 @@ export function ses(
       const fetcher = options.fetch ?? fetch;
       const endpoint = new URL("/v2/email/outbound-emails", baseUrl);
       const body = JSON.stringify(await toSesPayload(message, options));
-      const headers = signAwsRequest({
+      const headers = await signAwsRequest({
         accessKeyId: options.accessKeyId,
         secretAccessKey: options.secretAccessKey,
         sessionToken: options.sessionToken,
@@ -147,7 +145,7 @@ async function toSesPayload(message: EmailMessage, options: SesProviderOptions) 
   };
 }
 
-function signAwsRequest(input: {
+async function signAwsRequest(input: {
   accessKeyId: string;
   secretAccessKey: string;
   sessionToken?: string;
@@ -161,7 +159,7 @@ function signAwsRequest(input: {
   const now = new Date();
   const amzDate = toAmzDate(now);
   const dateStamp = amzDate.slice(0, 8);
-  const payloadHash = sha256Hex(input.body);
+  const payloadHash = await sha256Hex(input.body);
   const requestHeaders = {
     ...input.headers,
     "x-amz-content-sha256": payloadHash,
@@ -188,10 +186,15 @@ function signAwsRequest(input: {
     "AWS4-HMAC-SHA256",
     amzDate,
     credentialScope,
-    sha256Hex(canonicalRequest),
+    await sha256Hex(canonicalRequest),
   ].join("\n");
-  const signingKey = getSigningKey(input.secretAccessKey, dateStamp, input.region, input.service);
-  const signature = hmacHex(signingKey, stringToSign);
+  const signingKey = await getSigningKey(
+    input.secretAccessKey,
+    dateStamp,
+    input.region,
+    input.service,
+  );
+  const signature = await hmacHex(signingKey, stringToSign);
 
   return {
     ...requestHeaders,
@@ -207,8 +210,9 @@ function toAmzDate(date: Date) {
   return date.toISOString().replace(/[:-]|\.\d{3}/g, "");
 }
 
-function sha256Hex(value: string) {
-  return createHash("sha256").update(value).digest("hex");
+async function sha256Hex(value: string) {
+  const digest = await crypto.subtle.digest("SHA-256", textBytes(value));
+  return bytesToHex(new Uint8Array(digest));
 }
 
 function canonicalQueryString(searchParams: URLSearchParams) {
@@ -228,22 +232,44 @@ function awsEncode(value: string) {
   );
 }
 
-function hmac(key: string | Buffer, value: string) {
-  return createHmac("sha256", key).update(value).digest();
+async function hmac(key: string | Uint8Array, value: string) {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    typeof key === "string" ? textBytes(key) : toArrayBuffer(key),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", cryptoKey, textBytes(value));
+  return new Uint8Array(signature);
 }
 
-function hmacHex(key: string | Buffer, value: string) {
-  return createHmac("sha256", key).update(value).digest("hex");
+async function hmacHex(key: string | Uint8Array, value: string) {
+  return bytesToHex(await hmac(key, value));
 }
 
-function getSigningKey(
+async function getSigningKey(
   secretAccessKey: string,
   dateStamp: string,
   region: string,
   service: string,
 ) {
-  const dateKey = hmac(`AWS4${secretAccessKey}`, dateStamp);
-  const regionKey = hmac(dateKey, region);
-  const serviceKey = hmac(regionKey, service);
+  const dateKey = await hmac(`AWS4${secretAccessKey}`, dateStamp);
+  const regionKey = await hmac(dateKey, region);
+  const serviceKey = await hmac(regionKey, service);
   return hmac(serviceKey, "aws4_request");
+}
+
+function textBytes(value: string) {
+  return new TextEncoder().encode(value);
+}
+
+function toArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer;
+}
+
+function bytesToHex(bytes: Uint8Array) {
+  return [...bytes].map((byte) => byte.toString(16).padStart(2, "0")).join("");
 }

--- a/packages/email-sdk/src/ses.ts
+++ b/packages/email-sdk/src/ses.ts
@@ -179,7 +179,7 @@ function signAwsRequest(input: {
   const canonicalRequest = [
     input.method,
     input.url.pathname,
-    input.url.searchParams.toString(),
+    canonicalQueryString(input.url.searchParams),
     canonicalHeaders.map(([name, value]) => `${name}:${value}\n`).join(""),
     signedHeaders,
     payloadHash,
@@ -209,6 +209,23 @@ function toAmzDate(date: Date) {
 
 function sha256Hex(value: string) {
   return createHash("sha256").update(value).digest("hex");
+}
+
+function canonicalQueryString(searchParams: URLSearchParams) {
+  return [...searchParams.entries()]
+    .map(([key, value]) => [awsEncode(key), awsEncode(value)] as const)
+    .sort(([leftKey, leftValue], [rightKey, rightValue]) => {
+      const keyOrder = leftKey.localeCompare(rightKey);
+      return keyOrder === 0 ? leftValue.localeCompare(rightValue) : keyOrder;
+    })
+    .map(([key, value]) => `${key}=${value}`)
+    .join("&");
+}
+
+function awsEncode(value: string) {
+  return encodeURIComponent(value).replace(/[!'()*]/g, (character) =>
+    `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
 }
 
 function hmac(key: string | Buffer, value: string) {

--- a/packages/email-sdk/src/ses.ts
+++ b/packages/email-sdk/src/ses.ts
@@ -162,14 +162,16 @@ function signAwsRequest(input: {
   const amzDate = toAmzDate(now);
   const dateStamp = amzDate.slice(0, 8);
   const payloadHash = sha256Hex(input.body);
-  const headers = {
+  const requestHeaders = {
     ...input.headers,
-    host: input.url.host,
     "x-amz-content-sha256": payloadHash,
     "x-amz-date": amzDate,
     ...(input.sessionToken ? { "x-amz-security-token": input.sessionToken } : {}),
   };
-  const canonicalHeaders = Object.entries(headers)
+  const canonicalHeaders = Object.entries({
+    ...requestHeaders,
+    host: input.url.host,
+  })
     .map(([name, value]) => [name.toLowerCase(), value.trim()] as const)
     .sort(([left], [right]) => left.localeCompare(right));
   const signedHeaders = canonicalHeaders.map(([name]) => name).join(";");
@@ -192,7 +194,7 @@ function signAwsRequest(input: {
   const signature = hmacHex(signingKey, stringToSign);
 
   return {
-    ...headers,
+    ...requestHeaders,
     Authorization: [
       `AWS4-HMAC-SHA256 Credential=${input.accessKeyId}/${credentialScope}`,
       `SignedHeaders=${signedHeaders}`,

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["dist/**", ".output/**"]
+      "outputs": ["dist/**", ".output/**", ".vercel/output/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "apps/fumadocs/.vercel/output/static"
+}


### PR DESCRIPTION
## Summary
- Add a new `ses` adapter that sends directly to the AWS SES v2 `SendEmail` API with SigV4 signing and no AWS SDK dependency.
- Wire SES into the CLI, package exports, provider registry, and docs so it appears alongside the existing adapters.
- Add coverage for SES payload mapping, request signing, and unsupported field validation.

## Testing
- `Not run` (no test suite was executed in this turn).
- Added unit tests in `packages/email-sdk/src/adapters.test.ts` covering SES request construction and error handling.
- Updated docs and adapter metadata to expose the new SES provider and its required environment variables.