### PR TITLE
Publish package from opencoredev npm scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ you actually send through, and keep provider-specific field support visible in t
 ## Quickstart
 
 ```bash
-bun add @email-sdk/email-sdk
+bun add @opencoredev/email-sdk
 ```
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
 
 const email = createEmailClient({
   adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs/adapters/brevo.mdx
@@ -7,8 +7,8 @@ icon: brevo
 <ProviderBadge adapter="brevo" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { brevo } from "@email-sdk/email-sdk/brevo";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { brevo } from "@opencoredev/email-sdk/brevo";
 
 const email = createEmailClient({
   adapters: [brevo({ apiKey: process.env.BREVO_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -16,9 +16,9 @@ before choosing fallback routes.
 ## Import pattern
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
-import { smtp } from "@email-sdk/email-sdk/smtp";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs/adapters/loops.mdx
@@ -9,8 +9,8 @@ icon: loops
 Loops transactional sends normally use a `transactionalId`.
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { loops } from "@email-sdk/email-sdk/loops";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { loops } from "@opencoredev/email-sdk/loops";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailchimp.mdx
@@ -9,8 +9,8 @@ icon: mailchimp
 Mailchimp Transactional is the API formerly known as Mandrill.
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { mailchimp } from "@email-sdk/email-sdk/mailchimp";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailchimp } from "@opencoredev/email-sdk/mailchimp";
 
 const email = createEmailClient({
   adapters: [mailchimp({ apiKey: process.env.MAILCHIMP_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailersend.mdx
@@ -7,8 +7,8 @@ icon: mailersend
 <ProviderBadge adapter="mailersend" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { mailersend } from "@email-sdk/email-sdk/mailersend";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailersend } from "@opencoredev/email-sdk/mailersend";
 
 const email = createEmailClient({
   adapters: [mailersend({ apiKey: process.env.MAILERSEND_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailgun.mdx
@@ -7,8 +7,8 @@ icon: mailgun
 <ProviderBadge adapter="mailgun" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { mailgun } from "@email-sdk/email-sdk/mailgun";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailgun } from "@opencoredev/email-sdk/mailgun";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailpace.mdx
@@ -7,8 +7,8 @@ icon: mailpace
 <ProviderBadge adapter="mailpace" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { mailpace } from "@email-sdk/email-sdk/mailpace";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailpace } from "@opencoredev/email-sdk/mailpace";
 
 const email = createEmailClient({
   adapters: [mailpace({ apiKey: process.env.MAILPACE_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailtrap.mdx
@@ -7,8 +7,8 @@ icon: mailtrap
 <ProviderBadge adapter="mailtrap" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { mailtrap } from "@email-sdk/email-sdk/mailtrap";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailtrap } from "@opencoredev/email-sdk/mailtrap";
 
 const email = createEmailClient({
   adapters: [mailtrap({ apiKey: process.env.MAILTRAP_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs/adapters/plunk.mdx
@@ -7,8 +7,8 @@ icon: plunk
 <ProviderBadge adapter="plunk" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { plunk } from "@email-sdk/email-sdk/plunk";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { plunk } from "@opencoredev/email-sdk/plunk";
 
 const email = createEmailClient({
   adapters: [plunk({ apiKey: process.env.PLUNK_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs/adapters/postmark.mdx
@@ -9,8 +9,8 @@ The Postmark adapter calls the Postmark Email API directly. It does not add a ru
 <ProviderBadge adapter="postmark" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { postmark } from "@email-sdk/email-sdk/postmark";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { postmark } from "@opencoredev/email-sdk/postmark";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs/adapters/resend.mdx
@@ -9,8 +9,8 @@ The Resend adapter calls the Resend Email API directly. It does not add a runtim
 <ProviderBadge adapter="resend" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
 
 const email = createEmailClient({
   adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs/adapters/scaleway.mdx
@@ -7,8 +7,8 @@ icon: scaleway
 <ProviderBadge adapter="scaleway" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { scaleway } from "@email-sdk/email-sdk/scaleway";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { scaleway } from "@opencoredev/email-sdk/scaleway";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -7,8 +7,8 @@ icon: sendgrid
 <ProviderBadge adapter="sendgrid" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { sendgrid } from "@email-sdk/email-sdk/sendgrid";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sendgrid } from "@opencoredev/email-sdk/sendgrid";
 
 const email = createEmailClient({
   adapters: [sendgrid({ apiKey: process.env.SENDGRID_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs/adapters/smtp.mdx
@@ -11,8 +11,8 @@ When `auth` is configured with `secure: false`, the adapter sends `STARTTLS` bef
 ## Configure
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { smtp } from "@email-sdk/email-sdk/smtp";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { smtp } from "@opencoredev/email-sdk/smtp";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs/adapters/sparkpost.mdx
@@ -7,8 +7,8 @@ icon: sparkpost
 <ProviderBadge adapter="sparkpost" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { sparkpost } from "@email-sdk/email-sdk/sparkpost";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sparkpost } from "@opencoredev/email-sdk/sparkpost";
 
 const email = createEmailClient({
   adapters: [sparkpost({ apiKey: process.env.SPARKPOST_API_KEY! })],

--- a/apps/fumadocs/content/docs/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs/adapters/zeptomail.mdx
@@ -7,8 +7,8 @@ icon: zeptomail
 <ProviderBadge adapter="zeptomail" />
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { zeptomail } from "@email-sdk/email-sdk/zeptomail";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { zeptomail } from "@opencoredev/email-sdk/zeptomail";
 
 const email = createEmailClient({
   adapters: [zeptomail({ token: process.env.ZEPTOMAIL_TOKEN! })],

--- a/apps/fumadocs/content/docs/concepts/adapter-model.mdx
+++ b/apps/fumadocs/content/docs/concepts/adapter-model.mdx
@@ -7,9 +7,9 @@ icon: Plug
 An adapter is an Email SDK module that knows how to send through one service or transport.
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
-import { postmark } from "@email-sdk/email-sdk/postmark";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { postmark } from "@opencoredev/email-sdk/postmark";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs/getting-started/quickstart.mdx
@@ -7,14 +7,14 @@ icon: Rocket
 Install the SDK:
 
 ```bash
-bun add @email-sdk/email-sdk
+bun add @opencoredev/email-sdk
 ```
 
 This example sends through Resend. Set `RESEND_API_KEY` in the environment before running it.
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
 
 const email = createEmailClient({
   adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
@@ -38,9 +38,9 @@ Only use fallback adapters that can send the same message shape. For example, SM
 fields and headers, but not provider-only fields like tags, metadata, or attachments.
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
-import { smtp } from "@email-sdk/email-sdk/smtp";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
 
 export const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/index.mdx
+++ b/apps/fumadocs/content/docs/index.mdx
@@ -12,8 +12,8 @@ provider when its field support fits your app better. Your application code stil
 the adapter decides how that message maps to the provider.
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
 
 const email = createEmailClient({
   adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],

--- a/apps/fumadocs/content/docs/reference/adapter-contract.mdx
+++ b/apps/fumadocs/content/docs/reference/adapter-contract.mdx
@@ -7,7 +7,7 @@ icon: Plug
 Custom adapters are plain objects.
 
 ```ts
-import type { EmailProvider } from "@email-sdk/email-sdk";
+import type { EmailProvider } from "@opencoredev/email-sdk";
 
 export const customAdapter: EmailProvider = {
   name: "custom",

--- a/apps/fumadocs/content/docs/reference/errors.mdx
+++ b/apps/fumadocs/content/docs/reference/errors.mdx
@@ -12,7 +12,7 @@ import {
   EmailProviderNotFoundError,
   EmailSdkError,
   EmailValidationError,
-} from "@email-sdk/email-sdk";
+} from "@opencoredev/email-sdk";
 ```
 
 ## Error fields

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -6,12 +6,12 @@ Use one client in your app, pick the adapters you actually send through, and kee
 field support visible instead of pretending every email API behaves the same way.
 
 ```bash
-bun add @email-sdk/email-sdk
+bun add @opencoredev/email-sdk
 ```
 
 ```ts
-import { createEmailClient } from "@email-sdk/email-sdk";
-import { resend } from "@email-sdk/email-sdk/resend";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
 
 const email = createEmailClient({
   adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
@@ -27,22 +27,22 @@ await email.send({
 
 Adapters:
 
-- `@email-sdk/email-sdk/resend`
-- `@email-sdk/email-sdk/smtp`
-- `@email-sdk/email-sdk/postmark`
-- `@email-sdk/email-sdk/sendgrid`
-- `@email-sdk/email-sdk/ses`
-- `@email-sdk/email-sdk/mailgun`
-- `@email-sdk/email-sdk/mailersend`
-- `@email-sdk/email-sdk/brevo`
-- `@email-sdk/email-sdk/mailchimp`
-- `@email-sdk/email-sdk/sparkpost`
-- `@email-sdk/email-sdk/loops`
-- `@email-sdk/email-sdk/plunk`
-- `@email-sdk/email-sdk/mailtrap`
-- `@email-sdk/email-sdk/scaleway`
-- `@email-sdk/email-sdk/zeptomail`
-- `@email-sdk/email-sdk/mailpace`
+- `@opencoredev/email-sdk/resend`
+- `@opencoredev/email-sdk/smtp`
+- `@opencoredev/email-sdk/postmark`
+- `@opencoredev/email-sdk/sendgrid`
+- `@opencoredev/email-sdk/ses`
+- `@opencoredev/email-sdk/mailgun`
+- `@opencoredev/email-sdk/mailersend`
+- `@opencoredev/email-sdk/brevo`
+- `@opencoredev/email-sdk/mailchimp`
+- `@opencoredev/email-sdk/sparkpost`
+- `@opencoredev/email-sdk/loops`
+- `@opencoredev/email-sdk/plunk`
+- `@opencoredev/email-sdk/mailtrap`
+- `@opencoredev/email-sdk/scaleway`
+- `@opencoredev/email-sdk/zeptomail`
+- `@opencoredev/email-sdk/mailpace`
 
 SMTP is built in and does not require Nodemailer.
 

--- a/packages/email-sdk/package.json
+++ b/packages/email-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@email-sdk/email-sdk",
+  "name": "@opencoredev/email-sdk",
   "version": "0.2.0",
   "description": "A lightweight TypeScript SDK for unified email sending.",
   "homepage": "https://github.com/opencoredev/email-sdk#readme",


### PR DESCRIPTION
Switches the publish package name and docs to @opencoredev/email-sdk now that the opencoredev npm org exists. Keeps trusted publishing through GitHub Actions and avoids long-lived npm tokens.