### PR TITLE
Fix Homebrew formula release updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,23 @@ jobs:
 
       - name: Update Homebrew formula checksum
         if: steps.changesets.outputs.published == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           bun run homebrew:update
           if ! git diff --quiet -- Formula/email-sdk.rb; then
+            VERSION="$(bun -e 'const pkg = await Bun.file("packages/email-sdk/package.json").json(); console.log(pkg.version)')"
+            BRANCH="automation/homebrew-formula-${VERSION}"
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git checkout -B "$BRANCH"
             git add Formula/email-sdk.rb
-            git commit -m "Update Homebrew formula"
-            git push
+            git commit -m "Update Homebrew formula for ${VERSION}"
+            git push --force-with-lease origin "$BRANCH"
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "Update Homebrew formula for ${VERSION}" \
+              --body "Updates the Homebrew formula to the published @opencoredev/email-sdk ${VERSION} npm tarball." \
+              || echo "::notice::Pushed Homebrew formula update to ${BRANCH}. Open a pull request into main to apply it."
           fi

--- a/Formula/email-sdk.rb
+++ b/Formula/email-sdk.rb
@@ -1,8 +1,8 @@
 class EmailSdk < Formula
   desc "Lightweight TypeScript SDK and CLI for unified email sending"
   homepage "https://github.com/opencoredev/email-sdk"
-  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.1.0.tgz"
-  sha256 "TODO_UPDATE_AFTER_NPM_PUBLISH"
+  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.3.0.tgz"
+  sha256 "e241c00e56cb63fce480ca296c593a9f2acb95d859f283394f5f18994d979e24"
   license "MIT"
 
   depends_on "bun"

--- a/scripts/update-homebrew-formula.ts
+++ b/scripts/update-homebrew-formula.ts
@@ -26,12 +26,27 @@ formula = formula.replace(/sha256 "[^"]+"/, `sha256 "${sha256}"`);
 await writeFile(formulaPath, formula);
 
 async function resolvePublishedSha(url: string) {
-  const response = await fetch(url);
+  const maxAttempts = 12;
+  const retryDelayMs = 5_000;
 
-  if (!response.ok) {
-    return "TODO_UPDATE_AFTER_NPM_PUBLISH";
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const response = await fetch(url, { cache: "no-store" });
+
+    if (response.ok) {
+      const bytes = Buffer.from(await response.arrayBuffer());
+      return createHash("sha256").update(bytes).digest("hex");
+    }
+
+    if (attempt === maxAttempts) {
+      throw new Error(`Unable to fetch published npm tarball ${url}: ${response.status}`);
+    }
+
+    await delay(retryDelayMs);
   }
 
-  const bytes = Buffer.from(await response.arrayBuffer());
-  return createHash("sha256").update(bytes).digest("hex");
+  throw new Error(`Unable to fetch published npm tarball ${url}`);
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Updates the Homebrew formula to the published @opencoredev/email-sdk 0.3.0 npm tarball and changes the release workflow so future formula updates are pushed to a branch instead of directly to protected main.\n\nChecks run locally:\n- bash -n .github/workflows/release.yml\n- bun run homebrew:update\n- git diff --check