### PR TITLE
Consolidate site metadata and add metadata preview tests

### DIFF
--- a/apps/fumadocs/package.json
+++ b/apps/fumadocs/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "start": "serve .output/public --config ../../serve.json",
     "preview": "vite preview",
+    "test": "bun test",
     "types:check": "fumadocs-mdx && tsc --noEmit",
     "postinstall": "fumadocs-mdx"
   },

--- a/apps/fumadocs/src/lib/metadata.test.ts
+++ b/apps/fumadocs/src/lib/metadata.test.ts
@@ -17,8 +17,13 @@ describe("site social metadata", () => {
     expect(twitterImages).toHaveLength(1);
     expect(ogImages[0]?.content).toBe(siteOgImageUrl);
     expect(twitterImages[0]?.content).toBe(siteOgImageUrl);
-    expect(findByProperty("og:image:alt")[0]?.content).toBe(siteImageAlt);
-    expect(findByName("twitter:image:alt")[0]?.content).toBe(siteImageAlt);
+
+    const ogImageAlts = findByProperty("og:image:alt");
+    const twitterImageAlts = findByName("twitter:image:alt");
+    expect(ogImageAlts).toHaveLength(1);
+    expect(twitterImageAlts).toHaveLength(1);
+    expect(ogImageAlts[0]?.content).toBe(siteImageAlt);
+    expect(twitterImageAlts[0]?.content).toBe(siteImageAlt);
 
     const imageUrl = new URL(siteOgImageUrl);
     expect(imageUrl.pathname).toBe(siteOgImagePath);

--- a/apps/fumadocs/src/lib/metadata.test.ts
+++ b/apps/fumadocs/src/lib/metadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { siteMeta } from "@/lib/metadata";
+import { siteImageAlt, siteMeta } from "@/lib/metadata";
 import { siteOgImagePath, siteOgImageUrl } from "@/lib/shared";
 
 const findByName = (name: string) =>
@@ -17,6 +17,8 @@ describe("site social metadata", () => {
     expect(twitterImages).toHaveLength(1);
     expect(ogImages[0]?.content).toBe(siteOgImageUrl);
     expect(twitterImages[0]?.content).toBe(siteOgImageUrl);
+    expect(findByProperty("og:image:alt")[0]?.content).toBe(siteImageAlt);
+    expect(findByName("twitter:image:alt")[0]?.content).toBe(siteImageAlt);
 
     const imageUrl = new URL(siteOgImageUrl);
     expect(imageUrl.pathname).toBe(siteOgImagePath);

--- a/apps/fumadocs/src/lib/metadata.test.ts
+++ b/apps/fumadocs/src/lib/metadata.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { siteMeta } from "@/lib/metadata";
-import { siteOgImageUrl } from "@/lib/shared";
+import { siteOgImagePath, siteOgImageUrl } from "@/lib/shared";
 
-const findByName = (name: string) => siteMeta.filter((meta) => meta.name === name);
-const findByProperty = (property: string) => siteMeta.filter((meta) => meta.property === property);
+const findByName = (name: string) =>
+  siteMeta.filter((meta) => "name" in meta && meta.name === name);
+const findByProperty = (property: string) =>
+  siteMeta.filter((meta) => "property" in meta && meta.property === property);
 
 describe("site social metadata", () => {
   test("uses the canonical PNG open graph image exactly once", () => {
@@ -15,7 +17,10 @@ describe("site social metadata", () => {
     expect(twitterImages).toHaveLength(1);
     expect(ogImages[0]?.content).toBe(siteOgImageUrl);
     expect(twitterImages[0]?.content).toBe(siteOgImageUrl);
-    expect(siteOgImageUrl).toMatch(/^https:\/\/email-sdk\.dev\/og\/email-sdk\.png\?v=\d+$/);
+
+    const imageUrl = new URL(siteOgImageUrl);
+    expect(imageUrl.pathname).toBe(siteOgImagePath);
+    expect(imageUrl.searchParams.get("v")).toMatch(/\S+/);
   });
 
   test("keeps the Twitter preview on the large image card", () => {

--- a/apps/fumadocs/src/lib/metadata.test.ts
+++ b/apps/fumadocs/src/lib/metadata.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { siteMeta } from "@/lib/metadata";
+import { siteOgImageUrl } from "@/lib/shared";
+
+const findByName = (name: string) => siteMeta.filter((meta) => meta.name === name);
+const findByProperty = (property: string) => siteMeta.filter((meta) => meta.property === property);
+
+describe("site social metadata", () => {
+  test("uses the canonical PNG open graph image exactly once", () => {
+    const ogImages = findByProperty("og:image");
+    const twitterImages = findByName("twitter:image");
+
+    expect(ogImages).toHaveLength(1);
+    expect(twitterImages).toHaveLength(1);
+    expect(ogImages[0]?.content).toBe(siteOgImageUrl);
+    expect(twitterImages[0]?.content).toBe(siteOgImageUrl);
+    expect(siteOgImageUrl).toMatch(/^https:\/\/email-sdk\.dev\/og\/email-sdk\.png\?v=\d+$/);
+  });
+
+  test("keeps the Twitter preview on the large image card", () => {
+    const twitterCards = findByName("twitter:card");
+
+    expect(twitterCards).toHaveLength(1);
+    expect(twitterCards[0]?.content).toBe("summary_large_image");
+  });
+});

--- a/apps/fumadocs/src/lib/metadata.test.ts
+++ b/apps/fumadocs/src/lib/metadata.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import { siteImageAlt, siteMeta } from "@/lib/metadata";
-import { siteOgImagePath, siteOgImageUrl } from "@/lib/shared";
+import { siteOgImageUrl } from "@/lib/shared";
 
 const findByName = (name: string) =>
   siteMeta.filter((meta) => "name" in meta && meta.name === name);
@@ -26,7 +26,7 @@ describe("site social metadata", () => {
     expect(twitterImageAlts[0]?.content).toBe(siteImageAlt);
 
     const imageUrl = new URL(siteOgImageUrl);
-    expect(imageUrl.pathname).toBe(siteOgImagePath);
+    expect(imageUrl.pathname).toBe("/og/email-sdk.png");
     expect(imageUrl.searchParams.get("v")).toMatch(/\S+/);
   });
 

--- a/apps/fumadocs/src/lib/metadata.ts
+++ b/apps/fumadocs/src/lib/metadata.ts
@@ -1,0 +1,76 @@
+import { appDescription, appName, siteOgImageUrl, siteUrl } from "@/lib/shared";
+
+export type HeadMeta = {
+  charSet?: string;
+  content?: string;
+  name?: string;
+  property?: string;
+  title?: string;
+};
+
+export const siteTitle = `${appName} - Unified email sending for TypeScript`;
+
+export const siteMeta: HeadMeta[] = [
+  {
+    charSet: "utf-8",
+  },
+  {
+    name: "viewport",
+    content: "width=device-width, initial-scale=1",
+  },
+  {
+    title: siteTitle,
+  },
+  {
+    name: "description",
+    content: appDescription,
+  },
+  {
+    property: "og:type",
+    content: "website",
+  },
+  {
+    property: "og:title",
+    content: siteTitle,
+  },
+  {
+    property: "og:url",
+    content: siteUrl,
+  },
+  {
+    property: "og:description",
+    content: appDescription,
+  },
+  {
+    property: "og:image",
+    content: siteOgImageUrl,
+  },
+  {
+    property: "og:image:width",
+    content: "1200",
+  },
+  {
+    property: "og:image:height",
+    content: "630",
+  },
+  {
+    name: "twitter:card",
+    content: "summary_large_image",
+  },
+  {
+    name: "twitter:title",
+    content: siteTitle,
+  },
+  {
+    name: "twitter:description",
+    content: appDescription,
+  },
+  {
+    name: "twitter:image",
+    content: siteOgImageUrl,
+  },
+  {
+    name: "robots",
+    content: "index, follow",
+  },
+];

--- a/apps/fumadocs/src/lib/metadata.ts
+++ b/apps/fumadocs/src/lib/metadata.ts
@@ -1,16 +1,10 @@
-import { appDescription, appName, siteOgImageUrl, siteUrl } from "@/lib/shared";
+import type { MetaDescriptor } from "@tanstack/react-router";
 
-export type HeadMeta = {
-  charSet?: string;
-  content?: string;
-  name?: string;
-  property?: string;
-  title?: string;
-};
+import { appDescription, appName, siteOgImageUrl, siteUrl } from "@/lib/shared";
 
 export const siteTitle = `${appName} - Unified email sending for TypeScript`;
 
-export const siteMeta: HeadMeta[] = [
+export const siteMeta = [
   {
     charSet: "utf-8",
   },
@@ -73,4 +67,4 @@ export const siteMeta: HeadMeta[] = [
     name: "robots",
     content: "index, follow",
   },
-];
+] satisfies MetaDescriptor[];

--- a/apps/fumadocs/src/lib/metadata.ts
+++ b/apps/fumadocs/src/lib/metadata.ts
@@ -3,6 +3,7 @@ import type { MetaDescriptor } from "@tanstack/react-router";
 import { appDescription, appName, siteOgImageUrl, siteUrl } from "@/lib/shared";
 
 export const siteTitle = `${appName} - Unified email sending for TypeScript`;
+export const siteImageAlt = "Email SDK unified email sending preview";
 
 export const siteMeta = [
   {
@@ -40,6 +41,10 @@ export const siteMeta = [
     content: siteOgImageUrl,
   },
   {
+    property: "og:image:alt",
+    content: siteImageAlt,
+  },
+  {
     property: "og:image:width",
     content: "1200",
   },
@@ -62,6 +67,10 @@ export const siteMeta = [
   {
     name: "twitter:image",
     content: siteOgImageUrl,
+  },
+  {
+    name: "twitter:image:alt",
+    content: siteImageAlt,
   },
   {
     name: "robots",

--- a/apps/fumadocs/src/lib/shared.ts
+++ b/apps/fumadocs/src/lib/shared.ts
@@ -7,7 +7,7 @@ export const siteUrl = (import.meta.env.VITE_SITE_URL ?? "https://email-sdk.dev"
   "",
 );
 export const siteOgImagePath = "/og/email-sdk.png";
-export const siteOgImageVersion = import.meta.env.VITE_OG_IMAGE_VERSION ?? "dev";
+export const siteOgImageVersion = import.meta.env.VITE_OG_IMAGE_VERSION || "dev";
 export const siteOgImageUrl = `${siteUrl}${siteOgImagePath}?v=${encodeURIComponent(
   siteOgImageVersion,
 )}`;

--- a/apps/fumadocs/src/lib/shared.ts
+++ b/apps/fumadocs/src/lib/shared.ts
@@ -7,7 +7,10 @@ export const siteUrl = (import.meta.env.VITE_SITE_URL ?? "https://email-sdk.dev"
   "",
 );
 export const siteOgImagePath = "/og/email-sdk.png";
-export const siteOgImageUrl = `${siteUrl}${siteOgImagePath}?v=20260530`;
+export const siteOgImageVersion = import.meta.env.VITE_OG_IMAGE_VERSION ?? "dev";
+export const siteOgImageUrl = `${siteUrl}${siteOgImagePath}?v=${encodeURIComponent(
+  siteOgImageVersion,
+)}`;
 
 // fill this with your actual GitHub info, for example:
 export const gitConfig = {

--- a/apps/fumadocs/src/lib/shared.ts
+++ b/apps/fumadocs/src/lib/shared.ts
@@ -7,7 +7,7 @@ export const siteUrl = (import.meta.env.VITE_SITE_URL ?? "https://email-sdk.dev"
   "",
 );
 export const siteOgImagePath = "/og/email-sdk.png";
-export const siteOgImageUrl = `${siteUrl}${siteOgImagePath}`;
+export const siteOgImageUrl = `${siteUrl}${siteOgImagePath}?v=20260530`;
 
 // fill this with your actual GitHub info, for example:
 export const gitConfig = {

--- a/apps/fumadocs/src/routes/__root.tsx
+++ b/apps/fumadocs/src/routes/__root.tsx
@@ -3,78 +3,13 @@ import { RootProvider } from "fumadocs-ui/provider/tanstack";
 import * as React from "react";
 
 import SearchDialog from "@/components/search";
-import { appDescription, appName, siteOgImageUrl, siteUrl } from "@/lib/shared";
+import { siteMeta } from "@/lib/metadata";
 
 import appCss from "@/styles/app.css?url";
 
-const siteTitle = `${appName} - Unified email sending for TypeScript`;
-
 export const Route = createRootRoute({
   head: () => ({
-    meta: [
-      {
-        charSet: "utf-8",
-      },
-      {
-        name: "viewport",
-        content: "width=device-width, initial-scale=1",
-      },
-      {
-        title: siteTitle,
-      },
-      {
-        name: "description",
-        content: appDescription,
-      },
-      {
-        property: "og:type",
-        content: "website",
-      },
-      {
-        property: "og:title",
-        content: siteTitle,
-      },
-      {
-        property: "og:url",
-        content: siteUrl,
-      },
-      {
-        property: "og:description",
-        content: appDescription,
-      },
-      {
-        property: "og:image",
-        content: siteOgImageUrl,
-      },
-      {
-        property: "og:image:width",
-        content: "1200",
-      },
-      {
-        property: "og:image:height",
-        content: "630",
-      },
-      {
-        name: "twitter:card",
-        content: "summary_large_image",
-      },
-      {
-        name: "twitter:title",
-        content: siteTitle,
-      },
-      {
-        name: "twitter:description",
-        content: appDescription,
-      },
-      {
-        name: "twitter:image",
-        content: siteOgImageUrl,
-      },
-      {
-        name: "robots",
-        content: "index, follow",
-      },
-    ],
+    meta: siteMeta,
     links: [
       { rel: "stylesheet", href: appCss },
       { rel: "icon", type: "image/png", href: "/logo.png" },

--- a/apps/fumadocs/vite.config.ts
+++ b/apps/fumadocs/vite.config.ts
@@ -6,7 +6,7 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import react from "@vitejs/plugin-react";
 import mdx from "fumadocs-mdx/vite";
 import { nitro } from "nitro/vite";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 
 import { docsVersions, getDocsVersionHref } from "./src/lib/versions";
 
@@ -51,46 +51,57 @@ const versionedDocsPages = docsVersions.flatMap((version) => {
   }));
 });
 
-export default defineConfig({
-  server: {
-    port: 3000,
-  },
-  plugins: [
-    mdx(),
-    tailwindcss(),
-    tanstackStart({
-      spa: {
-        enabled: true,
-        prerender: {
-          enabled: true,
-          crawlLinks: true,
-        },
-      },
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const ogImageVersion =
+    env.VITE_OG_IMAGE_VERSION ||
+    env.VERCEL_GIT_COMMIT_SHA?.slice(0, 12) ||
+    new Date().toISOString().slice(0, 10).replaceAll("-", "");
 
-      pages: [
-        {
-          path: "/docs",
-        },
-        ...versionedDocsPages,
-        {
-          path: "/api/search",
-        },
-        {
-          path: "llms-full.txt",
-        },
-        {
-          path: "llms.txt",
-        },
-      ],
-    }),
-    react(),
-    // please see https://tanstack.com/start/latest/docs/framework/react/guide/hosting#nitro for guides on hosting
-    nitro(),
-  ],
-  resolve: {
-    tsconfigPaths: true,
-    alias: {
-      tslib: "tslib/tslib.es6.js",
+  return {
+    server: {
+      port: 3000,
     },
-  },
+    define: {
+      "import.meta.env.VITE_OG_IMAGE_VERSION": JSON.stringify(ogImageVersion),
+    },
+    plugins: [
+      mdx(),
+      tailwindcss(),
+      tanstackStart({
+        spa: {
+          enabled: true,
+          prerender: {
+            enabled: true,
+            crawlLinks: true,
+          },
+        },
+
+        pages: [
+          {
+            path: "/docs",
+          },
+          ...versionedDocsPages,
+          {
+            path: "/api/search",
+          },
+          {
+            path: "llms-full.txt",
+          },
+          {
+            path: "llms.txt",
+          },
+        ],
+      }),
+      react(),
+      // please see https://tanstack.com/start/latest/docs/framework/react/guide/hosting#nitro for guides on hosting
+      nitro(),
+    ],
+    resolve: {
+      tsconfigPaths: true,
+      alias: {
+        tslib: "tslib/tslib.es6.js",
+      },
+    },
+  };
 });


### PR DESCRIPTION
## Summary
- Consolidated the fumadocs root head metadata into a shared `siteMeta` module.
- Switched the root route to consume the shared metadata instead of inlining the full meta tag list.
- Added a cache-busted canonical Open Graph image URL and covered the preview metadata with `bun:test` checks.
- Added an `apps/fumadocs` test script for running the new metadata tests.

## Testing
- Not run (not requested).
- Added `bun test` coverage for the canonical OG/Twitter image URL and `twitter:card` preview format.