### PR TITLE
Rename Email SDK package to @opencoredev/email-sdk

### DIFF
--- a/.changeset/clear-cli-install-docs.md
+++ b/.changeset/clear-cli-install-docs.md
@@ -1,0 +1,5 @@
+---
+"@opencoredev/email-sdk": patch
+---
+
+Clarify CLI installation and one-off `bunx` usage in the package docs.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ bun add @opencoredev/email-sdk
 ```
 
 The public npm package is `@opencoredev/email-sdk`; the unscoped `email-sdk` package is unrelated.
+The CLI binary installed by this package is still named `email-sdk`.
 
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -38,6 +39,20 @@ await email.send({
 SMTP is built in and does not require Nodemailer.
 
 Adapters are stable by contract: they map supported `EmailMessage` fields and reject unsupported fields instead of silently dropping them.
+
+## CLI
+
+Run the CLI without installing anything globally:
+
+```bash
+bunx --yes @opencoredev/email-sdk adapters
+```
+
+After adding the package to a project, run the installed binary with Bun:
+
+```bash
+bun email-sdk doctor --adapter resend
+```
 
 ## Agent Skill
 

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -28,5 +28,5 @@ See <a href="/docs/adapters/field-support">field support</a> for headers, tags, 
 ## CLI
 
 ```bash
-email-sdk send --adapter sendgrid --from hello@example.com --to user@example.com --subject "Hello" --text "It works"
+bunx --yes @opencoredev/email-sdk send --adapter sendgrid --from hello@example.com --to user@example.com --subject "Hello" --text "It works"
 ```

--- a/apps/fumadocs/content/docs/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs/adapters/ses.mdx
@@ -55,7 +55,7 @@ await email.send({
 AWS_ACCESS_KEY_ID=... \
 AWS_SECRET_ACCESS_KEY=... \
 AWS_REGION=us-east-1 \
-email-sdk send --adapter ses \
+bunx --yes @opencoredev/email-sdk send --adapter ses \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \
   --subject "Welcome" \

--- a/apps/fumadocs/content/docs/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs/adapters/smtp.mdx
@@ -65,7 +65,7 @@ const email = createEmailClient({
 ## CLI
 
 ```bash
-email-sdk send \
+bunx --yes @opencoredev/email-sdk send \
   --adapter smtp \
   --host smtp.purelymail.com \
   --user hello@example.com \

--- a/apps/fumadocs/content/docs/getting-started/install.mdx
+++ b/apps/fumadocs/content/docs/getting-started/install.mdx
@@ -1,0 +1,60 @@
+---
+title: Install
+description: Install the SDK package and run the email-sdk CLI.
+icon: Package
+---
+
+Email SDK is published on npm as `@opencoredev/email-sdk`.
+
+The command-line binary is named `email-sdk`. That means the package name and the command name are different on purpose:
+
+| What you want | Use this |
+| --- | --- |
+| Install the package | `bun add @opencoredev/email-sdk` |
+| Run the installed CLI | `bun email-sdk ...` |
+| Run the CLI without installing | `bunx --yes @opencoredev/email-sdk ...` |
+
+Do not install the unscoped `email-sdk` package from npm. It is a different package.
+
+## Install in your app
+
+```bash
+bun add @opencoredev/email-sdk
+```
+
+Then import the client and adapters from the scoped package:
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+```
+
+## Run the CLI once
+
+Use `bunx` when you want a quick adapter check without adding the package to a project.
+
+```bash
+bunx --yes @opencoredev/email-sdk adapters
+```
+
+Check a provider configuration:
+
+```bash
+RESEND_API_KEY="re_..." bunx --yes @opencoredev/email-sdk doctor --adapter resend
+```
+
+## Run the CLI from an installed project
+
+After `bun add @opencoredev/email-sdk`, Bun can run the installed binary:
+
+```bash
+bun email-sdk adapters
+```
+
+The command is still `email-sdk`; the package you installed is still `@opencoredev/email-sdk`. Avoid `bunx email-sdk` outside an installed project because the unscoped npm package is unrelated.
+
+## Prerequisites
+
+- Bun is required for the CLI because the binary runs with `#!/usr/bin/env bun`.
+- Node 20 or newer is supported for SDK usage.
+- Provider credentials must be set in environment variables or passed with CLI flags.

--- a/apps/fumadocs/content/docs/getting-started/meta.json
+++ b/apps/fumadocs/content/docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Getting started",
-  "pages": ["quickstart"]
+  "pages": ["install", "quickstart"]
 }

--- a/apps/fumadocs/content/docs/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs/getting-started/quickstart.mdx
@@ -1,18 +1,20 @@
 ---
 title: Quickstart
-description: Install Email SDK, create a client, and send a first transactional email.
+description: Create a client, send a first transactional email, and verify the CLI path.
 icon: Rocket
 ---
 
-Install the SDK:
+Start with the scoped package:
 
 ```bash
 bun add @opencoredev/email-sdk
 ```
 
-The public npm package is `@opencoredev/email-sdk`; the unscoped `email-sdk` package is unrelated.
+The installed CLI command is named `email-sdk`. If you only need the CLI for a quick check, run `bunx --yes @opencoredev/email-sdk ...` instead. See <a href="/docs/getting-started/install">Install</a> for the package and CLI distinction.
 
-This example sends through Resend. Set `RESEND_API_KEY` in the environment before running it.
+## Send through Resend
+
+Set `RESEND_API_KEY`, then create a client with the Resend adapter.
 
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -30,7 +32,48 @@ await email.send({
 });
 ```
 
-## Add built-in SMTP fallback
+## Check the send result
+
+`send` resolves with the normalized adapter response. The `provider` value tells you which adapter
+actually handled the send.
+
+```ts
+const result = await email.send(message);
+
+console.log(result.provider);
+console.log(result.id);
+```
+
+If the adapter returns a message ID, Email SDK exposes it as both `id` and `messageId`. Provider
+responses are still available through `raw` when an adapter includes them.
+
+## Verify from the CLI
+
+Use `doctor` to check that the selected adapter has the required environment variables.
+
+```bash
+RESEND_API_KEY="re_..." bunx --yes @opencoredev/email-sdk doctor --adapter resend
+```
+
+Use `--dry-run` to validate the message shape without sending email.
+
+```bash
+bunx --yes @opencoredev/email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works" \
+  --dry-run
+```
+
+When the package is installed in your project, the same command can run through the installed binary:
+
+```bash
+bun email-sdk doctor --adapter resend
+```
+
+## Add SMTP fallback
 
 Add SMTP when you want a second route for the same transactional email. The SMTP adapter is built in
 and does not require Nodemailer. When SMTP auth is configured on a non-secure connection, Email SDK
@@ -70,39 +113,3 @@ await email.send({
   text: "Thanks for your order.",
 });
 ```
-
-## Check the result
-
-`send` resolves with the normalized adapter response. The `provider` value tells you which adapter
-actually handled the send.
-
-```ts
-const result = await email.send(message);
-
-console.log(result.provider);
-console.log(result.id);
-```
-
-If the adapter returns a message ID, Email SDK exposes it as both `id` and `messageId`. Provider
-responses are still available through `raw` when an adapter includes them.
-
-## Test from the CLI
-
-Use the CLI to check adapter credentials from your terminal.
-
-```bash
-email-sdk doctor --adapter resend
-```
-
-Send a test email:
-
-```bash
-email-sdk send \
-  --adapter resend \
-  --from "Acme <hello@acme.com>" \
-  --to "user@example.com" \
-  --subject "Hello" \
-  --text "It works"
-```
-
-Use `--dry-run` when you want to validate the message and selected adapter without sending email.

--- a/apps/fumadocs/content/docs/index.mdx
+++ b/apps/fumadocs/content/docs/index.mdx
@@ -31,6 +31,11 @@ await email.send({
 
 <Cards>
   <Card
+    title="Install package and CLI"
+    href="/docs/getting-started/install"
+    description="Use the scoped npm package and the email-sdk command."
+  />
+  <Card
     title="Send your first email"
     href="/docs/getting-started/quickstart"
     description="Install the SDK, create a client, and send a message."
@@ -72,6 +77,4 @@ call, typed errors, and a fallback path that is explicit enough to debug.
 ## Provider behavior is not hidden
 
 Email providers do not all support the same fields. A fallback route is only safe when the backup
-adapter can represent the same class of message. Before choosing routes, read the
-[field support guide](/docs/adapters/field-support); unsupported fields should fail fast instead of
-being silently dropped.
+adapter can represent the same class of message. Before choosing routes, read the <a href="/docs/adapters/field-support">field support guide</a>; unsupported fields should fail fast instead of being silently dropped.

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -6,14 +6,39 @@ icon: Terminal
 
 The CLI is intentionally small. Use it to inspect adapters, check environment variables, validate a message with `--dry-run`, and send a smoke-test email from your terminal.
 
-The CLI ships with the npm package. Check the installed version before comparing behavior against the docs:
+The npm package is `@opencoredev/email-sdk`; the CLI command it installs is `email-sdk`.
+
+## Install or run
+
+Run the CLI once with `bunx`:
 
 ```bash
-email-sdk version
+bunx --yes @opencoredev/email-sdk adapters
 ```
 
+Install the SDK in a project:
+
 ```bash
-email-sdk send \
+bun add @opencoredev/email-sdk
+```
+
+Then run the installed binary:
+
+```bash
+bun email-sdk adapters
+```
+
+The CLI requires Bun on your `PATH`. Check the installed version before comparing behavior against
+the docs:
+
+```bash
+bun email-sdk version
+```
+
+## Send
+
+```bash
+bunx --yes @opencoredev/email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to "user@example.com" \
@@ -24,7 +49,7 @@ email-sdk send \
 ## Adapters
 
 ```bash
-email-sdk adapters
+bunx --yes @opencoredev/email-sdk adapters
 ```
 
 | Adapter      | Required environment                                       |
@@ -51,7 +76,7 @@ If `--adapter` is omitted, the CLI selects the first adapter with all required e
 ## Doctor
 
 ```bash
-email-sdk doctor --adapter resend
+bunx --yes @opencoredev/email-sdk doctor --adapter resend
 ```
 
 `doctor` checks whether the selected adapter has the required environment variables.
@@ -59,10 +84,10 @@ email-sdk doctor --adapter resend
 ## Version
 
 ```bash
-email-sdk version
-email-sdk --version
-email-sdk -v
-email-sdk version --json
+bun email-sdk version
+bun email-sdk --version
+bun email-sdk -v
+bun email-sdk version --json
 ```
 
 `version` reads the installed `@opencoredev/email-sdk` package metadata, so it reports the SDK and CLI version from the package currently on your machine. The docs version picker in the top navigation uses the same package version from this repository.

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -10,6 +10,7 @@ bun add @opencoredev/email-sdk
 ```
 
 The public npm package is `@opencoredev/email-sdk`; the unscoped `email-sdk` package is unrelated.
+The command-line binary it installs is named `email-sdk`.
 
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -51,3 +52,13 @@ SMTP is built in and does not require Nodemailer.
 Adapters map supported `EmailMessage` fields and reject unsupported fields instead of silently
 dropping message data. Attachment `content` is treated as raw content by default; set
 `contentEncoding: "base64"` when passing pre-encoded content.
+
+CLI:
+
+```bash
+# one-off: no install needed
+bunx --yes @opencoredev/email-sdk adapters
+
+# after bun add @opencoredev/email-sdk
+bun email-sdk doctor --adapter resend
+```

--- a/skills/email-sdk/SKILL.md
+++ b/skills/email-sdk/SKILL.md
@@ -28,7 +28,7 @@ Before changing code, inspect the most relevant current sources:
    - the app's existing email, notification, queue, environment, and test patterns.
 3. If local docs are missing or the task depends on version-sensitive behavior, fetch the current published package metadata/docs before implementing:
    - `bun pm view @opencoredev/email-sdk`
-   - `email-sdk version` when the CLI is installed in the target app
+   - `bun email-sdk version` when the CLI is installed in the target app
    - `bunx --yes jsr info email-sdk` only if the project is using JSR
    - the repository docs or package README for the exact version in use.
 


### PR DESCRIPTION
## Summary
- Renamed the package from `email-sdk` to `@opencoredev/email-sdk` and updated the workspace lockfile accordingly.
- Replaced all import examples and adapter references in docs, README files, and the Email SDK skill with the scoped package path.
- Added a dedicated getting-started install page and clarified the split between the npm package name and the installed `email-sdk` CLI binary.
- Updated CLI docs and quickstart guidance to use `bunx --yes @opencoredev/email-sdk` for one-off runs and `bun email-sdk ...` when installed in a project.

## Testing
- Not run (documentation and package metadata updates only).
- Verified the diff updates package names, CLI examples, and adapter import paths consistently across docs and package metadata.