### PR TITLE
Add live smoke testing for email providers

### DIFF
--- a/apps/fumadocs/src/components/provider-catalog.tsx
+++ b/apps/fumadocs/src/components/provider-catalog.tsx
@@ -15,11 +15,12 @@ export function ProviderGrid() {
         >
           <div className="flex items-center gap-3">
             <ProviderMark logo={provider.logo} name={provider.name} />
-            <div>
+            <div className="min-w-0">
               <div className="font-medium">{provider.name}</div>
               <div className="text-xs text-fd-muted-foreground">{provider.category}</div>
             </div>
           </div>
+          <VerificationPill status={provider.verification.status} />
           <code className="mt-3 block text-xs text-fd-muted-foreground">{provider.importPath}</code>
         </Link>
       ))}
@@ -35,27 +36,63 @@ export function ProviderBadge({ adapter }: { adapter: string }) {
   }
 
   return (
-    <div className="not-prose mb-6 flex w-fit items-center gap-3 rounded-lg border border-fd-border bg-fd-card px-3 py-2 text-sm text-fd-foreground">
-      <ProviderMark logo={provider.logo} name={provider.name} />
-      <div>
-        <div className="font-medium">{provider.name}</div>
-        <code className="text-xs text-fd-muted-foreground">{provider.importPath}</code>
+    <div className="not-prose mb-6 max-w-2xl rounded-lg border border-fd-border bg-fd-card px-3 py-3 text-sm text-fd-foreground">
+      <div className="flex items-center gap-3">
+        <ProviderMark logo={provider.logo} name={provider.name} />
+        <div className="min-w-0">
+          <div className="font-medium">{provider.name}</div>
+          <code className="text-xs text-fd-muted-foreground">{provider.importPath}</code>
+        </div>
+        <VerificationPill className="ml-auto" status={provider.verification.status} />
+      </div>
+      <div className="mt-3 border-t border-fd-border pt-3 text-xs leading-5 text-fd-muted-foreground">
+        {provider.verification.note} If live delivery fails or provider behavior has changed,{" "}
+        <a className="font-medium text-fd-foreground underline" href="https://github.com/t3dotgg/email-sdk/issues">
+          open an issue
+        </a>
+        .
       </div>
     </div>
+  );
+}
+
+function VerificationPill({
+  className,
+  status,
+}: {
+  className?: string;
+  status: "verified" | "untested";
+}) {
+  if (status === "verified") {
+    return (
+      <span
+        className={`mt-3 inline-flex w-fit rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300 ${className ?? ""}`}
+      >
+        Live verified
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`mt-3 inline-flex w-fit rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-800 dark:text-amber-300 ${className ?? ""}`}
+    >
+      Untested live
+    </span>
   );
 }
 
 function ProviderMark({ logo, name }: { logo: string; name: string }) {
   if (!logo) {
     return (
-      <span className="grid size-9 place-items-center rounded-md border border-fd-border bg-fd-muted text-xs font-medium">
+      <span className="grid size-9 shrink-0 place-items-center rounded-md border border-fd-border bg-fd-muted text-xs font-medium">
         SMTP
       </span>
     );
   }
 
   return (
-    <span className="grid size-9 place-items-center rounded-md border border-fd-border bg-white p-1.5">
+    <span className="grid size-9 shrink-0 place-items-center rounded-md border border-fd-border bg-white p-1.5">
       <img
         alt={`${name} logo`}
         className="size-full object-contain"

--- a/apps/fumadocs/src/lib/providers.ts
+++ b/apps/fumadocs/src/lib/providers.ts
@@ -7,6 +7,10 @@ export const providers = [
     logo: "https://cdn.simpleicons.org/resend",
     sidebarLogo: "https://cdn.simpleicons.org/resend/white",
     category: "Popular APIs",
+    verification: {
+      status: "verified",
+      note: "Live delivery was verified with Resend's testing sender. Sending to arbitrary recipients still requires a verified Resend domain.",
+    },
   },
   {
     name: "Postmark",
@@ -15,6 +19,10 @@ export const providers = [
     docs: "/docs/adapters/postmark",
     logo: "https://www.google.com/s2/favicons?domain=postmarkapp.com&sz=64",
     category: "Popular APIs",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "SendGrid",
@@ -23,6 +31,10 @@ export const providers = [
     docs: "/docs/adapters/sendgrid",
     logo: "https://www.google.com/s2/favicons?domain=sendgrid.com&sz=64",
     category: "Popular APIs",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "Mailgun",
@@ -31,6 +43,10 @@ export const providers = [
     docs: "/docs/adapters/mailgun",
     logo: "https://cdn.simpleicons.org/mailgun",
     category: "Popular APIs",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "MailerSend",
@@ -39,6 +55,10 @@ export const providers = [
     docs: "/docs/adapters/mailersend",
     logo: "https://www.google.com/s2/favicons?domain=mailersend.com&sz=64",
     category: "Popular APIs",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "Brevo",
@@ -47,6 +67,10 @@ export const providers = [
     docs: "/docs/adapters/brevo",
     logo: "https://cdn.simpleicons.org/brevo",
     category: "Popular APIs",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "Mailchimp Transactional",
@@ -55,6 +79,10 @@ export const providers = [
     docs: "/docs/adapters/mailchimp",
     logo: "https://cdn.simpleicons.org/mailchimp",
     category: "Popular APIs",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests. Live Mailchimp Transactional delivery is not verified because the provider is paid or account-gated.",
+    },
   },
   {
     name: "SparkPost",
@@ -63,6 +91,10 @@ export const providers = [
     docs: "/docs/adapters/sparkpost",
     logo: "https://cdn.simpleicons.org/sparkpost",
     category: "Infrastructure",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "Mailtrap",
@@ -71,6 +103,10 @@ export const providers = [
     docs: "/docs/adapters/mailtrap",
     logo: "https://cdn.simpleicons.org/mailtrap",
     category: "Infrastructure",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "Scaleway",
@@ -79,6 +115,10 @@ export const providers = [
     docs: "/docs/adapters/scaleway",
     logo: "https://cdn.simpleicons.org/scaleway",
     category: "Infrastructure",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "ZeptoMail",
@@ -87,6 +127,10 @@ export const providers = [
     docs: "/docs/adapters/zeptomail",
     logo: "https://cdn.simpleicons.org/zoho",
     category: "Infrastructure",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "MailPace",
@@ -95,6 +139,10 @@ export const providers = [
     docs: "/docs/adapters/mailpace",
     logo: "https://www.google.com/s2/favicons?domain=mailpace.com&sz=64",
     category: "Infrastructure",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "Loops",
@@ -103,6 +151,10 @@ export const providers = [
     docs: "/docs/adapters/loops",
     logo: "https://cdn.simpleicons.org/loops",
     category: "Product-led",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "Plunk",
@@ -111,6 +163,10 @@ export const providers = [
     docs: "/docs/adapters/plunk",
     logo: "https://www.google.com/s2/favicons?domain=useplunk.com&sz=64",
     category: "Product-led",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live provider delivery has not been verified yet.",
+    },
   },
   {
     name: "SMTP",
@@ -119,6 +175,10 @@ export const providers = [
     docs: "/docs/adapters/smtp",
     logo: "",
     category: "Transport",
+    verification: {
+      status: "untested",
+      note: "Adapter contract is covered by tests, but live transport delivery has not been verified yet.",
+    },
   },
 ] as const;
 

--- a/packages/email-sdk/.env.live.example
+++ b/packages/email-sdk/.env.live.example
@@ -1,0 +1,60 @@
+# Copy to .env or export these in your shell before running live provider smoke tests.
+# Do not commit real provider keys.
+
+LIVE_EMAIL_TO=leodoesdev@gmail.com
+LIVE_EMAIL_FROM=
+LIVE_EMAIL_SUBJECT_PREFIX=Email SDK live smoke
+
+# Optional per-adapter verified senders. Use these when each provider has a different
+# verified domain or sandbox sender.
+# LIVE_EMAIL_FROM_RESEND=
+# LIVE_EMAIL_FROM_POSTMARK=
+# LIVE_EMAIL_FROM_SENDGRID=
+# LIVE_EMAIL_FROM_MAILGUN=
+# LIVE_EMAIL_FROM_MAILERSEND=
+# LIVE_EMAIL_FROM_BREVO=
+# LIVE_EMAIL_FROM_MAILCHIMP=
+# LIVE_EMAIL_FROM_SPARKPOST=
+# LIVE_EMAIL_FROM_LOOPS=
+# LIVE_EMAIL_FROM_PLUNK=
+# LIVE_EMAIL_FROM_MAILTRAP=
+# LIVE_EMAIL_FROM_SCALEWAY=
+# LIVE_EMAIL_FROM_ZEPTOMAIL=
+# LIVE_EMAIL_FROM_MAILPACE=
+
+# Optional comma-separated adapter filter:
+# LIVE_EMAIL_ADAPTERS=resend,postmark,sendgrid,mailgun,mailersend,brevo,mailchimp,sparkpost,loops,plunk,mailtrap,scaleway,zeptomail,mailpace
+
+RESEND_API_KEY=
+
+POSTMARK_SERVER_TOKEN=
+POSTMARK_MESSAGE_STREAM=outbound
+
+SENDGRID_API_KEY=
+
+MAILGUN_API_KEY=
+MAILGUN_DOMAIN=
+MAILGUN_BASE_URL=
+
+MAILERSEND_API_KEY=
+
+BREVO_API_KEY=
+
+MAILCHIMP_API_KEY=
+
+SPARKPOST_API_KEY=
+
+LOOPS_API_KEY=
+LOOPS_TRANSACTIONAL_ID=
+
+PLUNK_API_KEY=
+
+MAILTRAP_API_KEY=
+
+SCALEWAY_SECRET_KEY=
+SCALEWAY_PROJECT_ID=
+SCALEWAY_REGION=fr-par
+
+ZEPTOMAIL_TOKEN=
+
+MAILPACE_API_KEY=

--- a/packages/email-sdk/live-verification.json
+++ b/packages/email-sdk/live-verification.json
@@ -1,0 +1,35 @@
+{
+  "providers": {
+    "resend": {
+      "status": "verified",
+      "verifiedAt": "2026-05-30",
+      "scope": "Resend testing sender to account-owner recipient",
+      "messageId": "1415dfa2-2170-46bf-8537-2a625b752f96",
+      "notes": [
+        "A previous successful Resend smoke returned message ID 808d95ee-bf2e-4a40-a389-3ef912f9422a.",
+        "Sending to arbitrary recipients returned Resend's testing-mode restriction.",
+        "Domain verification is still required for production recipient coverage."
+      ]
+    },
+    "postmark": { "status": "untested" },
+    "sendgrid": { "status": "untested" },
+    "mailgun": { "status": "untested" },
+    "mailersend": { "status": "untested" },
+    "brevo": { "status": "untested" },
+    "mailchimp": {
+      "status": "untested",
+      "notes": ["Live Mailchimp Transactional delivery was skipped because the provider is paid or account-gated."]
+    },
+    "sparkpost": { "status": "untested" },
+    "loops": {
+      "status": "untested",
+      "notes": ["The current adapter requires both LOOPS_API_KEY and LOOPS_TRANSACTIONAL_ID."]
+    },
+    "plunk": { "status": "untested" },
+    "mailtrap": { "status": "untested" },
+    "scaleway": { "status": "untested" },
+    "zeptomail": { "status": "untested" },
+    "mailpace": { "status": "untested" },
+    "smtp": { "status": "untested" }
+  }
+}

--- a/packages/email-sdk/package.json
+++ b/packages/email-sdk/package.json
@@ -89,6 +89,7 @@
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.json && chmod +x dist/cli.js",
     "check-types": "tsc -p tsconfig.json --noEmit",
+    "live:smoke": "bun run src/live-smoke.ts",
     "test": "bun test"
   },
   "devDependencies": {

--- a/packages/email-sdk/src/live-smoke.ts
+++ b/packages/email-sdk/src/live-smoke.ts
@@ -1,0 +1,355 @@
+#!/usr/bin/env bun
+import "dotenv/config";
+
+import { brevo } from "./brevo.js";
+import { createEmailClient } from "./core.js";
+import { loops } from "./loops.js";
+import { mailchimp } from "./mailchimp.js";
+import { mailersend } from "./mailersend.js";
+import { mailgun } from "./mailgun.js";
+import { mailpace } from "./mailpace.js";
+import { mailtrap } from "./mailtrap.js";
+import { plunk } from "./plunk.js";
+import { postmark } from "./postmark.js";
+import { resend } from "./resend.js";
+import { scaleway } from "./scaleway.js";
+import { sendgrid } from "./sendgrid.js";
+import { sparkpost } from "./sparkpost.js";
+import type { EmailMessage, EmailProvider, EmailProviderResponse } from "./types.js";
+import { zeptomail } from "./zeptomail.js";
+
+type SmokeFlags = Record<string, string | true>;
+
+type SmokeProvider = {
+  name: string;
+  env: string[];
+  optionalEnv?: string[];
+  create: () => EmailProvider;
+};
+
+const flags = parseFlags(Bun.argv.slice(2));
+const sendLive = truthyFlag("send");
+const selectedAdapters = selectedAdapterNames();
+const to = stringFlag("to") ?? process.env.LIVE_EMAIL_TO ?? "leodoesdev@gmail.com";
+const subjectPrefix =
+  stringFlag("subject-prefix") ?? process.env.LIVE_EMAIL_SUBJECT_PREFIX ?? "Email SDK live smoke";
+
+const providers: SmokeProvider[] = [
+  {
+    name: "resend",
+    env: ["RESEND_API_KEY"],
+    create: () => resend({ apiKey: env("RESEND_API_KEY") }),
+  },
+  {
+    name: "postmark",
+    env: ["POSTMARK_SERVER_TOKEN"],
+    optionalEnv: ["POSTMARK_MESSAGE_STREAM"],
+    create: () =>
+      postmark({
+        serverToken: env("POSTMARK_SERVER_TOKEN"),
+        messageStream: process.env.POSTMARK_MESSAGE_STREAM,
+      }),
+  },
+  {
+    name: "sendgrid",
+    env: ["SENDGRID_API_KEY"],
+    create: () => sendgrid({ apiKey: env("SENDGRID_API_KEY") }),
+  },
+  {
+    name: "mailgun",
+    env: ["MAILGUN_API_KEY", "MAILGUN_DOMAIN"],
+    optionalEnv: ["MAILGUN_BASE_URL"],
+    create: () =>
+      mailgun({
+        apiKey: env("MAILGUN_API_KEY"),
+        domain: env("MAILGUN_DOMAIN"),
+        baseUrl: process.env.MAILGUN_BASE_URL,
+      }),
+  },
+  {
+    name: "mailersend",
+    env: ["MAILERSEND_API_KEY"],
+    create: () => mailersend({ apiKey: env("MAILERSEND_API_KEY") }),
+  },
+  {
+    name: "brevo",
+    env: ["BREVO_API_KEY"],
+    create: () => brevo({ apiKey: env("BREVO_API_KEY") }),
+  },
+  {
+    name: "mailchimp",
+    env: ["MAILCHIMP_API_KEY"],
+    create: () => mailchimp({ apiKey: env("MAILCHIMP_API_KEY") }),
+  },
+  {
+    name: "sparkpost",
+    env: ["SPARKPOST_API_KEY"],
+    create: () => sparkpost({ apiKey: env("SPARKPOST_API_KEY") }),
+  },
+  {
+    name: "loops",
+    env: ["LOOPS_API_KEY", "LOOPS_TRANSACTIONAL_ID"],
+    create: () =>
+      loops({
+        apiKey: env("LOOPS_API_KEY"),
+        transactionalId: env("LOOPS_TRANSACTIONAL_ID"),
+      }),
+  },
+  {
+    name: "plunk",
+    env: ["PLUNK_API_KEY"],
+    create: () => plunk({ apiKey: env("PLUNK_API_KEY") }),
+  },
+  {
+    name: "mailtrap",
+    env: ["MAILTRAP_API_KEY"],
+    create: () => mailtrap({ apiKey: env("MAILTRAP_API_KEY") }),
+  },
+  {
+    name: "scaleway",
+    env: ["SCALEWAY_SECRET_KEY", "SCALEWAY_PROJECT_ID"],
+    optionalEnv: ["SCALEWAY_REGION"],
+    create: () =>
+      scaleway({
+        secretKey: env("SCALEWAY_SECRET_KEY"),
+        projectId: env("SCALEWAY_PROJECT_ID"),
+        region: process.env.SCALEWAY_REGION,
+      }),
+  },
+  {
+    name: "zeptomail",
+    env: ["ZEPTOMAIL_TOKEN"],
+    create: () => zeptomail({ token: env("ZEPTOMAIL_TOKEN") }),
+  },
+  {
+    name: "mailpace",
+    env: ["MAILPACE_API_KEY"],
+    create: () => mailpace({ apiKey: env("MAILPACE_API_KEY") }),
+  },
+];
+
+if (truthyFlag("help")) {
+  printHelp();
+  process.exit(0);
+}
+
+const candidates = providers.filter((provider) => {
+  return selectedAdapters.length === 0 || selectedAdapters.includes(provider.name);
+});
+
+if (candidates.length === 0) {
+  console.error(
+    `No matching adapters. Known adapters: ${providers.map((item) => item.name).join(", ")}`,
+  );
+  process.exit(1);
+}
+
+const results: Array<
+  | { ok: true; adapter: string; sent: boolean; response?: EmailProviderResponse }
+  | { ok: false; adapter: string; skipped?: boolean; missing?: string[]; error?: string }
+> = [];
+
+for (const provider of candidates) {
+  const missing = provider.env.filter((name) => !process.env[name]);
+  const liveFrom = senderFor(provider.name);
+
+  if (!liveFrom) {
+    missing.push(`LIVE_EMAIL_FROM_${envSuffix(provider.name)} or LIVE_EMAIL_FROM or --from`);
+  }
+
+  if (missing.length > 0) {
+    results.push({ ok: false, adapter: provider.name, skipped: true, missing });
+    continue;
+  }
+
+  const message = buildMessage(provider.name, liveFrom as string);
+
+  if (!sendLive) {
+    results.push({ ok: true, adapter: provider.name, sent: false });
+    continue;
+  }
+
+  try {
+    const client = createEmailClient({ adapters: [provider.create()] });
+    const response = await client.send(message, {
+      idempotencyKey: `email-sdk-live-smoke-${provider.name}-${Date.now()}`,
+      metadata: { test: "live-smoke", adapter: provider.name },
+    });
+
+    results.push({
+      ok: true,
+      adapter: provider.name,
+      sent: true,
+      response: redactResponse(response),
+    });
+  } catch (error) {
+    results.push({
+      ok: false,
+      adapter: provider.name,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+const summary = {
+  mode: sendLive ? "send" : "dry-run",
+  to,
+  results,
+};
+
+console.log(JSON.stringify(summary, null, 2));
+
+if (results.some((result) => !result.ok && !result.skipped)) {
+  process.exit(1);
+}
+
+function buildMessage(adapter: string, from: string): EmailMessage {
+  const subject = `${subjectPrefix} [${adapter}]`;
+
+  return {
+    from,
+    to,
+    subject,
+    text: [
+      "Email SDK live smoke test.",
+      `Adapter: ${adapter}`,
+      `Timestamp: ${new Date().toISOString()}`,
+    ].join("\n"),
+    html: [
+      "<p>Email SDK live smoke test.</p>",
+      `<p><strong>Adapter:</strong> ${escapeHtml(adapter)}</p>`,
+      `<p><strong>Timestamp:</strong> ${escapeHtml(new Date().toISOString())}</p>`,
+    ].join(""),
+  };
+}
+
+function redactResponse(response: EmailProviderResponse) {
+  return {
+    provider: response.provider,
+    id: response.id,
+    messageId: response.messageId,
+    accepted: response.accepted,
+    rejected: response.rejected,
+  };
+}
+
+function selectedAdapterNames() {
+  const adapterFlag =
+    stringFlag("adapter") ?? stringFlag("provider") ?? process.env.LIVE_EMAIL_ADAPTERS;
+
+  return adapterFlag
+    ? adapterFlag
+        .split(",")
+        .map((item) => item.trim())
+        .filter(Boolean)
+    : [];
+}
+
+function senderFor(adapter: string) {
+  return (
+    stringFlag("from") ??
+    process.env[`LIVE_EMAIL_FROM_${envSuffix(adapter)}`] ??
+    process.env.LIVE_EMAIL_FROM
+  );
+}
+
+function envSuffix(adapter: string) {
+  return adapter.toUpperCase().replace(/[^A-Z0-9]/g, "_");
+}
+
+function parseFlags(args: string[]): SmokeFlags {
+  const parsed: SmokeFlags = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+
+    if (!current?.startsWith("--")) {
+      continue;
+    }
+
+    const [key, inlineValue] = current.slice(2).split(/=(.*)/s);
+
+    if (!key) {
+      continue;
+    }
+
+    if (inlineValue !== undefined) {
+      parsed[key] = inlineValue;
+      continue;
+    }
+
+    const next = args[index + 1];
+
+    if (!next || next.startsWith("--")) {
+      parsed[key] = true;
+      continue;
+    }
+
+    parsed[key] = next;
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function stringFlag(name: string) {
+  const value = flags[name];
+  return typeof value === "string" ? value : undefined;
+}
+
+function truthyFlag(name: string) {
+  const value = flags[name];
+  return value === true || value === "true" || value === "1";
+}
+
+function env(name: string) {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing ${name}`);
+  }
+
+  return value;
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, (character) => {
+    switch (character) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#039;";
+      default:
+        return character;
+    }
+  });
+}
+
+function printHelp() {
+  console.log(`Email SDK live smoke
+
+Usage:
+  bun run live:smoke -- --from "Acme <hello@example.com>"
+  bun run live:smoke -- --send --adapter resend,postmark --from "Acme <hello@example.com>"
+
+Options:
+  --send                         Actually send emails. Omit for a non-sending env check.
+  --adapter <names>              Comma-separated adapter names. Defaults to all known adapters.
+  --provider <names>             Alias for --adapter.
+  --from <address>               Verified sender address. Defaults to LIVE_EMAIL_FROM.
+                                  Can be overridden per adapter with LIVE_EMAIL_FROM_RESEND, etc.
+  --to <address>                 Recipient. Defaults to LIVE_EMAIL_TO or leodoesdev@gmail.com.
+  --subject-prefix <text>        Subject prefix. Defaults to LIVE_EMAIL_SUBJECT_PREFIX.
+
+Environment:
+  LIVE_EMAIL_FROM                Verified sender used for all adapters.
+  LIVE_EMAIL_TO                  Smoke recipient.
+  LIVE_EMAIL_ADAPTERS            Optional comma-separated adapter filter.
+`);
+}


### PR DESCRIPTION
## Summary
- Add a new `live:smoke` script and `src/live-smoke.ts` CLI to validate provider configuration and optionally send live test emails.
- Add a live environment example file with provider-specific sender and API key variables for smoke testing.
- Record live verification status for each provider and surface it in the Fumadocs provider catalog with verified/untested badges and notes.
- Document the current verified Resend scope in `live-verification.json`.

## Testing
- Not run (not requested).
- Added a dry-run path that prints a JSON summary without sending mail unless `--send` is passed.
- Added provider-specific env checks so missing credentials or sender addresses are reported before attempting delivery.
- Verified the UI changes update provider cards/badges to reflect live verification status and notes.