### PR TITLE
Sync email SDK package version

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,7 +53,7 @@
       "version": "0.0.0",
     },
     "packages/email-sdk": {
-      "name": "@email-sdk/email-sdk",
+      "name": "@opencoredev/email-sdk",
       "version": "0.2.0",
       "bin": {
         "email-sdk": "dist/cli.js",
@@ -139,8 +139,6 @@
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
     "@email-sdk/config": ["@email-sdk/config@workspace:packages/config"],
-
-    "@email-sdk/email-sdk": ["@email-sdk/email-sdk@workspace:packages/email-sdk"],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -243,6 +241,8 @@
     "@oozcitak/url": ["@oozcitak/url@3.0.0", "", { "dependencies": { "@oozcitak/infra": "^2.0.2", "@oozcitak/util": "^10.0.0" } }, "sha512-ZKfET8Ak1wsLAiLWNfFkZc/BraDccuTJKR6svTYc7sVjbR+Iu0vtXdiDMY4o6jaFl5TW2TlS7jbLl4VovtAJWQ=="],
 
     "@oozcitak/util": ["@oozcitak/util@10.0.0", "", {}, "sha512-hAX0pT/73190NLqBPPWSdBVGtbY6VOhWYK3qqHqtXQ1gK7kS2yz4+ivsN07hpJ6I3aeMtKP6J6npsEKOAzuTLA=="],
+
+    "@opencoredev/email-sdk": ["@opencoredev/email-sdk@workspace:packages/email-sdk"],
 
     "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 

--- a/packages/email-sdk/package.json
+++ b/packages/email-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opencoredev/email-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A lightweight TypeScript SDK for unified email sending.",
   "homepage": "https://github.com/opencoredev/email-sdk#readme",
   "bugs": {


### PR DESCRIPTION
Syncs packages/email-sdk/package.json to the published @opencoredev/email-sdk@0.2.1 version after the npm bootstrap publish.\n\nValidation run locally:\n- bun run check-types\n- bun test\n- bun run build