### PR TITLE
docs: clarify published npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ you actually send through, and keep provider-specific field support visible in t
 bun add @opencoredev/email-sdk
 ```
 
+The public npm package is `@opencoredev/email-sdk`; the unscoped `email-sdk` package is unrelated.
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { resend } from "@opencoredev/email-sdk/resend";

--- a/apps/fumadocs/content/docs/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs/getting-started/quickstart.mdx
@@ -10,6 +10,8 @@ Install the SDK:
 bun add @opencoredev/email-sdk
 ```
 
+The public npm package is `@opencoredev/email-sdk`; the unscoped `email-sdk` package is unrelated.
+
 This example sends through Resend. Set `RESEND_API_KEY` in the environment before running it.
 
 ```ts

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -9,6 +9,8 @@ field support visible instead of pretending every email API behaves the same way
 bun add @opencoredev/email-sdk
 ```
 
+The public npm package is `@opencoredev/email-sdk`; the unscoped `email-sdk` package is unrelated.
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { resend } from "@opencoredev/email-sdk/resend";


### PR DESCRIPTION
## Summary\n- clarify that the public npm package is @opencoredev/email-sdk\n- warn that the unscoped email-sdk package is unrelated\n\n## Validation\n- bun run check-types\n- bun test\n- bun run build\n- npm install @opencoredev/email-sdk@latest in a clean temp project\n- installed CLI: email-sdk adapters\n- installed CLI dry-run: email-sdk send --adapter resend ... --dry-run\n- installed SDK send smoke via @opencoredev/email-sdk/testing memory provider