### PR TITLE
Add docs version picker and CLI version command

### DIFF
--- a/.changeset/bright-docs-version.md
+++ b/.changeset/bright-docs-version.md
@@ -1,0 +1,5 @@
+---
+"@opencoredev/email-sdk": patch
+---
+
+Add an `email-sdk version` CLI command so users and agents can verify the installed SDK and CLI version.

--- a/apps/fumadocs/content/docs/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs/adapters/ses.mdx
@@ -9,8 +9,8 @@ The AWS SES adapter calls the SES v2 SendEmail API directly with SigV4-signed fe
 <ProviderBadge adapter="ses" />
 
 ```ts
-import { createEmailClient } from "email-sdk";
-import { ses } from "email-sdk/ses";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { ses } from "@opencoredev/email-sdk/ses";
 
 const email = createEmailClient({
   adapters: [

--- a/apps/fumadocs/content/docs/agents/skill.mdx
+++ b/apps/fumadocs/content/docs/agents/skill.mdx
@@ -21,7 +21,7 @@ Use it when an agent wires Email SDK into an app, reviews adapter setup, or upda
 ## What it tells agents
 
 - Use `bun` and `bunx`.
-- Refresh the current README, package exports, Fumadocs pages, and TypeScript declarations before implementing.
+- Refresh the current README, package version, package exports, Fumadocs pages, and TypeScript declarations before implementing.
 - Keep adapter credentials in environment variables.
 - Import adapters from their own entry points.
 - Do not add Nodemailer for SMTP; Email SDK includes its own SMTP transport.

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -61,6 +61,7 @@ email-sdk doctor --adapter resend
 ```bash
 email-sdk version
 email-sdk --version
+email-sdk -v
 email-sdk version --json
 ```
 
@@ -68,44 +69,44 @@ email-sdk version --json
 
 ## Flags
 
-| Flag                    | Adapter   | Notes                                                  |
-| ----------------------- | --------- | ------------------------------------------------------ |
-| `--adapter`             | all       | Adapter routing name.                                  |
-| `--provider`            | all       | Alias for `--adapter`.                                 |
-| `--from`                | all       | Sender address.                                        |
-| `--to`                  | all       | Recipient address. Comma-separated values are allowed. |
-| `--subject`             | all       | Message subject.                                       |
-| `--text`                | all       | Plain text body.                                       |
-| `--html`                | all       | HTML body.                                             |
-| `--cc`                  | send      | Comma-separated CC addresses.                          |
-| `--bcc`                 | send      | Comma-separated BCC addresses.                         |
-| `--reply-to`            | send      | Comma-separated reply-to addresses.                    |
-| `--header`              | send      | Header in `Name: value` format. Repeatable.            |
-| `--tag`                 | send      | Tag in `name=value` format. Repeatable.                |
-| `--metadata`            | send      | Metadata in `key=value` format. Repeatable.            |
-| `--attachment`          | send      | Local file path, optionally `path:content/type`.       |
-| `--message`             | send      | Read an `EmailMessage` JSON payload from a file.       |
-| `--dry-run`             | all       | Validate and print the send plan without sending.      |
-| `--json`                | version   | Print package name and version as JSON.                |
-| `--api-key`             | many      | Overrides the adapter API key variable.                |
-| `--server-token`        | Postmark  | Overrides `POSTMARK_SERVER_TOKEN`.                     |
-| `--message-stream`      | Postmark  | Optional message stream.                               |
-| `--access-key-id`       | AWS SES   | Overrides `AWS_ACCESS_KEY_ID`.                         |
-| `--secret-access-key`   | AWS SES   | Overrides `AWS_SECRET_ACCESS_KEY`.                     |
-| `--region`              | AWS SES   | Overrides `AWS_REGION`.                                |
-| `--session-token`       | AWS SES   | Overrides `AWS_SESSION_TOKEN`.                         |
-| `--configuration-set`   | AWS SES   | Overrides `AWS_SES_CONFIGURATION_SET`.                 |
-| `--domain`              | Mailgun   | Overrides `MAILGUN_DOMAIN`.                            |
-| `--transactional-id`    | Loops     | Overrides `LOOPS_TRANSACTIONAL_ID`.                    |
-| `--project-id`          | Scaleway  | Overrides `SCALEWAY_PROJECT_ID`.                       |
-| `--secret-key`          | Scaleway  | Overrides `SCALEWAY_SECRET_KEY`.                       |
-| `--token`               | ZeptoMail | Overrides `ZEPTOMAIL_TOKEN`.                           |
-| `--host`                | SMTP      | Overrides `SMTP_HOST`.                                 |
-| `--port`                | SMTP      | Overrides `SMTP_PORT`.                                 |
-| `--secure`              | SMTP      | Set to `true` for secure SMTP.                         |
-| `--require-tls`         | SMTP      | Require STARTTLS.                                      |
-| `--allow-insecure-auth` | SMTP      | Allow SMTP AUTH without TLS.                           |
-| `--user`                | SMTP      | Overrides `SMTP_USER`.                                 |
-| `--pass`                | SMTP      | Overrides `SMTP_PASS`.                                 |
+| Flag                    | Adapter           | Notes                                                  |
+| ----------------------- | ----------------- | ------------------------------------------------------ |
+| `--adapter`             | all               | Adapter routing name.                                  |
+| `--provider`            | all               | Alias for `--adapter`.                                 |
+| `--from`                | all               | Sender address.                                        |
+| `--to`                  | all               | Recipient address. Comma-separated values are allowed. |
+| `--subject`             | all               | Message subject.                                       |
+| `--text`                | all               | Plain text body.                                       |
+| `--html`                | all               | HTML body.                                             |
+| `--cc`                  | send              | Comma-separated CC addresses.                          |
+| `--bcc`                 | send              | Comma-separated BCC addresses.                         |
+| `--reply-to`            | send              | Comma-separated reply-to addresses.                    |
+| `--header`              | send              | Header in `Name: value` format. Repeatable.            |
+| `--tag`                 | send              | Tag in `name=value` format. Repeatable.                |
+| `--metadata`            | send              | Metadata in `key=value` format. Repeatable.            |
+| `--attachment`          | send              | Local file path, optionally `path:content/type`.       |
+| `--message`             | send              | Read an `EmailMessage` JSON payload from a file.       |
+| `--dry-run`             | all               | Validate and print the send plan without sending.      |
+| `--json`                | version, adapters | Print output as JSON.                                  |
+| `--api-key`             | many              | Overrides the adapter API key variable.                |
+| `--server-token`        | Postmark          | Overrides `POSTMARK_SERVER_TOKEN`.                     |
+| `--message-stream`      | Postmark          | Optional message stream.                               |
+| `--access-key-id`       | AWS SES           | Overrides `AWS_ACCESS_KEY_ID`.                         |
+| `--secret-access-key`   | AWS SES           | Overrides `AWS_SECRET_ACCESS_KEY`.                     |
+| `--region`              | AWS SES           | Overrides `AWS_REGION`.                                |
+| `--session-token`       | AWS SES           | Overrides `AWS_SESSION_TOKEN`.                         |
+| `--configuration-set`   | AWS SES           | Overrides `AWS_SES_CONFIGURATION_SET`.                 |
+| `--domain`              | Mailgun           | Overrides `MAILGUN_DOMAIN`.                            |
+| `--transactional-id`    | Loops             | Overrides `LOOPS_TRANSACTIONAL_ID`.                    |
+| `--project-id`          | Scaleway          | Overrides `SCALEWAY_PROJECT_ID`.                       |
+| `--secret-key`          | Scaleway          | Overrides `SCALEWAY_SECRET_KEY`.                       |
+| `--token`               | ZeptoMail         | Overrides `ZEPTOMAIL_TOKEN`.                           |
+| `--host`                | SMTP              | Overrides `SMTP_HOST`.                                 |
+| `--port`                | SMTP              | Overrides `SMTP_PORT`.                                 |
+| `--secure`              | SMTP              | Set to `true` for secure SMTP.                         |
+| `--require-tls`         | SMTP              | Require STARTTLS.                                      |
+| `--allow-insecure-auth` | SMTP              | Allow SMTP AUTH without TLS.                           |
+| `--user`                | SMTP              | Overrides `SMTP_USER`.                                 |
+| `--pass`                | SMTP              | Overrides `SMTP_PASS`.                                 |
 
 The CLI prints the normalized adapter response as JSON.

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -6,6 +6,12 @@ icon: Terminal
 
 The CLI is intentionally small. Use it to inspect adapters, check environment variables, validate a message with `--dry-run`, and send a smoke-test email from your terminal.
 
+The CLI ships with the npm package. Check the installed version before comparing behavior against the docs:
+
+```bash
+email-sdk version
+```
+
 ```bash
 email-sdk send \
   --adapter resend \
@@ -50,6 +56,16 @@ email-sdk doctor --adapter resend
 
 `doctor` checks whether the selected adapter has the required environment variables.
 
+## Version
+
+```bash
+email-sdk version
+email-sdk --version
+email-sdk version --json
+```
+
+`version` reads the installed `@opencoredev/email-sdk` package metadata, so it reports the SDK and CLI version from the package currently on your machine. The docs version picker in the top navigation uses the same package version from this repository.
+
 ## Flags
 
 | Flag                    | Adapter   | Notes                                                  |
@@ -70,6 +86,7 @@ email-sdk doctor --adapter resend
 | `--attachment`          | send      | Local file path, optionally `path:content/type`.       |
 | `--message`             | send      | Read an `EmailMessage` JSON payload from a file.       |
 | `--dry-run`             | all       | Validate and print the send plan without sending.      |
+| `--json`                | version   | Print package name and version as JSON.                |
 | `--api-key`             | many      | Overrides the adapter API key variable.                |
 | `--server-token`        | Postmark  | Overrides `POSTMARK_SERVER_TOKEN`.                     |
 | `--message-stream`      | Postmark  | Optional message stream.                               |

--- a/apps/fumadocs/src/components/version-picker.tsx
+++ b/apps/fumadocs/src/components/version-picker.tsx
@@ -1,10 +1,45 @@
 import { Check, ChevronDown, ExternalLink, PackageCheck } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 
 import { docsVersion, docsVersions, sdkPackageName, versionLinks } from "@/lib/versions";
 
 export function VersionPicker() {
+  const [open, setOpen] = useState(false);
+  const detailsRef = useRef<HTMLDetailsElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handlePointerDown(event: PointerEvent) {
+      if (!detailsRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    }
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
   return (
-    <details className="group/version relative block">
+    <details
+      className="group/version relative block"
+      onToggle={(event) => {
+        setOpen(event.currentTarget.open);
+      }}
+      open={open}
+      ref={detailsRef}
+    >
       <summary className="flex h-9 cursor-pointer list-none items-center gap-2 rounded-md border border-fd-border bg-fd-background px-3 text-sm font-medium text-fd-foreground transition hover:bg-fd-accent [&::-webkit-details-marker]:hidden">
         <PackageCheck className="size-4 text-fd-muted-foreground" strokeWidth={2} />
         <span>{docsVersion}</span>
@@ -26,6 +61,9 @@ export function VersionPicker() {
               className="flex items-start gap-2 rounded-md px-2 py-2 text-sm transition hover:bg-fd-accent"
               href={version.href}
               key={version.label}
+              onClick={() => {
+                setOpen(false);
+              }}
             >
               <span className="mt-0.5 grid size-4 place-items-center text-fd-primary">
                 {version.current ? <Check className="size-3.5" strokeWidth={2.2} /> : null}
@@ -46,6 +84,9 @@ export function VersionPicker() {
               className="flex items-center justify-between rounded-md px-2 py-1.5 text-xs text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-foreground"
               href={link.href}
               key={link.href}
+              onClick={() => {
+                setOpen(false);
+              }}
               rel="noreferrer"
               target="_blank"
             >

--- a/apps/fumadocs/src/components/version-picker.tsx
+++ b/apps/fumadocs/src/components/version-picker.tsx
@@ -1,0 +1,60 @@
+import { Check, ChevronDown, ExternalLink, PackageCheck } from "lucide-react";
+
+import { docsVersion, docsVersions, sdkPackageName, versionLinks } from "@/lib/versions";
+
+export function VersionPicker() {
+  return (
+    <details className="group/version relative block">
+      <summary className="flex h-9 cursor-pointer list-none items-center gap-2 rounded-md border border-fd-border bg-fd-background px-3 text-sm font-medium text-fd-foreground transition hover:bg-fd-accent [&::-webkit-details-marker]:hidden">
+        <PackageCheck className="size-4 text-fd-muted-foreground" strokeWidth={2} />
+        <span>{docsVersion}</span>
+        <ChevronDown
+          className="size-3.5 text-fd-muted-foreground transition group-open/version:rotate-180"
+          strokeWidth={2}
+        />
+      </summary>
+
+      <div className="absolute right-0 z-50 mt-2 w-72 overflow-hidden rounded-lg border border-fd-border bg-fd-popover text-fd-popover-foreground shadow-xl shadow-black/10">
+        <div className="border-b border-fd-border px-3 py-2">
+          <p className="text-xs font-medium uppercase text-fd-muted-foreground">Docs version</p>
+          <p className="mt-0.5 truncate text-sm">{sdkPackageName}</p>
+        </div>
+
+        <div className="p-1.5">
+          {docsVersions.map((version) => (
+            <a
+              className="flex items-start gap-2 rounded-md px-2 py-2 text-sm transition hover:bg-fd-accent"
+              href={version.href}
+              key={version.label}
+            >
+              <span className="mt-0.5 grid size-4 place-items-center text-fd-primary">
+                {version.current ? <Check className="size-3.5" strokeWidth={2.2} /> : null}
+              </span>
+              <span>
+                <span className="block font-medium">{version.label}</span>
+                <span className="block text-xs text-fd-muted-foreground">
+                  {version.description}
+                </span>
+              </span>
+            </a>
+          ))}
+        </div>
+
+        <div className="border-t border-fd-border p-1.5">
+          {versionLinks.map((link) => (
+            <a
+              className="flex items-center justify-between rounded-md px-2 py-1.5 text-xs text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-foreground"
+              href={link.href}
+              key={link.href}
+              rel="noreferrer"
+              target="_blank"
+            >
+              {link.label}
+              <ExternalLink className="size-3" strokeWidth={2} />
+            </a>
+          ))}
+        </div>
+      </div>
+    </details>
+  );
+}

--- a/apps/fumadocs/src/lib/layout.shared.tsx
+++ b/apps/fumadocs/src/lib/layout.shared.tsx
@@ -1,5 +1,7 @@
 import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
 
+import { VersionPicker } from "@/components/version-picker";
+
 import { appName, gitConfig } from "./shared";
 
 export function baseOptions(): BaseLayoutProps {
@@ -13,6 +15,7 @@ export function baseOptions(): BaseLayoutProps {
           <span>{appName}</span>
         </span>
       ),
+      children: <VersionPicker />,
     },
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };

--- a/apps/fumadocs/src/lib/providers.ts
+++ b/apps/fumadocs/src/lib/providers.ts
@@ -30,7 +30,7 @@ export const providers = [
   {
     name: "AWS SES",
     key: "ses",
-    importPath: "email-sdk/ses",
+    importPath: "@opencoredev/email-sdk/ses",
     docs: "/docs/adapters/ses",
     logo: "https://www.google.com/s2/favicons?domain=aws.amazon.com&sz=64",
     category: "Infrastructure",

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -1,0 +1,25 @@
+import emailSdkPackage from "../../../../packages/email-sdk/package.json";
+
+export const sdkPackageName = emailSdkPackage.name;
+export const sdkVersion = emailSdkPackage.version;
+export const docsVersion = `v${sdkVersion}`;
+
+export const docsVersions = [
+  {
+    label: docsVersion,
+    description: "Current SDK, CLI, and docs",
+    href: "/docs",
+    current: true,
+  },
+] as const;
+
+export const versionLinks = [
+  {
+    label: "npm package",
+    href: `https://www.npmjs.com/package/${sdkPackageName}/v/${sdkVersion}`,
+  },
+  {
+    label: "Changelog",
+    href: "https://github.com/opencoredev/email-sdk/blob/main/packages/email-sdk/CHANGELOG.md",
+  },
+] as const;

--- a/apps/fumadocs/src/routes/index.tsx
+++ b/apps/fumadocs/src/routes/index.tsx
@@ -10,9 +10,9 @@ export const Route = createFileRoute("/")({
   component: Home,
 });
 
-const example = `import { createEmailClient } from "email-sdk";
-import { resend } from "email-sdk/resend";
-import { smtp } from "email-sdk/smtp";
+const example = `import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
 
 const email = createEmailClient({
   adapters: [
@@ -192,15 +192,15 @@ function SyntaxCode() {
     <>
       <CodeLine number={1}>
         <Token tone="keyword">import</Token> {"{ createEmailClient }"}{" "}
-        <Token tone="keyword">from</Token> <Token tone="string">"email-sdk"</Token>;
+        <Token tone="keyword">from</Token> <Token tone="string">"@opencoredev/email-sdk"</Token>;
       </CodeLine>
       <CodeLine number={2}>
         <Token tone="keyword">import</Token> {"{ resend }"} <Token tone="keyword">from</Token>{" "}
-        <Token tone="string">"email-sdk/resend"</Token>;
+        <Token tone="string">"@opencoredev/email-sdk/resend"</Token>;
       </CodeLine>
       <CodeLine number={3}>
         <Token tone="keyword">import</Token> {"{ smtp }"} <Token tone="keyword">from</Token>{" "}
-        <Token tone="string">"email-sdk/smtp"</Token>;
+        <Token tone="string">"@opencoredev/email-sdk/smtp"</Token>;
       </CodeLine>
       <CodeLine />
       <CodeLine number={5}>

--- a/packages/email-sdk/src/cli.test.ts
+++ b/packages/email-sdk/src/cli.test.ts
@@ -7,19 +7,7 @@ const packageInfo = (await Bun.file(new URL("../package.json", import.meta.url))
 
 describe("email-sdk CLI", () => {
   test("prints the package version as JSON", async () => {
-    const packageRoot = new URL("..", import.meta.url).pathname;
-    const proc = Bun.spawn({
-      cmd: ["bun", "src/cli.ts", "version", "--json"],
-      cwd: packageRoot,
-      stderr: "pipe",
-      stdout: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
+    const { stdout, stderr, exitCode } = await runCli(["version", "--json"]);
 
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
@@ -28,4 +16,33 @@ describe("email-sdk CLI", () => {
       version: packageInfo.version,
     });
   });
+
+  test.each(["version", "--version", "-v"])(
+    "prints the package version with %s",
+    async (command) => {
+      const { stdout, stderr, exitCode } = await runCli([command]);
+
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+      expect(stdout.trim()).toBe(`${packageInfo.name} ${packageInfo.version}`);
+    },
+  );
 });
+
+async function runCli(args: string[]) {
+  const packageRoot = new URL("..", import.meta.url).pathname;
+  const proc = Bun.spawn({
+    cmd: ["bun", "src/cli.ts", ...args],
+    cwd: packageRoot,
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout, stderr, exitCode };
+}

--- a/packages/email-sdk/src/cli.test.ts
+++ b/packages/email-sdk/src/cli.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+const packageInfo = (await Bun.file(new URL("../package.json", import.meta.url)).json()) as {
+  name: string;
+  version: string;
+};
+
+describe("email-sdk CLI", () => {
+  test("prints the package version as JSON", async () => {
+    const packageRoot = new URL("..", import.meta.url).pathname;
+    const proc = Bun.spawn({
+      cmd: ["bun", "src/cli.ts", "version", "--json"],
+      cwd: packageRoot,
+      stderr: "pipe",
+      stdout: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({
+      name: packageInfo.name,
+      version: packageInfo.version,
+    });
+  });
+});

--- a/packages/email-sdk/src/cli.ts
+++ b/packages/email-sdk/src/cli.ts
@@ -251,14 +251,21 @@ async function printVersion(flags: CliFlags) {
 }
 
 async function readPackageInfo(): Promise<PackageInfo> {
-  const packageJson = (await Bun.file(new URL("../package.json", import.meta.url)).json()) as
-    | Partial<PackageInfo>
-    | undefined;
+  try {
+    const packageJson = (await Bun.file(new URL("../package.json", import.meta.url)).json()) as
+      | Partial<PackageInfo>
+      | undefined;
 
-  return {
-    name: packageJson?.name ?? "@opencoredev/email-sdk",
-    version: packageJson?.version ?? "0.0.0",
-  };
+    return {
+      name: packageJson?.name ?? "@opencoredev/email-sdk",
+      version: packageJson?.version ?? "0.0.0",
+    };
+  } catch {
+    return {
+      name: "@opencoredev/email-sdk",
+      version: "0.0.0",
+    };
+  }
 }
 
 function parseFlags(args: string[]): CliFlags {

--- a/packages/email-sdk/src/cli.ts
+++ b/packages/email-sdk/src/cli.ts
@@ -30,6 +30,10 @@ import { zeptomail } from "./zeptomail.js";
 
 type CliFlags = Record<string, string | string[] | true>;
 type ProviderFactory = (flags: CliFlags) => EmailProvider;
+type PackageInfo = {
+  name: string;
+  version: string;
+};
 
 const providerDocs: Array<{
   name: string;
@@ -136,6 +140,11 @@ async function main() {
     return;
   }
 
+  if (command === "version" || command === "--version" || command === "-v") {
+    await printVersion(flags);
+    return;
+  }
+
   if (command === "adapters" || command === "providers") {
     printAdapters(flags);
     return;
@@ -228,6 +237,28 @@ function doctor(flags: CliFlags) {
   }
 
   console.log(`${provider.name} looks configured.`);
+}
+
+async function printVersion(flags: CliFlags) {
+  const packageInfo = await readPackageInfo();
+
+  if (truthyFlag(flags, "json")) {
+    console.log(JSON.stringify(packageInfo, null, 2));
+    return;
+  }
+
+  console.log(`${packageInfo.name} ${packageInfo.version}`);
+}
+
+async function readPackageInfo(): Promise<PackageInfo> {
+  const packageJson = (await Bun.file(new URL("../package.json", import.meta.url)).json()) as
+    | Partial<PackageInfo>
+    | undefined;
+
+  return {
+    name: packageJson?.name ?? "@opencoredev/email-sdk",
+    version: packageJson?.version ?? "0.0.0",
+  };
 }
 
 function parseFlags(args: string[]): CliFlags {
@@ -441,6 +472,7 @@ function printHelp() {
   console.log(`Email SDK
 
 Usage:
+  email-sdk version
   email-sdk adapters
   email-sdk doctor --adapter resend
   email-sdk send --adapter resend --from you@example.com --to them@example.com --subject "Hello" --text "It works"

--- a/skills/email-sdk/SKILL.md
+++ b/skills/email-sdk/SKILL.md
@@ -28,6 +28,7 @@ Before changing code, inspect the most relevant current sources:
    - the app's existing email, notification, queue, environment, and test patterns.
 3. If local docs are missing or the task depends on version-sensitive behavior, fetch the current published package metadata/docs before implementing:
    - `bun pm view @opencoredev/email-sdk`
+   - `email-sdk version` when the CLI is installed in the target app
    - `bunx --yes jsr info email-sdk` only if the project is using JSR
    - the repository docs or package README for the exact version in use.
 


### PR DESCRIPTION
## Summary\n- add a docs version picker tied to the Email SDK package version\n- add email-sdk version / --version / version --json for installed CLI verification\n- fix stale unscoped package imports in docs and homepage examples\n- update agent guidance and add a patch changeset for the CLI command\n\n## Validation\n- bun run check-types\n- bun test\n- bun run build\n- docs quality gate for changed docs\n- packages/email-sdk/dist/cli.js version\n- packages/email-sdk/dist/cli.js version --json