### PR TITLE
Add versioned docs and community plugin registry

### DIFF
--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/brevo.mdx
@@ -1,0 +1,26 @@
+---
+title: Brevo
+description: Configure the Brevo transactional email adapter.
+icon: brevo
+---
+
+<ProviderBadge adapter="brevo" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { brevo } from "@opencoredev/email-sdk/brevo";
+
+const email = createEmailClient({
+  adapters: [brevo({ apiKey: process.env.BREVO_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                |
+| --------- | -------------- | -------- | ------------------------------------ |
+| `apiKey`  | `string`       | Yes      | Brevo API key.                       |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.brevo.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes. |
+
+See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/field-support.mdx
@@ -1,0 +1,105 @@
+---
+title: SDK field support
+description: See which EmailMessage fields Email SDK maps for each adapter.
+icon: Table
+---
+
+Email SDK keeps one message shape, but email APIs do not all expose the same features. This page documents what each Email SDK adapter maps today. Stable adapters either map a field or reject it with a validation error. They should not silently drop message data.
+
+## How to read this page
+
+- `Yes` means the adapter maps that `EmailMessage` field.
+- `No` means the adapter rejects that field before calling the provider.
+- `Values` means Email SDK sends each tag's value to the provider.
+- `First tag` means only the first tag can be represented by that provider API.
+
+## Best fits
+
+| Need                             | Start with                                         |
+| -------------------------------- | -------------------------------------------------- |
+| Most complete API field mapping  | Postmark, SendGrid, AWS SES, Mailgun, Brevo        |
+| Resend-style DX with attachments | Resend                                             |
+| Cheap or self-managed delivery   | SMTP                                               |
+| Product/event email              | Loops, Plunk                                       |
+| Provider fallback for production | Resend plus SMTP, or one primary API plus Postmark |
+| Attachment-heavy transactional   | Resend, Postmark, SendGrid, Mailgun, MailerSend    |
+
+## API adapters
+
+These adapters cover most transactional email fields. They are the best fit when your app needs CC, BCC, reply-to, custom headers, tags, metadata, or attachments.
+
+| Adapter                 | CC  | BCC | Reply-To | Headers | Metadata | Tags      | Attachments |
+| ----------------------- | --- | --- | -------- | ------- | -------- | --------- | ----------- |
+| Resend                  | Yes | Yes | Yes      | Yes     | No       | Yes       | Yes         |
+| Postmark                | Yes | Yes | Yes      | Yes     | Yes      | First tag | Yes         |
+| SendGrid                | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
+| AWS SES                 | Yes | Yes | Yes      | Yes     | No       | Yes       | Yes         |
+| Mailgun                 | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
+| MailerSend              | Yes | Yes | Yes      | Yes     | No       | Values    | Yes         |
+| Brevo                   | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
+| Mailchimp Transactional | Yes | Yes | No       | Yes     | Yes      | Values    | Yes         |
+| Mailtrap                | Yes | Yes | No       | Yes     | No       | First tag | Yes         |
+
+## Narrow adapters
+
+These adapters are useful, but their public APIs do not match the full `EmailMessage` shape. Email SDK keeps them stable by rejecting fields it cannot represent.
+
+| Adapter   | CC  | BCC | Reply-To | Headers | Metadata | Tags   | Attachments |
+| --------- | --- | --- | -------- | ------- | -------- | ------ | ----------- |
+| SparkPost | No  | No  | Yes      | Yes     | Yes      | Values | Yes         |
+| Loops     | No  | No  | No       | No      | Yes      | No     | No          |
+| Plunk     | No  | No  | No       | No      | Yes      | No     | No          |
+| Scaleway  | Yes | Yes | No       | Yes     | No       | No     | No          |
+| ZeptoMail | Yes | Yes | Yes      | No      | No       | No     | Yes         |
+| MailPace  | Yes | Yes | Yes      | No      | No       | No     | No          |
+
+## SMTP transport
+
+SMTP is built in and does not use Nodemailer. It maps address fields and headers directly to the SMTP message, but it does not map provider-only concepts like tags or metadata.
+
+| Adapter | CC  | BCC | Reply-To | Headers | Metadata | Tags | Attachments |
+| ------- | --- | --- | -------- | ------- | -------- | ---- | ----------- |
+| SMTP    | Yes | Yes | Yes      | Yes     | No       | No   | No          |
+
+## Validation behavior
+
+Unsupported fields fail fast. For example, Resend rejects `metadata`, Mailchimp Transactional rejects `replyTo`, and SMTP rejects attachments. That keeps production behavior boring: if a field matters, you find out before the provider request.
+
+## Attachment rules
+
+Attachment `content` is treated as raw content by default and encoded to Base64 for API adapters that require Base64.
+
+```ts
+attachments: [
+  {
+    filename: "receipt.txt",
+    content: "Thanks for your order.",
+    contentType: "text/plain",
+  },
+];
+```
+
+If you already have Base64 content, mark it:
+
+```ts
+attachments: [
+  {
+    filename: "receipt.pdf",
+    content: base64Pdf,
+    contentEncoding: "base64",
+    contentType: "application/pdf",
+  },
+];
+```
+
+Adapters that support attachments can also read a local path:
+
+```ts
+attachments: [
+  {
+    filename: "receipt.pdf",
+    path: "./receipt.pdf",
+    contentType: "application/pdf",
+  },
+];
+```

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Adapters
+description: Supported email service adapters and transports.
+icon: Cable
+---
+
+Email SDK ships with fifteen adapters. Import only the adapter you use; the package does not ask you
+to configure providers that are not on your send path.
+
+Every adapter follows the same contract: map the fields it supports and throw a validation error for
+fields the provider API cannot represent. Use the [SDK field support guide](/docs/adapters/field-support)
+before choosing fallback routes.
+
+<ProviderGrid />
+
+## Import pattern
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: process.env.SMTP_HOST!,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  fallback: ["smtp"],
+});
+```
+
+## Adapter groups
+
+| Group          | Adapters                                                                        |
+| -------------- | ------------------------------------------------------------------------------- |
+| Popular APIs   | Resend, Postmark, SendGrid, Mailgun, MailerSend, Brevo, Mailchimp Transactional |
+| Infrastructure | SparkPost, Mailtrap, Scaleway, ZeptoMail, MailPace                              |
+| Product-led    | Loops, Plunk                                                                    |
+| Transport      | Built-in SMTP                                                                   |

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/loops.mdx
@@ -1,0 +1,34 @@
+---
+title: Loops
+description: Configure the Loops transactional email adapter.
+icon: loops
+---
+
+<ProviderBadge adapter="loops" />
+
+Loops transactional sends normally use a `transactionalId`.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { loops } from "@opencoredev/email-sdk/loops";
+
+const email = createEmailClient({
+  adapters: [
+    loops({
+      apiKey: process.env.LOOPS_API_KEY!,
+      transactionalId: process.env.LOOPS_TRANSACTIONAL_ID!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option            | Type           | Required | Notes                                |
+| ----------------- | -------------- | -------- | ------------------------------------ |
+| `apiKey`          | `string`       | Yes      | Loops API key.                       |
+| `transactionalId` | `string`       | Usually  | Transactional email ID.              |
+| `baseUrl`         | `string`       | No       | Defaults to `https://app.loops.so`.  |
+| `fetch`           | `typeof fetch` | No       | Useful for tests or custom runtimes. |
+
+Loops transactional sends support one recipient and metadata through `dataVariables`. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/mailchimp.mdx
@@ -1,0 +1,28 @@
+---
+title: Mailchimp Transactional
+description: Configure the Mailchimp Transactional adapter.
+icon: mailchimp
+---
+
+<ProviderBadge adapter="mailchimp" />
+
+Mailchimp Transactional is the API formerly known as Mandrill.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailchimp } from "@opencoredev/email-sdk/mailchimp";
+
+const email = createEmailClient({
+  adapters: [mailchimp({ apiKey: process.env.MAILCHIMP_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                          |
+| --------- | -------------- | -------- | ---------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailchimp Transactional API key.               |
+| `baseUrl` | `string`       | No       | Defaults to `https://mandrillapp.com/api/1.0`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/mailersend.mdx
@@ -1,0 +1,26 @@
+---
+title: MailerSend
+description: Configure the MailerSend Email API adapter.
+icon: mailersend
+---
+
+<ProviderBadge adapter="mailersend" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailersend } from "@opencoredev/email-sdk/mailersend";
+
+const email = createEmailClient({
+  adapters: [mailersend({ apiKey: process.env.MAILERSEND_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                     |
+| --------- | -------------- | -------- | ----------------------------------------- |
+| `apiKey`  | `string`       | Yes      | MailerSend API token.                     |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.mailersend.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.      |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/mailgun.mdx
@@ -1,0 +1,32 @@
+---
+title: Mailgun
+description: Configure the Mailgun Messages API adapter.
+icon: mailgun
+---
+
+<ProviderBadge adapter="mailgun" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailgun } from "@opencoredev/email-sdk/mailgun";
+
+const email = createEmailClient({
+  adapters: [
+    mailgun({
+      apiKey: process.env.MAILGUN_API_KEY!,
+      domain: process.env.MAILGUN_DOMAIN!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                                                                              |
+| --------- | -------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailgun API key.                                                                                   |
+| `domain`  | `string`       | Yes      | Sending domain.                                                                                    |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.mailgun.net`. Use the EU API base URL if your domain is in the EU region. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                                               |
+
+Mailgun sends attachments as multipart form data. See <a href="/docs/adapters/field-support">field support</a> for the full mapping.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/mailpace.mdx
@@ -1,0 +1,26 @@
+---
+title: MailPace
+description: Configure the MailPace send API adapter.
+icon: mailpace
+---
+
+<ProviderBadge adapter="mailpace" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailpace } from "@opencoredev/email-sdk/mailpace";
+
+const email = createEmailClient({
+  adapters: [mailpace({ apiKey: process.env.MAILPACE_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                          |
+| --------- | -------------- | -------- | ---------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | MailPace server token.                         |
+| `baseUrl` | `string`       | No       | Defaults to `https://app.mailpace.com/api/v1`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
+
+MailPace supports CC, BCC, and reply-to. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/mailtrap.mdx
@@ -1,0 +1,26 @@
+---
+title: Mailtrap
+description: Configure the Mailtrap Email Sending API adapter.
+icon: mailtrap
+---
+
+<ProviderBadge adapter="mailtrap" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailtrap } from "@opencoredev/email-sdk/mailtrap";
+
+const email = createEmailClient({
+  adapters: [mailtrap({ apiKey: process.env.MAILTRAP_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                       |
+| --------- | -------------- | -------- | ------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailtrap API token.                         |
+| `baseUrl` | `string`       | No       | Defaults to `https://send.api.mailtrap.io`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.        |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/meta.json
@@ -1,0 +1,23 @@
+{
+  "title": "Adapters",
+  "pages": [
+    "index",
+    "field-support",
+    "resend",
+    "postmark",
+    "sendgrid",
+    "ses",
+    "mailgun",
+    "mailersend",
+    "brevo",
+    "mailchimp",
+    "sparkpost",
+    "loops",
+    "plunk",
+    "mailtrap",
+    "scaleway",
+    "zeptomail",
+    "mailpace",
+    "smtp"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/plunk.mdx
@@ -1,0 +1,26 @@
+---
+title: Plunk
+description: Configure the Plunk send API adapter.
+icon: plunk
+---
+
+<ProviderBadge adapter="plunk" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { plunk } from "@opencoredev/email-sdk/plunk";
+
+const email = createEmailClient({
+  adapters: [plunk({ apiKey: process.env.PLUNK_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                        |
+| --------- | -------------- | -------- | -------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Plunk API key.                               |
+| `baseUrl` | `string`       | No       | Defaults to `https://next-api.useplunk.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.         |
+
+Plunk maps `metadata` to `data`. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/postmark.mdx
@@ -1,0 +1,51 @@
+---
+title: Postmark
+description: Configure the fetch-based Postmark adapter.
+icon: postmark
+---
+
+The Postmark adapter calls the Postmark Email API directly. It does not add a runtime dependency.
+
+<ProviderBadge adapter="postmark" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { postmark } from "@opencoredev/email-sdk/postmark";
+
+const email = createEmailClient({
+  adapters: [
+    postmark({
+      serverToken: process.env.POSTMARK_SERVER_TOKEN!,
+      messageStream: "outbound",
+    }),
+  ],
+});
+```
+
+## Send
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  html: "<p>Thanks for your order.</p>",
+  metadata: {
+    orderId: "ord_123",
+  },
+});
+```
+
+## Options
+
+| Option          | Type                     | Required | Notes                                      |
+| --------------- | ------------------------ | -------- | ------------------------------------------ |
+| `serverToken`   | `string`                 | Yes      | Postmark server token.                     |
+| `baseUrl`       | `string`                 | No       | Defaults to `https://api.postmarkapp.com`. |
+| `messageStream` | `string`                 | No       | Postmark message stream.                   |
+| `fetch`         | `typeof fetch`           | No       | Useful for tests or custom runtimes.       |
+| `headers`       | `Record<string, string>` | No       | Extra request headers.                     |
+
+## Response
+
+The adapter maps Postmark `MessageID` to `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/resend.mdx
@@ -1,0 +1,48 @@
+---
+title: Resend
+description: Configure the fetch-based Resend adapter.
+icon: resend
+---
+
+The Resend adapter calls the Resend Email API directly. It does not add a runtime dependency.
+
+<ProviderBadge adapter="resend" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+await email.send(
+  {
+    from: "Acme <hello@acme.com>",
+    to: "user@example.com",
+    subject: "Welcome",
+    html: "<p>Your workspace is ready.</p>",
+    tags: [{ name: "type", value: "welcome" }],
+  },
+  {
+    idempotencyKey: "welcome:user_123",
+  },
+);
+```
+
+## Options
+
+| Option    | Type                     | Required | Notes                                 |
+| --------- | ------------------------ | -------- | ------------------------------------- |
+| `apiKey`  | `string`                 | Yes      | Resend API key.                       |
+| `baseUrl` | `string`                 | No       | Defaults to `https://api.resend.com`. |
+| `fetch`   | `typeof fetch`           | No       | Useful for tests or custom runtimes.  |
+| `headers` | `Record<string, string>` | No       | Extra request headers.                |
+
+## Response
+
+The adapter returns the Resend `id` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/scaleway.mdx
@@ -1,0 +1,33 @@
+---
+title: Scaleway
+description: Configure the Scaleway Transactional Email adapter.
+icon: scaleway
+---
+
+<ProviderBadge adapter="scaleway" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { scaleway } from "@opencoredev/email-sdk/scaleway";
+
+const email = createEmailClient({
+  adapters: [
+    scaleway({
+      secretKey: process.env.SCALEWAY_SECRET_KEY!,
+      projectId: process.env.SCALEWAY_PROJECT_ID!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option      | Type           | Required | Notes                                   |
+| ----------- | -------------- | -------- | --------------------------------------- |
+| `secretKey` | `string`       | Yes      | Scaleway secret key.                    |
+| `projectId` | `string`       | Yes      | Scaleway project ID.                    |
+| `region`    | `string`       | No       | Defaults to `fr-par`.                   |
+| `baseUrl`   | `string`       | No       | Defaults to `https://api.scaleway.com`. |
+| `fetch`     | `typeof fetch` | No       | Useful for tests or custom runtimes.    |
+
+Scaleway supports a narrower message shape than full API-first providers. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/sendgrid.mdx
@@ -1,0 +1,32 @@
+---
+title: SendGrid
+description: Configure the Twilio SendGrid Mail Send API adapter.
+icon: sendgrid
+---
+
+<ProviderBadge adapter="sendgrid" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sendgrid } from "@opencoredev/email-sdk/sendgrid";
+
+const email = createEmailClient({
+  adapters: [sendgrid({ apiKey: process.env.SENDGRID_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                   |
+| --------- | -------------- | -------- | --------------------------------------- |
+| `apiKey`  | `string`       | Yes      | SendGrid API key.                       |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.sendgrid.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.    |
+
+See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.
+
+## CLI
+
+```bash
+email-sdk send --adapter sendgrid --from hello@example.com --to user@example.com --subject "Hello" --text "It works"
+```

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/ses.mdx
@@ -1,0 +1,67 @@
+---
+title: AWS SES
+description: Configure the AWS SES v2 SendEmail adapter.
+icon: Cloud
+---
+
+The AWS SES adapter calls the SES v2 SendEmail API directly with SigV4-signed fetch requests. It does not add a runtime dependency on the AWS SDK.
+
+<ProviderBadge adapter="ses" />
+
+```ts
+import { createEmailClient } from "email-sdk";
+import { ses } from "email-sdk/ses";
+
+const email = createEmailClient({
+  adapters: [
+    ses({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+      region: process.env.AWS_REGION!,
+    }),
+  ],
+});
+```
+
+## Send
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
+  tags: [{ name: "type", value: "welcome" }],
+});
+```
+
+## Options
+
+| Option                 | Type           | Required | Notes                                                 |
+| ---------------------- | -------------- | -------- | ----------------------------------------------------- |
+| `accessKeyId`          | `string`       | Yes      | AWS access key ID.                                    |
+| `secretAccessKey`      | `string`       | Yes      | AWS secret access key.                                |
+| `region`               | `string`       | Yes      | SES region, for example `us-east-1`.                  |
+| `sessionToken`         | `string`       | No       | Required for temporary credentials.                   |
+| `baseUrl`              | `string`       | No       | Defaults to `https://email.{region}.amazonaws.com`.   |
+| `fetch`                | `typeof fetch` | No       | Useful for tests or custom runtimes.                  |
+| `charset`              | `string`       | No       | Defaults to `UTF-8`.                                  |
+| `configurationSetName` | `string`       | No       | SES configuration set for sends through this adapter. |
+
+## CLI
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_REGION=us-east-1 \
+email-sdk send --adapter ses \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Welcome" \
+  --html "<p>Your workspace is ready.</p>"
+```
+
+## Response
+
+The adapter returns the SES `MessageId` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/smtp.mdx
@@ -1,0 +1,75 @@
+---
+title: SMTP
+description: Configure generic SMTP for PurelyMail or a custom server.
+icon: smtp
+---
+
+The SMTP adapter is built in. It uses Node/Bun TCP and TLS sockets directly, so it does not need Nodemailer.
+
+When `auth` is configured with `secure: false`, the adapter sends `STARTTLS` before authenticating. Set `allowInsecureAuth: true` only for a trusted local server that does not support TLS.
+
+## Configure
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option              | Type                             | Required | Notes                                     |
+| ------------------- | -------------------------------- | -------- | ----------------------------------------- |
+| `host`              | `string`                         | Yes      | SMTP host.                                |
+| `port`              | `number`                         | No       | Common values are `587`, `465`, and `25`. |
+| `secure`            | `boolean`                        | No       | Use TLS from the start of the connection. |
+| `auth`              | `{ user: string; pass: string }` | No       | SMTP credentials.                         |
+| `defaults`          | `{ replyTo?: string }`           | No       | Default reply-to header.                  |
+| `tls`               | `Record<string, unknown>`        | No       | TLS options.                              |
+| `requireTLS`        | `boolean`                        | No       | Require STARTTLS.                         |
+| `allowInsecureAuth` | `boolean`                        | No       | Opt in to SMTP AUTH without TLS.          |
+| `name`              | `string`                         | No       | Defaults to `smtp`.                       |
+| `heloName`          | `string`                         | No       | EHLO name sent to the server.             |
+| `timeoutMs`         | `number`                         | No       | Socket timeout.                           |
+
+## Multiple SMTP routes
+
+Rename adapters when you have multiple SMTP routes.
+
+```ts
+const email = createEmailClient({
+  adapters: [
+    smtp({ name: "purelymail", host: "smtp.purelymail.com" }),
+    smtp({ name: "backup-smtp", host: "smtp.backup.example" }),
+  ],
+  defaultProvider: "purelymail",
+  fallback: ["backup-smtp"],
+});
+```
+
+## CLI
+
+```bash
+email-sdk send \
+  --adapter smtp \
+  --host smtp.purelymail.com \
+  --user hello@example.com \
+  --pass "$SMTP_PASS" \
+  --from "Acme <hello@example.com>" \
+  --to user@example.com \
+  --subject "SMTP test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/sparkpost.mdx
@@ -1,0 +1,27 @@
+---
+title: SparkPost
+description: Configure the SparkPost Transmissions API adapter.
+icon: sparkpost
+---
+
+<ProviderBadge adapter="sparkpost" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sparkpost } from "@opencoredev/email-sdk/sparkpost";
+
+const email = createEmailClient({
+  adapters: [sparkpost({ apiKey: process.env.SPARKPOST_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                           |
+| --------- | -------------- | -------- | ----------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | SparkPost API key.                              |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.sparkpost.com/api/v1`. |
+| `sandbox` | `boolean`      | No       | Enables SparkPost sandbox mode.                 |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.            |
+
+SparkPost does not expose normalized CC/BCC in this adapter. See <a href="/docs/adapters/field-support">field support</a>.

--- a/apps/fumadocs/content/docs-v/0.2.0/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/adapters/zeptomail.mdx
@@ -1,0 +1,26 @@
+---
+title: ZeptoMail
+description: Configure the Zoho ZeptoMail adapter.
+icon: zeptomail
+---
+
+<ProviderBadge adapter="zeptomail" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { zeptomail } from "@opencoredev/email-sdk/zeptomail";
+
+const email = createEmailClient({
+  adapters: [zeptomail({ token: process.env.ZEPTOMAIL_TOKEN! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                                                         |
+| --------- | -------------- | -------- | ----------------------------------------------------------------------------- |
+| `token`   | `string`       | Yes      | ZeptoMail API token. The adapter adds the `Zoho-enczapikey` prefix if needed. |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.zeptomail.com`.                                      |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                          |
+
+ZeptoMail supports recipients, reply-to, and attachments. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.0/agents/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.0/agents/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Agents",
+  "pages": ["skill"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.0/agents/skill.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/agents/skill.mdx
@@ -1,0 +1,41 @@
+---
+title: Agent skill
+description: Use the repo-local Email SDK skill when agents add or review email integrations.
+icon: Bot
+---
+
+This repo includes an agent skill at:
+
+```txt
+skills/email-sdk/SKILL.md
+```
+
+Install it with the skills.sh CLI:
+
+```bash
+npx skills add opencoredev/email-sdk --skill email-sdk
+```
+
+Use it when an agent wires Email SDK into an app, reviews adapter setup, or updates these docs.
+
+## What it tells agents
+
+- Use `bun` and `bunx`.
+- Refresh the current README, package exports, Fumadocs pages, and TypeScript declarations before implementing.
+- Keep adapter credentials in environment variables.
+- Import adapters from their own entry points.
+- Do not add Nodemailer for SMTP; Email SDK includes its own SMTP transport.
+- Use fallbacks only when the backup adapter can send the same class of email.
+- Add idempotency keys for externally visible transactional sends.
+- Run a narrow validation before calling the work done.
+
+## Prompt example
+
+```txt
+Use the repo-local Email SDK skill at skills/email-sdk/SKILL.md.
+Wire Resend as the primary adapter and SMTP as fallback.
+Keep secrets in environment variables.
+Add one narrow test around the send path.
+```
+
+The skill is dynamic on purpose. It teaches agents where to fetch the current docs and source first, so the skill does not need a manual update every time the SDK gains another adapter or option.

--- a/apps/fumadocs/content/docs-v/0.2.0/concepts/adapter-model.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/concepts/adapter-model.mdx
@@ -1,0 +1,71 @@
+---
+title: Adapter model
+description: How Email SDK adapters, routing names, and escape hatches work.
+icon: Plug
+---
+
+An adapter is an Email SDK module that knows how to send through one service or transport.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { postmark } from "@opencoredev/email-sdk/postmark";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    postmark({ serverToken: process.env.POSTMARK_SERVER_TOKEN! }),
+  ],
+});
+```
+
+## Routing names
+
+Each adapter registers a routing name. Email SDK uses that name for defaults, fallbacks, and per-send overrides.
+
+| Adapter                 | Routing name |
+| ----------------------- | ------------ |
+| Resend                  | `resend`     |
+| SMTP                    | `smtp`       |
+| Postmark                | `postmark`   |
+| SendGrid                | `sendgrid`   |
+| AWS SES                 | `ses`        |
+| Mailgun                 | `mailgun`    |
+| MailerSend              | `mailersend` |
+| Brevo                   | `brevo`      |
+| Mailchimp Transactional | `mailchimp`  |
+| SparkPost               | `sparkpost`  |
+| Loops                   | `loops`      |
+| Plunk                   | `plunk`      |
+| Mailtrap                | `mailtrap`   |
+| Scaleway                | `scaleway`   |
+| ZeptoMail               | `zeptomail`  |
+| MailPace                | `mailpace`   |
+
+## Send with one adapter
+
+```ts
+await email.send(message, {
+  adapter: "postmark",
+});
+```
+
+## Bind one adapter
+
+```ts
+const transactional = email.withAdapter("postmark");
+
+await transactional.send(message);
+```
+
+## Use adapter escape hatches
+
+Every adapter can expose `raw`. Keep provider-specific code close to the adapter and keep normal application code on the shared `send` path.
+
+```ts
+const adapter = email.adapter("resend");
+
+console.log(adapter.raw);
+```
+
+The older `provider`, `defaultProvider`, `email.provider()`, and `email.withProvider()` names still work as aliases.

--- a/apps/fumadocs/content/docs-v/0.2.0/concepts/fallbacks-and-retries.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/concepts/fallbacks-and-retries.mdx
@@ -1,0 +1,66 @@
+---
+title: Fallbacks and retries
+description: Retry transient failures and use a backup adapter.
+icon: Repeat2
+---
+
+Retries happen inside one adapter. Fallbacks happen after an adapter fails.
+
+```ts
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  retry: {
+    retries: 1,
+  },
+  fallback: ["smtp"],
+});
+```
+
+In this setup, Email SDK tries Resend first. If Resend fails with a retryable error, it retries once. If it still fails, it tries SMTP.
+
+## Override fallback for one send
+
+```ts
+await email.send(message, {
+  provider: "resend",
+  fallbackAdapters: ["smtp"],
+});
+```
+
+## Override retries for one send
+
+```ts
+await email.send(message, {
+  retries: 2,
+});
+```
+
+## Retryable HTTP responses
+
+The fetch-based adapters mark these responses as retryable:
+
+| Status | Meaning                         |
+| ------ | ------------------------------- |
+| `408`  | Request timeout                 |
+| `409`  | Conflict                        |
+| `425`  | Too early                       |
+| `429`  | Rate limited                    |
+| `5xx`  | Adapter or network-side failure |
+
+Use an idempotency key for email that may be retried.
+
+```ts
+await email.send(message, {
+  idempotencyKey: "receipt:order_123",
+});
+```

--- a/apps/fumadocs/content/docs-v/0.2.0/concepts/hooks.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/concepts/hooks.mdx
@@ -1,0 +1,44 @@
+---
+title: Hooks
+description: Observe sends without changing adapter code.
+icon: Activity
+---
+
+Hooks are for logs, metrics, tracing, and retry visibility.
+
+```ts
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  hooks: {
+    beforeSend(event) {
+      console.log("email.send", event.provider, event.message.subject);
+    },
+    afterSend(event) {
+      console.log("email.sent", event.response.id);
+    },
+    onRetry(event) {
+      console.warn("email.retry", event.provider, event.nextAttempt);
+    },
+    onError(event) {
+      console.error("email.error", event.provider, event.error);
+    },
+  },
+});
+```
+
+## Hook events
+
+Each hook receives:
+
+| Field      | Notes                               |
+| ---------- | ----------------------------------- |
+| `provider` | Routing name used for this attempt. |
+| `message`  | The original `EmailMessage`.        |
+| `attempt`  | Current attempt number.             |
+| `metadata` | Optional metadata passed to `send`. |
+
+`afterSend` also receives `response`. `onRetry` receives `nextAttempt` and `delayMs`. `onError` receives `error`.
+
+## Keep logs safe
+
+Do not log API keys, SMTP passwords, raw tokens, full message bodies, or unnecessary recipient data. For most production logs, routing name, status, subject category, template name, and message ID are enough.

--- a/apps/fumadocs/content/docs-v/0.2.0/concepts/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.0/concepts/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Concepts",
+  "pages": ["adapter-model", "fallbacks-and-retries", "hooks"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.0/getting-started/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.0/getting-started/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Getting started",
+  "pages": ["quickstart"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.0/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/getting-started/quickstart.mdx
@@ -1,0 +1,106 @@
+---
+title: Quickstart
+description: Install Email SDK, create a client, and send a first transactional email.
+icon: Rocket
+---
+
+Install the SDK:
+
+```bash
+bun add @opencoredev/email-sdk
+```
+
+This example sends through Resend. Set `RESEND_API_KEY` in the environment before running it.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome to Acme",
+  text: "Your account is ready.",
+});
+```
+
+## Add built-in SMTP fallback
+
+Add SMTP when you want a second route for the same transactional email. The SMTP adapter is built in
+and does not require Nodemailer. When SMTP auth is configured on a non-secure connection, Email SDK
+upgrades with STARTTLS before authenticating.
+
+Only use fallback adapters that can send the same message shape. For example, SMTP supports address
+fields and headers, but not provider-only fields like tags, metadata, or attachments.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+export const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  fallback: ["smtp"],
+});
+```
+
+Your application still sends the same way:
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  text: "Thanks for your order.",
+});
+```
+
+## Check the result
+
+`send` resolves with the normalized adapter response. The `provider` value tells you which adapter
+actually handled the send.
+
+```ts
+const result = await email.send(message);
+
+console.log(result.provider);
+console.log(result.id);
+```
+
+If the adapter returns a message ID, Email SDK exposes it as both `id` and `messageId`. Provider
+responses are still available through `raw` when an adapter includes them.
+
+## Test from the CLI
+
+Use the CLI to check adapter credentials from your terminal.
+
+```bash
+email-sdk doctor --adapter resend
+```
+
+Send a test email:
+
+```bash
+email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works"
+```
+
+Use `--dry-run` when you want to validate the message and selected adapter without sending email.

--- a/apps/fumadocs/content/docs-v/0.2.0/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/index.mdx
@@ -1,0 +1,77 @@
+---
+title: Email SDK
+description: A small TypeScript email client with swappable adapters and explicit provider limits.
+icon: Mail
+---
+
+Email SDK is a small TypeScript package for transactional email. It gives your application one
+client and one message shape while keeping provider-specific behavior visible in the adapter docs.
+
+Use Resend for a simple API path, SMTP when you want a cheap or self-managed route, or another
+provider when its field support fits your app better. Your application code still calls `send`;
+the adapter decides how that message maps to the provider.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+```
+
+## Start here
+
+<Cards>
+  <Card
+    title="Send your first email"
+    href="/docs/getting-started/quickstart"
+    description="Install the SDK, create a client, and send a message."
+  />
+  <Card
+    title="Understand adapters"
+    href="/docs/concepts/adapter-model"
+    description="Learn how adapters and routing names work."
+  />
+  <Card
+    title="Browse adapters"
+    href="/docs/adapters"
+    description="See all supported email services."
+  />
+  <Card
+    title="Read the API reference"
+    href="/docs/reference/client"
+    description="Look up client options, messages, errors, and the CLI."
+  />
+</Cards>
+
+## What is included
+
+- `createEmailClient` for one shared email client.
+- `email.send()` for one message.
+- `email.sendBatch()` for small batches where each result is reported separately.
+- Fifteen adapters, including Resend, SMTP, Postmark, SendGrid, Mailgun, and MailerSend.
+- Retry and fallback options that run in the order you configure.
+- Hooks for logs, metrics, tracing, and retry visibility.
+- A small CLI for setup checks, dry runs, and smoke-test sends.
+- A repo-local agent skill for future coding agents.
+
+## What stays small
+
+Email SDK does not try to be a template engine, campaign tool, queue, analytics platform, or full
+email operations suite. It is the layer many apps keep rebuilding: adapter setup, a consistent send
+call, typed errors, and a fallback path that is explicit enough to debug.
+
+## Provider behavior is not hidden
+
+Email providers do not all support the same fields. A fallback route is only safe when the backup
+adapter can represent the same class of message. Before choosing routes, read the
+[field support guide](/docs/adapters/field-support); unsupported fields should fail fast instead of
+being silently dropped.

--- a/apps/fumadocs/content/docs-v/0.2.0/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.0/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Email SDK",
+  "pages": ["index", "getting-started", "concepts", "adapters", "reference", "agents"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.0/reference/adapter-contract.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/reference/adapter-contract.mdx
@@ -1,0 +1,64 @@
+---
+title: Adapter contract
+description: Reference for writing a custom Email SDK adapter.
+icon: Plug
+---
+
+Custom adapters are plain objects.
+
+```ts
+import type { EmailProvider } from "@opencoredev/email-sdk";
+
+export const customAdapter: EmailProvider = {
+  name: "custom",
+  async send(message, context) {
+    const response = await fetch("https://api.example.com/email", {
+      method: "POST",
+      signal: context.signal,
+      body: JSON.stringify(message),
+    });
+
+    const body = await response.json();
+
+    return {
+      provider: "custom",
+      id: body.id,
+      raw: body,
+    };
+  },
+};
+```
+
+## `EmailProvider`
+
+```ts
+type EmailProvider<TRaw = unknown> = {
+  name: string;
+  send(message: EmailMessage, context: EmailProviderContext): MaybePromise<EmailProviderResponse>;
+  raw?: TRaw;
+};
+```
+
+## `EmailProviderContext`
+
+| Field            | Type                      | Notes                                          |
+| ---------------- | ------------------------- | ---------------------------------------------- |
+| `signal`         | `AbortSignal`             | Optional abort signal.                         |
+| `idempotencyKey` | `string`                  | Optional key from the message or send options. |
+| `attempt`        | `number`                  | Attempt number for this adapter.               |
+| `metadata`       | `Record<string, unknown>` | Metadata passed to `send`.                     |
+
+## Adapter responses
+
+```ts
+type EmailProviderResponse = {
+  id?: string;
+  provider: string;
+  messageId?: string;
+  accepted?: string[];
+  rejected?: string[];
+  raw?: unknown;
+};
+```
+
+Return the provider's raw response in `raw` when it helps callers debug or inspect provider-specific fields.

--- a/apps/fumadocs/content/docs-v/0.2.0/reference/cli.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/reference/cli.mdx
@@ -1,0 +1,94 @@
+---
+title: CLI
+description: Reference for the email-sdk command-line smoke test.
+icon: Terminal
+---
+
+The CLI is intentionally small. Use it to inspect adapters, check environment variables, validate a message with `--dry-run`, and send a smoke-test email from your terminal.
+
+```bash
+email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works"
+```
+
+## Adapters
+
+```bash
+email-sdk adapters
+```
+
+| Adapter      | Required environment                                       |
+| ------------ | ---------------------------------------------------------- |
+| `resend`     | `RESEND_API_KEY`                                           |
+| `postmark`   | `POSTMARK_SERVER_TOKEN`                                    |
+| `sendgrid`   | `SENDGRID_API_KEY`                                         |
+| `ses`        | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| `mailgun`    | `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`                        |
+| `mailersend` | `MAILERSEND_API_KEY`                                       |
+| `brevo`      | `BREVO_API_KEY`                                            |
+| `mailchimp`  | `MAILCHIMP_API_KEY`                                        |
+| `sparkpost`  | `SPARKPOST_API_KEY`                                        |
+| `loops`      | `LOOPS_API_KEY`, `LOOPS_TRANSACTIONAL_ID`                  |
+| `plunk`      | `PLUNK_API_KEY`                                            |
+| `mailtrap`   | `MAILTRAP_API_KEY`                                         |
+| `scaleway`   | `SCALEWAY_SECRET_KEY`, `SCALEWAY_PROJECT_ID`               |
+| `zeptomail`  | `ZEPTOMAIL_TOKEN`                                          |
+| `mailpace`   | `MAILPACE_API_KEY`                                         |
+| `smtp`       | `SMTP_HOST`, plus SMTP auth variables when needed          |
+
+If `--adapter` is omitted, the CLI selects the first adapter with all required environment variables set.
+
+## Doctor
+
+```bash
+email-sdk doctor --adapter resend
+```
+
+`doctor` checks whether the selected adapter has the required environment variables.
+
+## Flags
+
+| Flag                    | Adapter   | Notes                                                  |
+| ----------------------- | --------- | ------------------------------------------------------ |
+| `--adapter`             | all       | Adapter routing name.                                  |
+| `--provider`            | all       | Alias for `--adapter`.                                 |
+| `--from`                | all       | Sender address.                                        |
+| `--to`                  | all       | Recipient address. Comma-separated values are allowed. |
+| `--subject`             | all       | Message subject.                                       |
+| `--text`                | all       | Plain text body.                                       |
+| `--html`                | all       | HTML body.                                             |
+| `--cc`                  | send      | Comma-separated CC addresses.                          |
+| `--bcc`                 | send      | Comma-separated BCC addresses.                         |
+| `--reply-to`            | send      | Comma-separated reply-to addresses.                    |
+| `--header`              | send      | Header in `Name: value` format. Repeatable.            |
+| `--tag`                 | send      | Tag in `name=value` format. Repeatable.                |
+| `--metadata`            | send      | Metadata in `key=value` format. Repeatable.            |
+| `--attachment`          | send      | Local file path, optionally `path:content/type`.       |
+| `--message`             | send      | Read an `EmailMessage` JSON payload from a file.       |
+| `--dry-run`             | all       | Validate and print the send plan without sending.      |
+| `--api-key`             | many      | Overrides the adapter API key variable.                |
+| `--server-token`        | Postmark  | Overrides `POSTMARK_SERVER_TOKEN`.                     |
+| `--message-stream`      | Postmark  | Optional message stream.                               |
+| `--access-key-id`       | AWS SES   | Overrides `AWS_ACCESS_KEY_ID`.                         |
+| `--secret-access-key`   | AWS SES   | Overrides `AWS_SECRET_ACCESS_KEY`.                     |
+| `--region`              | AWS SES   | Overrides `AWS_REGION`.                                |
+| `--session-token`       | AWS SES   | Overrides `AWS_SESSION_TOKEN`.                         |
+| `--configuration-set`   | AWS SES   | Overrides `AWS_SES_CONFIGURATION_SET`.                 |
+| `--domain`              | Mailgun   | Overrides `MAILGUN_DOMAIN`.                            |
+| `--transactional-id`    | Loops     | Overrides `LOOPS_TRANSACTIONAL_ID`.                    |
+| `--project-id`          | Scaleway  | Overrides `SCALEWAY_PROJECT_ID`.                       |
+| `--secret-key`          | Scaleway  | Overrides `SCALEWAY_SECRET_KEY`.                       |
+| `--token`               | ZeptoMail | Overrides `ZEPTOMAIL_TOKEN`.                           |
+| `--host`                | SMTP      | Overrides `SMTP_HOST`.                                 |
+| `--port`                | SMTP      | Overrides `SMTP_PORT`.                                 |
+| `--secure`              | SMTP      | Set to `true` for secure SMTP.                         |
+| `--require-tls`         | SMTP      | Require STARTTLS.                                      |
+| `--allow-insecure-auth` | SMTP      | Allow SMTP AUTH without TLS.                           |
+| `--user`                | SMTP      | Overrides `SMTP_USER`.                                 |
+| `--pass`                | SMTP      | Overrides `SMTP_PASS`.                                 |
+
+The CLI prints the normalized adapter response as JSON.

--- a/apps/fumadocs/content/docs-v/0.2.0/reference/client.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/reference/client.mdx
@@ -1,0 +1,90 @@
+---
+title: Client
+description: Reference for createEmailClient, send, sendBatch, and adapter helpers.
+icon: Braces
+---
+
+## `createEmailClient(options)`
+
+Creates an email client.
+
+```ts
+const email = createEmailClient({
+  adapters,
+  defaultAdapter,
+  fallback,
+  retry,
+  hooks,
+});
+```
+
+| Option            | Type               | Default              |
+| ----------------- | ------------------ | -------------------- |
+| `adapters`        | `EmailProvider[]`  | Required             |
+| `providers`       | `EmailProvider[]`  | Alias for `adapters` |
+| `defaultAdapter`  | `string`           | First adapter        |
+| `defaultProvider` | `string`           | First adapter        |
+| `fallback`        | `string[]`         | `[]`                 |
+| `retry`           | `EmailRetryConfig` | No retries           |
+| `hooks`           | `EmailHooks`       | No hooks             |
+
+Routing names must be unique.
+
+## `email.send(message, options?)`
+
+Sends one message.
+
+```ts
+const result = await email.send(message, {
+  adapter: "resend",
+  fallbackAdapters: ["smtp"],
+  retries: 2,
+  idempotencyKey: "receipt:order_123",
+  metadata: {
+    route: "checkout.receipt",
+  },
+});
+```
+
+| Option              | Type                      | Notes                                     |
+| ------------------- | ------------------------- | ----------------------------------------- |
+| `adapter`           | `string`                  | Override the default routing name.        |
+| `provider`          | `string`                  | Alias for `adapter`.                      |
+| `fallbackAdapters`  | `string[]`                | Override fallback adapters for this send. |
+| `fallbackProviders` | `string[]`                | Alias for `fallbackAdapters`.             |
+| `retries`           | `number`                  | Override retry count for this send.       |
+| `signal`            | `AbortSignal`             | Abort provider work when supported.       |
+| `idempotencyKey`    | `string`                  | Passed to adapters that support it.       |
+| `metadata`          | `Record<string, unknown>` | Passed to hooks.                          |
+
+## `email.sendBatch(messages, options?)`
+
+Sends messages one at a time and returns one result per item.
+
+```ts
+const results = await email.sendBatch([messageA, messageB]);
+```
+
+`sendBatch` does not throw for the first failed item. Failed sends are returned as `{ ok: false, index, error }`.
+
+## `email.adapter(name)`
+
+Returns a registered adapter or throws `EmailProviderNotFoundError`.
+
+```ts
+const resendAdapter = email.adapter("resend");
+```
+
+`email.provider(name)` is kept as an alias.
+
+## `email.withAdapter(name)`
+
+Returns a small client bound to one adapter.
+
+```ts
+const transactional = email.withAdapter("postmark");
+
+await transactional.send(message);
+```
+
+`email.withProvider(name)` is kept as an alias.

--- a/apps/fumadocs/content/docs-v/0.2.0/reference/errors.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/reference/errors.mdx
@@ -1,0 +1,51 @@
+---
+title: Errors
+description: Reference for Email SDK error classes and retry flags.
+icon: TriangleAlert
+---
+
+Email SDK exports four error classes.
+
+```ts
+import {
+  EmailProviderError,
+  EmailProviderNotFoundError,
+  EmailSdkError,
+  EmailValidationError,
+} from "@opencoredev/email-sdk";
+```
+
+## Error fields
+
+`EmailSdkError` includes:
+
+| Field       | Type      | Notes                                   |
+| ----------- | --------- | --------------------------------------- |
+| `code`      | `string`  | Machine-readable error code.            |
+| `provider`  | `string`  | Routing name when available.            |
+| `status`    | `number`  | HTTP status when available.             |
+| `retryable` | `boolean` | Whether retry is reasonable.            |
+| `details`   | `unknown` | Adapter response body or extra context. |
+
+## Common errors
+
+| Error                        | When it happens                         |
+| ---------------------------- | --------------------------------------- |
+| `EmailValidationError`       | A message or client config is invalid.  |
+| `EmailProviderNotFoundError` | The selected adapter is not registered. |
+| `EmailProviderError`         | An adapter call fails.                  |
+| `EmailSdkError`              | A general SDK-level failure occurs.     |
+
+## Handling adapter errors
+
+```ts
+try {
+  await email.send(message);
+} catch (error) {
+  if (error instanceof EmailProviderError && error.retryable) {
+    // Queue a later retry, alert, or switch to another flow.
+  }
+
+  throw error;
+}
+```

--- a/apps/fumadocs/content/docs-v/0.2.0/reference/message.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.0/reference/message.mdx
@@ -1,0 +1,75 @@
+---
+title: Message
+description: Reference for EmailMessage, addresses, attachments, headers, and tags.
+icon: Mail
+---
+
+## `EmailMessage`
+
+```ts
+type EmailMessage = {
+  from: EmailAddress;
+  to: EmailAddress | EmailAddress[];
+  subject: string;
+  html?: string;
+  text?: string;
+  cc?: EmailAddress | EmailAddress[];
+  bcc?: EmailAddress | EmailAddress[];
+  replyTo?: EmailAddress | EmailAddress[];
+  headers?: Record<string, string> | EmailHeader[];
+  attachments?: EmailAttachment[];
+  tags?: EmailTag[];
+  metadata?: Record<string, string | number | boolean | null>;
+  idempotencyKey?: string;
+};
+```
+
+Every message must include:
+
+- `from`
+- at least one `to`
+- `subject`
+- `html` or `text`
+
+## Addresses
+
+An address can be a string or an object with a display name.
+
+```ts
+const from = "Acme <hello@acme.com>";
+
+const to = {
+  email: "user@example.com",
+  name: "Ada Lovelace",
+};
+```
+
+## Attachments
+
+```ts
+type EmailAttachment = {
+  filename: string;
+  content?: string | Uint8Array | ArrayBuffer | Blob;
+  contentEncoding?: "raw" | "base64";
+  path?: string;
+  contentType?: string;
+  contentId?: string;
+  disposition?: "attachment" | "inline";
+};
+```
+
+Use `content` for in-memory attachments. String content is treated as raw content and encoded to Base64 for API providers that require it. Use `contentEncoding: "base64"` when the string is already Base64.
+
+Use `path` when you want Email SDK to read a local file before sending. See <a href="/docs/adapters/field-support">field support</a> for adapter-specific attachment support.
+
+## Headers and tags
+
+Headers can be an object or a list:
+
+```ts
+headers: {
+  "X-Order-ID": "ord_123";
+}
+```
+
+Tags are provider-specific. Resend accepts `tags`. Postmark maps the first tag to its `Tag` field.

--- a/apps/fumadocs/content/docs-v/0.2.0/reference/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.0/reference/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Reference",
+  "pages": ["client", "message", "adapter-contract", "errors", "cli"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/brevo.mdx
@@ -1,0 +1,26 @@
+---
+title: Brevo
+description: Configure the Brevo transactional email adapter.
+icon: brevo
+---
+
+<ProviderBadge adapter="brevo" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { brevo } from "@opencoredev/email-sdk/brevo";
+
+const email = createEmailClient({
+  adapters: [brevo({ apiKey: process.env.BREVO_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                |
+| --------- | -------------- | -------- | ------------------------------------ |
+| `apiKey`  | `string`       | Yes      | Brevo API key.                       |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.brevo.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes. |
+
+See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/field-support.mdx
@@ -1,0 +1,105 @@
+---
+title: SDK field support
+description: See which EmailMessage fields Email SDK maps for each adapter.
+icon: Table
+---
+
+Email SDK keeps one message shape, but email APIs do not all expose the same features. This page documents what each Email SDK adapter maps today. Stable adapters either map a field or reject it with a validation error. They should not silently drop message data.
+
+## How to read this page
+
+- `Yes` means the adapter maps that `EmailMessage` field.
+- `No` means the adapter rejects that field before calling the provider.
+- `Values` means Email SDK sends each tag's value to the provider.
+- `First tag` means only the first tag can be represented by that provider API.
+
+## Best fits
+
+| Need                             | Start with                                         |
+| -------------------------------- | -------------------------------------------------- |
+| Most complete API field mapping  | Postmark, SendGrid, AWS SES, Mailgun, Brevo        |
+| Resend-style DX with attachments | Resend                                             |
+| Cheap or self-managed delivery   | SMTP                                               |
+| Product/event email              | Loops, Plunk                                       |
+| Provider fallback for production | Resend plus SMTP, or one primary API plus Postmark |
+| Attachment-heavy transactional   | Resend, Postmark, SendGrid, Mailgun, MailerSend    |
+
+## API adapters
+
+These adapters cover most transactional email fields. They are the best fit when your app needs CC, BCC, reply-to, custom headers, tags, metadata, or attachments.
+
+| Adapter                 | CC  | BCC | Reply-To | Headers | Metadata | Tags      | Attachments |
+| ----------------------- | --- | --- | -------- | ------- | -------- | --------- | ----------- |
+| Resend                  | Yes | Yes | Yes      | Yes     | No       | Yes       | Yes         |
+| Postmark                | Yes | Yes | Yes      | Yes     | Yes      | First tag | Yes         |
+| SendGrid                | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
+| AWS SES                 | Yes | Yes | Yes      | Yes     | No       | Yes       | Yes         |
+| Mailgun                 | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
+| MailerSend              | Yes | Yes | Yes      | Yes     | No       | Values    | Yes         |
+| Brevo                   | Yes | Yes | Yes      | Yes     | Yes      | Values    | Yes         |
+| Mailchimp Transactional | Yes | Yes | No       | Yes     | Yes      | Values    | Yes         |
+| Mailtrap                | Yes | Yes | No       | Yes     | No       | First tag | Yes         |
+
+## Narrow adapters
+
+These adapters are useful, but their public APIs do not match the full `EmailMessage` shape. Email SDK keeps them stable by rejecting fields it cannot represent.
+
+| Adapter   | CC  | BCC | Reply-To | Headers | Metadata | Tags   | Attachments |
+| --------- | --- | --- | -------- | ------- | -------- | ------ | ----------- |
+| SparkPost | No  | No  | Yes      | Yes     | Yes      | Values | Yes         |
+| Loops     | No  | No  | No       | No      | Yes      | No     | No          |
+| Plunk     | No  | No  | No       | No      | Yes      | No     | No          |
+| Scaleway  | Yes | Yes | No       | Yes     | No       | No     | No          |
+| ZeptoMail | Yes | Yes | Yes      | No      | No       | No     | Yes         |
+| MailPace  | Yes | Yes | Yes      | No      | No       | No     | No          |
+
+## SMTP transport
+
+SMTP is built in and does not use Nodemailer. It maps address fields and headers directly to the SMTP message, but it does not map provider-only concepts like tags or metadata.
+
+| Adapter | CC  | BCC | Reply-To | Headers | Metadata | Tags | Attachments |
+| ------- | --- | --- | -------- | ------- | -------- | ---- | ----------- |
+| SMTP    | Yes | Yes | Yes      | Yes     | No       | No   | No          |
+
+## Validation behavior
+
+Unsupported fields fail fast. For example, Resend rejects `metadata`, Mailchimp Transactional rejects `replyTo`, and SMTP rejects attachments. That keeps production behavior boring: if a field matters, you find out before the provider request.
+
+## Attachment rules
+
+Attachment `content` is treated as raw content by default and encoded to Base64 for API adapters that require Base64.
+
+```ts
+attachments: [
+  {
+    filename: "receipt.txt",
+    content: "Thanks for your order.",
+    contentType: "text/plain",
+  },
+];
+```
+
+If you already have Base64 content, mark it:
+
+```ts
+attachments: [
+  {
+    filename: "receipt.pdf",
+    content: base64Pdf,
+    contentEncoding: "base64",
+    contentType: "application/pdf",
+  },
+];
+```
+
+Adapters that support attachments can also read a local path:
+
+```ts
+attachments: [
+  {
+    filename: "receipt.pdf",
+    path: "./receipt.pdf",
+    contentType: "application/pdf",
+  },
+];
+```

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Adapters
+description: Supported email service adapters and transports.
+icon: Cable
+---
+
+Email SDK ships with fifteen adapters. Import only the adapter you use; the package does not ask you
+to configure providers that are not on your send path.
+
+Every adapter follows the same contract: map the fields it supports and throw a validation error for
+fields the provider API cannot represent. Use the [SDK field support guide](/docs/adapters/field-support)
+before choosing fallback routes.
+
+<ProviderGrid />
+
+## Import pattern
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: process.env.SMTP_HOST!,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  fallback: ["smtp"],
+});
+```
+
+## Adapter groups
+
+| Group          | Adapters                                                                        |
+| -------------- | ------------------------------------------------------------------------------- |
+| Popular APIs   | Resend, Postmark, SendGrid, Mailgun, MailerSend, Brevo, Mailchimp Transactional |
+| Infrastructure | SparkPost, Mailtrap, Scaleway, ZeptoMail, MailPace                              |
+| Product-led    | Loops, Plunk                                                                    |
+| Transport      | Built-in SMTP                                                                   |

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/loops.mdx
@@ -1,0 +1,34 @@
+---
+title: Loops
+description: Configure the Loops transactional email adapter.
+icon: loops
+---
+
+<ProviderBadge adapter="loops" />
+
+Loops transactional sends normally use a `transactionalId`.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { loops } from "@opencoredev/email-sdk/loops";
+
+const email = createEmailClient({
+  adapters: [
+    loops({
+      apiKey: process.env.LOOPS_API_KEY!,
+      transactionalId: process.env.LOOPS_TRANSACTIONAL_ID!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option            | Type           | Required | Notes                                |
+| ----------------- | -------------- | -------- | ------------------------------------ |
+| `apiKey`          | `string`       | Yes      | Loops API key.                       |
+| `transactionalId` | `string`       | Usually  | Transactional email ID.              |
+| `baseUrl`         | `string`       | No       | Defaults to `https://app.loops.so`.  |
+| `fetch`           | `typeof fetch` | No       | Useful for tests or custom runtimes. |
+
+Loops transactional sends support one recipient and metadata through `dataVariables`. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/mailchimp.mdx
@@ -1,0 +1,28 @@
+---
+title: Mailchimp Transactional
+description: Configure the Mailchimp Transactional adapter.
+icon: mailchimp
+---
+
+<ProviderBadge adapter="mailchimp" />
+
+Mailchimp Transactional is the API formerly known as Mandrill.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailchimp } from "@opencoredev/email-sdk/mailchimp";
+
+const email = createEmailClient({
+  adapters: [mailchimp({ apiKey: process.env.MAILCHIMP_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                          |
+| --------- | -------------- | -------- | ---------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailchimp Transactional API key.               |
+| `baseUrl` | `string`       | No       | Defaults to `https://mandrillapp.com/api/1.0`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/mailersend.mdx
@@ -1,0 +1,26 @@
+---
+title: MailerSend
+description: Configure the MailerSend Email API adapter.
+icon: mailersend
+---
+
+<ProviderBadge adapter="mailersend" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailersend } from "@opencoredev/email-sdk/mailersend";
+
+const email = createEmailClient({
+  adapters: [mailersend({ apiKey: process.env.MAILERSEND_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                     |
+| --------- | -------------- | -------- | ----------------------------------------- |
+| `apiKey`  | `string`       | Yes      | MailerSend API token.                     |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.mailersend.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.      |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/mailgun.mdx
@@ -1,0 +1,32 @@
+---
+title: Mailgun
+description: Configure the Mailgun Messages API adapter.
+icon: mailgun
+---
+
+<ProviderBadge adapter="mailgun" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailgun } from "@opencoredev/email-sdk/mailgun";
+
+const email = createEmailClient({
+  adapters: [
+    mailgun({
+      apiKey: process.env.MAILGUN_API_KEY!,
+      domain: process.env.MAILGUN_DOMAIN!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                                                                              |
+| --------- | -------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailgun API key.                                                                                   |
+| `domain`  | `string`       | Yes      | Sending domain.                                                                                    |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.mailgun.net`. Use the EU API base URL if your domain is in the EU region. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                                               |
+
+Mailgun sends attachments as multipart form data. See <a href="/docs/adapters/field-support">field support</a> for the full mapping.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/mailpace.mdx
@@ -1,0 +1,26 @@
+---
+title: MailPace
+description: Configure the MailPace send API adapter.
+icon: mailpace
+---
+
+<ProviderBadge adapter="mailpace" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailpace } from "@opencoredev/email-sdk/mailpace";
+
+const email = createEmailClient({
+  adapters: [mailpace({ apiKey: process.env.MAILPACE_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                          |
+| --------- | -------------- | -------- | ---------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | MailPace server token.                         |
+| `baseUrl` | `string`       | No       | Defaults to `https://app.mailpace.com/api/v1`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
+
+MailPace supports CC, BCC, and reply-to. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/mailtrap.mdx
@@ -1,0 +1,26 @@
+---
+title: Mailtrap
+description: Configure the Mailtrap Email Sending API adapter.
+icon: mailtrap
+---
+
+<ProviderBadge adapter="mailtrap" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailtrap } from "@opencoredev/email-sdk/mailtrap";
+
+const email = createEmailClient({
+  adapters: [mailtrap({ apiKey: process.env.MAILTRAP_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                       |
+| --------- | -------------- | -------- | ------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailtrap API token.                         |
+| `baseUrl` | `string`       | No       | Defaults to `https://send.api.mailtrap.io`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.        |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/meta.json
@@ -1,0 +1,23 @@
+{
+  "title": "Adapters",
+  "pages": [
+    "index",
+    "field-support",
+    "resend",
+    "postmark",
+    "sendgrid",
+    "ses",
+    "mailgun",
+    "mailersend",
+    "brevo",
+    "mailchimp",
+    "sparkpost",
+    "loops",
+    "plunk",
+    "mailtrap",
+    "scaleway",
+    "zeptomail",
+    "mailpace",
+    "smtp"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/plunk.mdx
@@ -1,0 +1,26 @@
+---
+title: Plunk
+description: Configure the Plunk send API adapter.
+icon: plunk
+---
+
+<ProviderBadge adapter="plunk" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { plunk } from "@opencoredev/email-sdk/plunk";
+
+const email = createEmailClient({
+  adapters: [plunk({ apiKey: process.env.PLUNK_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                        |
+| --------- | -------------- | -------- | -------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Plunk API key.                               |
+| `baseUrl` | `string`       | No       | Defaults to `https://next-api.useplunk.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.         |
+
+Plunk maps `metadata` to `data`. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/postmark.mdx
@@ -1,0 +1,51 @@
+---
+title: Postmark
+description: Configure the fetch-based Postmark adapter.
+icon: postmark
+---
+
+The Postmark adapter calls the Postmark Email API directly. It does not add a runtime dependency.
+
+<ProviderBadge adapter="postmark" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { postmark } from "@opencoredev/email-sdk/postmark";
+
+const email = createEmailClient({
+  adapters: [
+    postmark({
+      serverToken: process.env.POSTMARK_SERVER_TOKEN!,
+      messageStream: "outbound",
+    }),
+  ],
+});
+```
+
+## Send
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  html: "<p>Thanks for your order.</p>",
+  metadata: {
+    orderId: "ord_123",
+  },
+});
+```
+
+## Options
+
+| Option          | Type                     | Required | Notes                                      |
+| --------------- | ------------------------ | -------- | ------------------------------------------ |
+| `serverToken`   | `string`                 | Yes      | Postmark server token.                     |
+| `baseUrl`       | `string`                 | No       | Defaults to `https://api.postmarkapp.com`. |
+| `messageStream` | `string`                 | No       | Postmark message stream.                   |
+| `fetch`         | `typeof fetch`           | No       | Useful for tests or custom runtimes.       |
+| `headers`       | `Record<string, string>` | No       | Extra request headers.                     |
+
+## Response
+
+The adapter maps Postmark `MessageID` to `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/resend.mdx
@@ -1,0 +1,48 @@
+---
+title: Resend
+description: Configure the fetch-based Resend adapter.
+icon: resend
+---
+
+The Resend adapter calls the Resend Email API directly. It does not add a runtime dependency.
+
+<ProviderBadge adapter="resend" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+await email.send(
+  {
+    from: "Acme <hello@acme.com>",
+    to: "user@example.com",
+    subject: "Welcome",
+    html: "<p>Your workspace is ready.</p>",
+    tags: [{ name: "type", value: "welcome" }],
+  },
+  {
+    idempotencyKey: "welcome:user_123",
+  },
+);
+```
+
+## Options
+
+| Option    | Type                     | Required | Notes                                 |
+| --------- | ------------------------ | -------- | ------------------------------------- |
+| `apiKey`  | `string`                 | Yes      | Resend API key.                       |
+| `baseUrl` | `string`                 | No       | Defaults to `https://api.resend.com`. |
+| `fetch`   | `typeof fetch`           | No       | Useful for tests or custom runtimes.  |
+| `headers` | `Record<string, string>` | No       | Extra request headers.                |
+
+## Response
+
+The adapter returns the Resend `id` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/scaleway.mdx
@@ -1,0 +1,33 @@
+---
+title: Scaleway
+description: Configure the Scaleway Transactional Email adapter.
+icon: scaleway
+---
+
+<ProviderBadge adapter="scaleway" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { scaleway } from "@opencoredev/email-sdk/scaleway";
+
+const email = createEmailClient({
+  adapters: [
+    scaleway({
+      secretKey: process.env.SCALEWAY_SECRET_KEY!,
+      projectId: process.env.SCALEWAY_PROJECT_ID!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option      | Type           | Required | Notes                                   |
+| ----------- | -------------- | -------- | --------------------------------------- |
+| `secretKey` | `string`       | Yes      | Scaleway secret key.                    |
+| `projectId` | `string`       | Yes      | Scaleway project ID.                    |
+| `region`    | `string`       | No       | Defaults to `fr-par`.                   |
+| `baseUrl`   | `string`       | No       | Defaults to `https://api.scaleway.com`. |
+| `fetch`     | `typeof fetch` | No       | Useful for tests or custom runtimes.    |
+
+Scaleway supports a narrower message shape than full API-first providers. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/sendgrid.mdx
@@ -1,0 +1,32 @@
+---
+title: SendGrid
+description: Configure the Twilio SendGrid Mail Send API adapter.
+icon: sendgrid
+---
+
+<ProviderBadge adapter="sendgrid" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sendgrid } from "@opencoredev/email-sdk/sendgrid";
+
+const email = createEmailClient({
+  adapters: [sendgrid({ apiKey: process.env.SENDGRID_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                   |
+| --------- | -------------- | -------- | --------------------------------------- |
+| `apiKey`  | `string`       | Yes      | SendGrid API key.                       |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.sendgrid.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.    |
+
+See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.
+
+## CLI
+
+```bash
+email-sdk send --adapter sendgrid --from hello@example.com --to user@example.com --subject "Hello" --text "It works"
+```

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/ses.mdx
@@ -1,0 +1,67 @@
+---
+title: AWS SES
+description: Configure the AWS SES v2 SendEmail adapter.
+icon: Cloud
+---
+
+The AWS SES adapter calls the SES v2 SendEmail API directly with SigV4-signed fetch requests. It does not add a runtime dependency on the AWS SDK.
+
+<ProviderBadge adapter="ses" />
+
+```ts
+import { createEmailClient } from "email-sdk";
+import { ses } from "email-sdk/ses";
+
+const email = createEmailClient({
+  adapters: [
+    ses({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+      region: process.env.AWS_REGION!,
+    }),
+  ],
+});
+```
+
+## Send
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
+  tags: [{ name: "type", value: "welcome" }],
+});
+```
+
+## Options
+
+| Option                 | Type           | Required | Notes                                                 |
+| ---------------------- | -------------- | -------- | ----------------------------------------------------- |
+| `accessKeyId`          | `string`       | Yes      | AWS access key ID.                                    |
+| `secretAccessKey`      | `string`       | Yes      | AWS secret access key.                                |
+| `region`               | `string`       | Yes      | SES region, for example `us-east-1`.                  |
+| `sessionToken`         | `string`       | No       | Required for temporary credentials.                   |
+| `baseUrl`              | `string`       | No       | Defaults to `https://email.{region}.amazonaws.com`.   |
+| `fetch`                | `typeof fetch` | No       | Useful for tests or custom runtimes.                  |
+| `charset`              | `string`       | No       | Defaults to `UTF-8`.                                  |
+| `configurationSetName` | `string`       | No       | SES configuration set for sends through this adapter. |
+
+## CLI
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_REGION=us-east-1 \
+email-sdk send --adapter ses \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Welcome" \
+  --html "<p>Your workspace is ready.</p>"
+```
+
+## Response
+
+The adapter returns the SES `MessageId` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/smtp.mdx
@@ -1,0 +1,75 @@
+---
+title: SMTP
+description: Configure generic SMTP for PurelyMail or a custom server.
+icon: smtp
+---
+
+The SMTP adapter is built in. It uses Node/Bun TCP and TLS sockets directly, so it does not need Nodemailer.
+
+When `auth` is configured with `secure: false`, the adapter sends `STARTTLS` before authenticating. Set `allowInsecureAuth: true` only for a trusted local server that does not support TLS.
+
+## Configure
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option              | Type                             | Required | Notes                                     |
+| ------------------- | -------------------------------- | -------- | ----------------------------------------- |
+| `host`              | `string`                         | Yes      | SMTP host.                                |
+| `port`              | `number`                         | No       | Common values are `587`, `465`, and `25`. |
+| `secure`            | `boolean`                        | No       | Use TLS from the start of the connection. |
+| `auth`              | `{ user: string; pass: string }` | No       | SMTP credentials.                         |
+| `defaults`          | `{ replyTo?: string }`           | No       | Default reply-to header.                  |
+| `tls`               | `Record<string, unknown>`        | No       | TLS options.                              |
+| `requireTLS`        | `boolean`                        | No       | Require STARTTLS.                         |
+| `allowInsecureAuth` | `boolean`                        | No       | Opt in to SMTP AUTH without TLS.          |
+| `name`              | `string`                         | No       | Defaults to `smtp`.                       |
+| `heloName`          | `string`                         | No       | EHLO name sent to the server.             |
+| `timeoutMs`         | `number`                         | No       | Socket timeout.                           |
+
+## Multiple SMTP routes
+
+Rename adapters when you have multiple SMTP routes.
+
+```ts
+const email = createEmailClient({
+  adapters: [
+    smtp({ name: "purelymail", host: "smtp.purelymail.com" }),
+    smtp({ name: "backup-smtp", host: "smtp.backup.example" }),
+  ],
+  defaultProvider: "purelymail",
+  fallback: ["backup-smtp"],
+});
+```
+
+## CLI
+
+```bash
+email-sdk send \
+  --adapter smtp \
+  --host smtp.purelymail.com \
+  --user hello@example.com \
+  --pass "$SMTP_PASS" \
+  --from "Acme <hello@example.com>" \
+  --to user@example.com \
+  --subject "SMTP test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/sparkpost.mdx
@@ -1,0 +1,27 @@
+---
+title: SparkPost
+description: Configure the SparkPost Transmissions API adapter.
+icon: sparkpost
+---
+
+<ProviderBadge adapter="sparkpost" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sparkpost } from "@opencoredev/email-sdk/sparkpost";
+
+const email = createEmailClient({
+  adapters: [sparkpost({ apiKey: process.env.SPARKPOST_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                           |
+| --------- | -------------- | -------- | ----------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | SparkPost API key.                              |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.sparkpost.com/api/v1`. |
+| `sandbox` | `boolean`      | No       | Enables SparkPost sandbox mode.                 |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.            |
+
+SparkPost does not expose normalized CC/BCC in this adapter. See <a href="/docs/adapters/field-support">field support</a>.

--- a/apps/fumadocs/content/docs-v/0.2.1/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/adapters/zeptomail.mdx
@@ -1,0 +1,26 @@
+---
+title: ZeptoMail
+description: Configure the Zoho ZeptoMail adapter.
+icon: zeptomail
+---
+
+<ProviderBadge adapter="zeptomail" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { zeptomail } from "@opencoredev/email-sdk/zeptomail";
+
+const email = createEmailClient({
+  adapters: [zeptomail({ token: process.env.ZEPTOMAIL_TOKEN! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                                                         |
+| --------- | -------------- | -------- | ----------------------------------------------------------------------------- |
+| `token`   | `string`       | Yes      | ZeptoMail API token. The adapter adds the `Zoho-enczapikey` prefix if needed. |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.zeptomail.com`.                                      |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                          |
+
+ZeptoMail supports recipients, reply-to, and attachments. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.2.1/agents/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.1/agents/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Agents",
+  "pages": ["skill"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.1/agents/skill.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/agents/skill.mdx
@@ -1,0 +1,41 @@
+---
+title: Agent skill
+description: Use the repo-local Email SDK skill when agents add or review email integrations.
+icon: Bot
+---
+
+This repo includes an agent skill at:
+
+```txt
+skills/email-sdk/SKILL.md
+```
+
+Install it with the skills.sh CLI:
+
+```bash
+npx skills add opencoredev/email-sdk --skill email-sdk
+```
+
+Use it when an agent wires Email SDK into an app, reviews adapter setup, or updates these docs.
+
+## What it tells agents
+
+- Use `bun` and `bunx`.
+- Refresh the current README, package exports, Fumadocs pages, and TypeScript declarations before implementing.
+- Keep adapter credentials in environment variables.
+- Import adapters from their own entry points.
+- Do not add Nodemailer for SMTP; Email SDK includes its own SMTP transport.
+- Use fallbacks only when the backup adapter can send the same class of email.
+- Add idempotency keys for externally visible transactional sends.
+- Run a narrow validation before calling the work done.
+
+## Prompt example
+
+```txt
+Use the repo-local Email SDK skill at skills/email-sdk/SKILL.md.
+Wire Resend as the primary adapter and SMTP as fallback.
+Keep secrets in environment variables.
+Add one narrow test around the send path.
+```
+
+The skill is dynamic on purpose. It teaches agents where to fetch the current docs and source first, so the skill does not need a manual update every time the SDK gains another adapter or option.

--- a/apps/fumadocs/content/docs-v/0.2.1/concepts/adapter-model.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/concepts/adapter-model.mdx
@@ -1,0 +1,71 @@
+---
+title: Adapter model
+description: How Email SDK adapters, routing names, and escape hatches work.
+icon: Plug
+---
+
+An adapter is an Email SDK module that knows how to send through one service or transport.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { postmark } from "@opencoredev/email-sdk/postmark";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    postmark({ serverToken: process.env.POSTMARK_SERVER_TOKEN! }),
+  ],
+});
+```
+
+## Routing names
+
+Each adapter registers a routing name. Email SDK uses that name for defaults, fallbacks, and per-send overrides.
+
+| Adapter                 | Routing name |
+| ----------------------- | ------------ |
+| Resend                  | `resend`     |
+| SMTP                    | `smtp`       |
+| Postmark                | `postmark`   |
+| SendGrid                | `sendgrid`   |
+| AWS SES                 | `ses`        |
+| Mailgun                 | `mailgun`    |
+| MailerSend              | `mailersend` |
+| Brevo                   | `brevo`      |
+| Mailchimp Transactional | `mailchimp`  |
+| SparkPost               | `sparkpost`  |
+| Loops                   | `loops`      |
+| Plunk                   | `plunk`      |
+| Mailtrap                | `mailtrap`   |
+| Scaleway                | `scaleway`   |
+| ZeptoMail               | `zeptomail`  |
+| MailPace                | `mailpace`   |
+
+## Send with one adapter
+
+```ts
+await email.send(message, {
+  adapter: "postmark",
+});
+```
+
+## Bind one adapter
+
+```ts
+const transactional = email.withAdapter("postmark");
+
+await transactional.send(message);
+```
+
+## Use adapter escape hatches
+
+Every adapter can expose `raw`. Keep provider-specific code close to the adapter and keep normal application code on the shared `send` path.
+
+```ts
+const adapter = email.adapter("resend");
+
+console.log(adapter.raw);
+```
+
+The older `provider`, `defaultProvider`, `email.provider()`, and `email.withProvider()` names still work as aliases.

--- a/apps/fumadocs/content/docs-v/0.2.1/concepts/fallbacks-and-retries.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/concepts/fallbacks-and-retries.mdx
@@ -1,0 +1,66 @@
+---
+title: Fallbacks and retries
+description: Retry transient failures and use a backup adapter.
+icon: Repeat2
+---
+
+Retries happen inside one adapter. Fallbacks happen after an adapter fails.
+
+```ts
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  retry: {
+    retries: 1,
+  },
+  fallback: ["smtp"],
+});
+```
+
+In this setup, Email SDK tries Resend first. If Resend fails with a retryable error, it retries once. If it still fails, it tries SMTP.
+
+## Override fallback for one send
+
+```ts
+await email.send(message, {
+  provider: "resend",
+  fallbackAdapters: ["smtp"],
+});
+```
+
+## Override retries for one send
+
+```ts
+await email.send(message, {
+  retries: 2,
+});
+```
+
+## Retryable HTTP responses
+
+The fetch-based adapters mark these responses as retryable:
+
+| Status | Meaning                         |
+| ------ | ------------------------------- |
+| `408`  | Request timeout                 |
+| `409`  | Conflict                        |
+| `425`  | Too early                       |
+| `429`  | Rate limited                    |
+| `5xx`  | Adapter or network-side failure |
+
+Use an idempotency key for email that may be retried.
+
+```ts
+await email.send(message, {
+  idempotencyKey: "receipt:order_123",
+});
+```

--- a/apps/fumadocs/content/docs-v/0.2.1/concepts/hooks.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/concepts/hooks.mdx
@@ -1,0 +1,44 @@
+---
+title: Hooks
+description: Observe sends without changing adapter code.
+icon: Activity
+---
+
+Hooks are for logs, metrics, tracing, and retry visibility.
+
+```ts
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  hooks: {
+    beforeSend(event) {
+      console.log("email.send", event.provider, event.message.subject);
+    },
+    afterSend(event) {
+      console.log("email.sent", event.response.id);
+    },
+    onRetry(event) {
+      console.warn("email.retry", event.provider, event.nextAttempt);
+    },
+    onError(event) {
+      console.error("email.error", event.provider, event.error);
+    },
+  },
+});
+```
+
+## Hook events
+
+Each hook receives:
+
+| Field      | Notes                               |
+| ---------- | ----------------------------------- |
+| `provider` | Routing name used for this attempt. |
+| `message`  | The original `EmailMessage`.        |
+| `attempt`  | Current attempt number.             |
+| `metadata` | Optional metadata passed to `send`. |
+
+`afterSend` also receives `response`. `onRetry` receives `nextAttempt` and `delayMs`. `onError` receives `error`.
+
+## Keep logs safe
+
+Do not log API keys, SMTP passwords, raw tokens, full message bodies, or unnecessary recipient data. For most production logs, routing name, status, subject category, template name, and message ID are enough.

--- a/apps/fumadocs/content/docs-v/0.2.1/concepts/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.1/concepts/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Concepts",
+  "pages": ["adapter-model", "fallbacks-and-retries", "hooks"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.1/getting-started/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.1/getting-started/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Getting started",
+  "pages": ["quickstart"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.1/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/getting-started/quickstart.mdx
@@ -1,0 +1,106 @@
+---
+title: Quickstart
+description: Install Email SDK, create a client, and send a first transactional email.
+icon: Rocket
+---
+
+Install the SDK:
+
+```bash
+bun add @opencoredev/email-sdk
+```
+
+This example sends through Resend. Set `RESEND_API_KEY` in the environment before running it.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome to Acme",
+  text: "Your account is ready.",
+});
+```
+
+## Add built-in SMTP fallback
+
+Add SMTP when you want a second route for the same transactional email. The SMTP adapter is built in
+and does not require Nodemailer. When SMTP auth is configured on a non-secure connection, Email SDK
+upgrades with STARTTLS before authenticating.
+
+Only use fallback adapters that can send the same message shape. For example, SMTP supports address
+fields and headers, but not provider-only fields like tags, metadata, or attachments.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+export const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  fallback: ["smtp"],
+});
+```
+
+Your application still sends the same way:
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  text: "Thanks for your order.",
+});
+```
+
+## Check the result
+
+`send` resolves with the normalized adapter response. The `provider` value tells you which adapter
+actually handled the send.
+
+```ts
+const result = await email.send(message);
+
+console.log(result.provider);
+console.log(result.id);
+```
+
+If the adapter returns a message ID, Email SDK exposes it as both `id` and `messageId`. Provider
+responses are still available through `raw` when an adapter includes them.
+
+## Test from the CLI
+
+Use the CLI to check adapter credentials from your terminal.
+
+```bash
+email-sdk doctor --adapter resend
+```
+
+Send a test email:
+
+```bash
+email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works"
+```
+
+Use `--dry-run` when you want to validate the message and selected adapter without sending email.

--- a/apps/fumadocs/content/docs-v/0.2.1/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/index.mdx
@@ -1,0 +1,77 @@
+---
+title: Email SDK
+description: A small TypeScript email client with swappable adapters and explicit provider limits.
+icon: Mail
+---
+
+Email SDK is a small TypeScript package for transactional email. It gives your application one
+client and one message shape while keeping provider-specific behavior visible in the adapter docs.
+
+Use Resend for a simple API path, SMTP when you want a cheap or self-managed route, or another
+provider when its field support fits your app better. Your application code still calls `send`;
+the adapter decides how that message maps to the provider.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+```
+
+## Start here
+
+<Cards>
+  <Card
+    title="Send your first email"
+    href="/docs/getting-started/quickstart"
+    description="Install the SDK, create a client, and send a message."
+  />
+  <Card
+    title="Understand adapters"
+    href="/docs/concepts/adapter-model"
+    description="Learn how adapters and routing names work."
+  />
+  <Card
+    title="Browse adapters"
+    href="/docs/adapters"
+    description="See all supported email services."
+  />
+  <Card
+    title="Read the API reference"
+    href="/docs/reference/client"
+    description="Look up client options, messages, errors, and the CLI."
+  />
+</Cards>
+
+## What is included
+
+- `createEmailClient` for one shared email client.
+- `email.send()` for one message.
+- `email.sendBatch()` for small batches where each result is reported separately.
+- Fifteen adapters, including Resend, SMTP, Postmark, SendGrid, Mailgun, and MailerSend.
+- Retry and fallback options that run in the order you configure.
+- Hooks for logs, metrics, tracing, and retry visibility.
+- A small CLI for setup checks, dry runs, and smoke-test sends.
+- A repo-local agent skill for future coding agents.
+
+## What stays small
+
+Email SDK does not try to be a template engine, campaign tool, queue, analytics platform, or full
+email operations suite. It is the layer many apps keep rebuilding: adapter setup, a consistent send
+call, typed errors, and a fallback path that is explicit enough to debug.
+
+## Provider behavior is not hidden
+
+Email providers do not all support the same fields. A fallback route is only safe when the backup
+adapter can represent the same class of message. Before choosing routes, read the
+[field support guide](/docs/adapters/field-support); unsupported fields should fail fast instead of
+being silently dropped.

--- a/apps/fumadocs/content/docs-v/0.2.1/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.1/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Email SDK",
+  "pages": ["index", "getting-started", "concepts", "adapters", "reference", "agents"]
+}

--- a/apps/fumadocs/content/docs-v/0.2.1/reference/adapter-contract.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/reference/adapter-contract.mdx
@@ -1,0 +1,64 @@
+---
+title: Adapter contract
+description: Reference for writing a custom Email SDK adapter.
+icon: Plug
+---
+
+Custom adapters are plain objects.
+
+```ts
+import type { EmailProvider } from "@opencoredev/email-sdk";
+
+export const customAdapter: EmailProvider = {
+  name: "custom",
+  async send(message, context) {
+    const response = await fetch("https://api.example.com/email", {
+      method: "POST",
+      signal: context.signal,
+      body: JSON.stringify(message),
+    });
+
+    const body = await response.json();
+
+    return {
+      provider: "custom",
+      id: body.id,
+      raw: body,
+    };
+  },
+};
+```
+
+## `EmailProvider`
+
+```ts
+type EmailProvider<TRaw = unknown> = {
+  name: string;
+  send(message: EmailMessage, context: EmailProviderContext): MaybePromise<EmailProviderResponse>;
+  raw?: TRaw;
+};
+```
+
+## `EmailProviderContext`
+
+| Field            | Type                      | Notes                                          |
+| ---------------- | ------------------------- | ---------------------------------------------- |
+| `signal`         | `AbortSignal`             | Optional abort signal.                         |
+| `idempotencyKey` | `string`                  | Optional key from the message or send options. |
+| `attempt`        | `number`                  | Attempt number for this adapter.               |
+| `metadata`       | `Record<string, unknown>` | Metadata passed to `send`.                     |
+
+## Adapter responses
+
+```ts
+type EmailProviderResponse = {
+  id?: string;
+  provider: string;
+  messageId?: string;
+  accepted?: string[];
+  rejected?: string[];
+  raw?: unknown;
+};
+```
+
+Return the provider's raw response in `raw` when it helps callers debug or inspect provider-specific fields.

--- a/apps/fumadocs/content/docs-v/0.2.1/reference/cli.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/reference/cli.mdx
@@ -1,0 +1,94 @@
+---
+title: CLI
+description: Reference for the email-sdk command-line smoke test.
+icon: Terminal
+---
+
+The CLI is intentionally small. Use it to inspect adapters, check environment variables, validate a message with `--dry-run`, and send a smoke-test email from your terminal.
+
+```bash
+email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works"
+```
+
+## Adapters
+
+```bash
+email-sdk adapters
+```
+
+| Adapter      | Required environment                                       |
+| ------------ | ---------------------------------------------------------- |
+| `resend`     | `RESEND_API_KEY`                                           |
+| `postmark`   | `POSTMARK_SERVER_TOKEN`                                    |
+| `sendgrid`   | `SENDGRID_API_KEY`                                         |
+| `ses`        | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| `mailgun`    | `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`                        |
+| `mailersend` | `MAILERSEND_API_KEY`                                       |
+| `brevo`      | `BREVO_API_KEY`                                            |
+| `mailchimp`  | `MAILCHIMP_API_KEY`                                        |
+| `sparkpost`  | `SPARKPOST_API_KEY`                                        |
+| `loops`      | `LOOPS_API_KEY`, `LOOPS_TRANSACTIONAL_ID`                  |
+| `plunk`      | `PLUNK_API_KEY`                                            |
+| `mailtrap`   | `MAILTRAP_API_KEY`                                         |
+| `scaleway`   | `SCALEWAY_SECRET_KEY`, `SCALEWAY_PROJECT_ID`               |
+| `zeptomail`  | `ZEPTOMAIL_TOKEN`                                          |
+| `mailpace`   | `MAILPACE_API_KEY`                                         |
+| `smtp`       | `SMTP_HOST`, plus SMTP auth variables when needed          |
+
+If `--adapter` is omitted, the CLI selects the first adapter with all required environment variables set.
+
+## Doctor
+
+```bash
+email-sdk doctor --adapter resend
+```
+
+`doctor` checks whether the selected adapter has the required environment variables.
+
+## Flags
+
+| Flag                    | Adapter   | Notes                                                  |
+| ----------------------- | --------- | ------------------------------------------------------ |
+| `--adapter`             | all       | Adapter routing name.                                  |
+| `--provider`            | all       | Alias for `--adapter`.                                 |
+| `--from`                | all       | Sender address.                                        |
+| `--to`                  | all       | Recipient address. Comma-separated values are allowed. |
+| `--subject`             | all       | Message subject.                                       |
+| `--text`                | all       | Plain text body.                                       |
+| `--html`                | all       | HTML body.                                             |
+| `--cc`                  | send      | Comma-separated CC addresses.                          |
+| `--bcc`                 | send      | Comma-separated BCC addresses.                         |
+| `--reply-to`            | send      | Comma-separated reply-to addresses.                    |
+| `--header`              | send      | Header in `Name: value` format. Repeatable.            |
+| `--tag`                 | send      | Tag in `name=value` format. Repeatable.                |
+| `--metadata`            | send      | Metadata in `key=value` format. Repeatable.            |
+| `--attachment`          | send      | Local file path, optionally `path:content/type`.       |
+| `--message`             | send      | Read an `EmailMessage` JSON payload from a file.       |
+| `--dry-run`             | all       | Validate and print the send plan without sending.      |
+| `--api-key`             | many      | Overrides the adapter API key variable.                |
+| `--server-token`        | Postmark  | Overrides `POSTMARK_SERVER_TOKEN`.                     |
+| `--message-stream`      | Postmark  | Optional message stream.                               |
+| `--access-key-id`       | AWS SES   | Overrides `AWS_ACCESS_KEY_ID`.                         |
+| `--secret-access-key`   | AWS SES   | Overrides `AWS_SECRET_ACCESS_KEY`.                     |
+| `--region`              | AWS SES   | Overrides `AWS_REGION`.                                |
+| `--session-token`       | AWS SES   | Overrides `AWS_SESSION_TOKEN`.                         |
+| `--configuration-set`   | AWS SES   | Overrides `AWS_SES_CONFIGURATION_SET`.                 |
+| `--domain`              | Mailgun   | Overrides `MAILGUN_DOMAIN`.                            |
+| `--transactional-id`    | Loops     | Overrides `LOOPS_TRANSACTIONAL_ID`.                    |
+| `--project-id`          | Scaleway  | Overrides `SCALEWAY_PROJECT_ID`.                       |
+| `--secret-key`          | Scaleway  | Overrides `SCALEWAY_SECRET_KEY`.                       |
+| `--token`               | ZeptoMail | Overrides `ZEPTOMAIL_TOKEN`.                           |
+| `--host`                | SMTP      | Overrides `SMTP_HOST`.                                 |
+| `--port`                | SMTP      | Overrides `SMTP_PORT`.                                 |
+| `--secure`              | SMTP      | Set to `true` for secure SMTP.                         |
+| `--require-tls`         | SMTP      | Require STARTTLS.                                      |
+| `--allow-insecure-auth` | SMTP      | Allow SMTP AUTH without TLS.                           |
+| `--user`                | SMTP      | Overrides `SMTP_USER`.                                 |
+| `--pass`                | SMTP      | Overrides `SMTP_PASS`.                                 |
+
+The CLI prints the normalized adapter response as JSON.

--- a/apps/fumadocs/content/docs-v/0.2.1/reference/client.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/reference/client.mdx
@@ -1,0 +1,90 @@
+---
+title: Client
+description: Reference for createEmailClient, send, sendBatch, and adapter helpers.
+icon: Braces
+---
+
+## `createEmailClient(options)`
+
+Creates an email client.
+
+```ts
+const email = createEmailClient({
+  adapters,
+  defaultAdapter,
+  fallback,
+  retry,
+  hooks,
+});
+```
+
+| Option            | Type               | Default              |
+| ----------------- | ------------------ | -------------------- |
+| `adapters`        | `EmailProvider[]`  | Required             |
+| `providers`       | `EmailProvider[]`  | Alias for `adapters` |
+| `defaultAdapter`  | `string`           | First adapter        |
+| `defaultProvider` | `string`           | First adapter        |
+| `fallback`        | `string[]`         | `[]`                 |
+| `retry`           | `EmailRetryConfig` | No retries           |
+| `hooks`           | `EmailHooks`       | No hooks             |
+
+Routing names must be unique.
+
+## `email.send(message, options?)`
+
+Sends one message.
+
+```ts
+const result = await email.send(message, {
+  adapter: "resend",
+  fallbackAdapters: ["smtp"],
+  retries: 2,
+  idempotencyKey: "receipt:order_123",
+  metadata: {
+    route: "checkout.receipt",
+  },
+});
+```
+
+| Option              | Type                      | Notes                                     |
+| ------------------- | ------------------------- | ----------------------------------------- |
+| `adapter`           | `string`                  | Override the default routing name.        |
+| `provider`          | `string`                  | Alias for `adapter`.                      |
+| `fallbackAdapters`  | `string[]`                | Override fallback adapters for this send. |
+| `fallbackProviders` | `string[]`                | Alias for `fallbackAdapters`.             |
+| `retries`           | `number`                  | Override retry count for this send.       |
+| `signal`            | `AbortSignal`             | Abort provider work when supported.       |
+| `idempotencyKey`    | `string`                  | Passed to adapters that support it.       |
+| `metadata`          | `Record<string, unknown>` | Passed to hooks.                          |
+
+## `email.sendBatch(messages, options?)`
+
+Sends messages one at a time and returns one result per item.
+
+```ts
+const results = await email.sendBatch([messageA, messageB]);
+```
+
+`sendBatch` does not throw for the first failed item. Failed sends are returned as `{ ok: false, index, error }`.
+
+## `email.adapter(name)`
+
+Returns a registered adapter or throws `EmailProviderNotFoundError`.
+
+```ts
+const resendAdapter = email.adapter("resend");
+```
+
+`email.provider(name)` is kept as an alias.
+
+## `email.withAdapter(name)`
+
+Returns a small client bound to one adapter.
+
+```ts
+const transactional = email.withAdapter("postmark");
+
+await transactional.send(message);
+```
+
+`email.withProvider(name)` is kept as an alias.

--- a/apps/fumadocs/content/docs-v/0.2.1/reference/errors.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/reference/errors.mdx
@@ -1,0 +1,51 @@
+---
+title: Errors
+description: Reference for Email SDK error classes and retry flags.
+icon: TriangleAlert
+---
+
+Email SDK exports four error classes.
+
+```ts
+import {
+  EmailProviderError,
+  EmailProviderNotFoundError,
+  EmailSdkError,
+  EmailValidationError,
+} from "@opencoredev/email-sdk";
+```
+
+## Error fields
+
+`EmailSdkError` includes:
+
+| Field       | Type      | Notes                                   |
+| ----------- | --------- | --------------------------------------- |
+| `code`      | `string`  | Machine-readable error code.            |
+| `provider`  | `string`  | Routing name when available.            |
+| `status`    | `number`  | HTTP status when available.             |
+| `retryable` | `boolean` | Whether retry is reasonable.            |
+| `details`   | `unknown` | Adapter response body or extra context. |
+
+## Common errors
+
+| Error                        | When it happens                         |
+| ---------------------------- | --------------------------------------- |
+| `EmailValidationError`       | A message or client config is invalid.  |
+| `EmailProviderNotFoundError` | The selected adapter is not registered. |
+| `EmailProviderError`         | An adapter call fails.                  |
+| `EmailSdkError`              | A general SDK-level failure occurs.     |
+
+## Handling adapter errors
+
+```ts
+try {
+  await email.send(message);
+} catch (error) {
+  if (error instanceof EmailProviderError && error.retryable) {
+    // Queue a later retry, alert, or switch to another flow.
+  }
+
+  throw error;
+}
+```

--- a/apps/fumadocs/content/docs-v/0.2.1/reference/message.mdx
+++ b/apps/fumadocs/content/docs-v/0.2.1/reference/message.mdx
@@ -1,0 +1,75 @@
+---
+title: Message
+description: Reference for EmailMessage, addresses, attachments, headers, and tags.
+icon: Mail
+---
+
+## `EmailMessage`
+
+```ts
+type EmailMessage = {
+  from: EmailAddress;
+  to: EmailAddress | EmailAddress[];
+  subject: string;
+  html?: string;
+  text?: string;
+  cc?: EmailAddress | EmailAddress[];
+  bcc?: EmailAddress | EmailAddress[];
+  replyTo?: EmailAddress | EmailAddress[];
+  headers?: Record<string, string> | EmailHeader[];
+  attachments?: EmailAttachment[];
+  tags?: EmailTag[];
+  metadata?: Record<string, string | number | boolean | null>;
+  idempotencyKey?: string;
+};
+```
+
+Every message must include:
+
+- `from`
+- at least one `to`
+- `subject`
+- `html` or `text`
+
+## Addresses
+
+An address can be a string or an object with a display name.
+
+```ts
+const from = "Acme <hello@acme.com>";
+
+const to = {
+  email: "user@example.com",
+  name: "Ada Lovelace",
+};
+```
+
+## Attachments
+
+```ts
+type EmailAttachment = {
+  filename: string;
+  content?: string | Uint8Array | ArrayBuffer | Blob;
+  contentEncoding?: "raw" | "base64";
+  path?: string;
+  contentType?: string;
+  contentId?: string;
+  disposition?: "attachment" | "inline";
+};
+```
+
+Use `content` for in-memory attachments. String content is treated as raw content and encoded to Base64 for API providers that require it. Use `contentEncoding: "base64"` when the string is already Base64.
+
+Use `path` when you want Email SDK to read a local file before sending. See <a href="/docs/adapters/field-support">field support</a> for adapter-specific attachment support.
+
+## Headers and tags
+
+Headers can be an object or a list:
+
+```ts
+headers: {
+  "X-Order-ID": "ord_123";
+}
+```
+
+Tags are provider-specific. Resend accepts `tags`. Postmark maps the first tag to its `Tag` field.

--- a/apps/fumadocs/content/docs-v/0.2.1/reference/meta.json
+++ b/apps/fumadocs/content/docs-v/0.2.1/reference/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Reference",
+  "pages": ["client", "message", "adapter-contract", "errors", "cli"]
+}

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -90,7 +90,7 @@ bun email-sdk -v
 bun email-sdk version --json
 ```
 
-`version` reads the installed `@opencoredev/email-sdk` package metadata, so it reports the SDK and CLI version from the package currently on your machine. The docs version picker in the top navigation uses the same package version from this repository.
+`version` reads the installed `@opencoredev/email-sdk` package metadata, so it reports the SDK and CLI version from the package currently on your machine. The docs version picker uses the same package version from this repository.
 
 ## Flags
 

--- a/apps/fumadocs/source.config.ts
+++ b/apps/fumadocs/source.config.ts
@@ -9,4 +9,22 @@ export const docs = defineDocs({
   },
 });
 
+export const docsV020 = defineDocs({
+  dir: "content/docs-v/0.2.0",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
+});
+
+export const docsV021 = defineDocs({
+  dir: "content/docs-v/0.2.1",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
+});
+
 export default defineConfig();

--- a/apps/fumadocs/src/components/docs-version-link.tsx
+++ b/apps/fumadocs/src/components/docs-version-link.tsx
@@ -1,0 +1,19 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+import { useSelectedDocsVersion } from "@/lib/docs-version-state";
+import { getDocsVersionHref } from "@/lib/versions";
+
+type DocsVersionLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> & {
+  children: ReactNode;
+  docsPath?: string;
+};
+
+export function DocsVersionLink({ children, docsPath = "/docs", ...props }: DocsVersionLinkProps) {
+  const selectedVersion = useSelectedDocsVersion();
+
+  return (
+    <a {...props} href={getDocsVersionHref(selectedVersion, docsPath)}>
+      {children}
+    </a>
+  );
+}

--- a/apps/fumadocs/src/components/docs-version-link.tsx
+++ b/apps/fumadocs/src/components/docs-version-link.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import type { AnchorHTMLAttributes, ReactNode } from "react";
 
 import { useSelectedDocsVersion } from "@/lib/docs-version-state";
@@ -6,14 +7,22 @@ import { getDocsVersionHref } from "@/lib/versions";
 type DocsVersionLinkProps = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, "href"> & {
   children: ReactNode;
   docsPath?: string;
+  preload?: "intent" | false;
 };
 
-export function DocsVersionLink({ children, docsPath = "/docs", ...props }: DocsVersionLinkProps) {
+export function DocsVersionLink({
+  children,
+  docsPath = "/docs",
+  preload = "intent",
+  ...props
+}: DocsVersionLinkProps) {
   const selectedVersion = useSelectedDocsVersion();
+  const href = getDocsVersionHref(selectedVersion, docsPath);
+  const splat = href.replace(/^\/docs\/?/, "");
 
   return (
-    <a {...props} href={getDocsVersionHref(selectedVersion, docsPath)}>
+    <Link to="/docs/$" params={{ _splat: splat }} preload={preload} {...props}>
       {children}
-    </a>
+    </Link>
   );
 }

--- a/apps/fumadocs/src/components/mdx.tsx
+++ b/apps/fumadocs/src/components/mdx.tsx
@@ -4,9 +4,35 @@ import type { MDXComponents } from "mdx/types";
 import { CommunityPluginRegistry } from "./community-plugin-registry";
 import { ProviderBadge, ProviderGrid } from "./provider-catalog";
 
-export function getMDXComponents(components?: MDXComponents) {
+type MdxComponentOptions = {
+  docsBasePath?: string;
+};
+
+function versionDocsHref(href: unknown, docsBasePath: string) {
+  if (typeof href !== "string" || docsBasePath === "/docs") return href;
+  if (href === "/docs") return docsBasePath;
+  if (href.startsWith("/docs/")) return `${docsBasePath}${href.slice("/docs".length)}`;
+
+  return href;
+}
+
+export function getMDXComponents(components?: MDXComponents, options: MdxComponentOptions = {}) {
+  const docsBasePath = options.docsBasePath ?? "/docs";
+
   return {
     ...defaultMdxComponents,
+    a: (props) => (
+      <defaultMdxComponents.a
+        {...props}
+        href={versionDocsHref(props.href, docsBasePath) as string}
+      />
+    ),
+    Card: (props) => (
+      <defaultMdxComponents.Card
+        {...props}
+        href={versionDocsHref(props.href, docsBasePath) as string}
+      />
+    ),
     CommunityPluginRegistry,
     ProviderBadge,
     ProviderGrid,

--- a/apps/fumadocs/src/components/provider-catalog.tsx
+++ b/apps/fumadocs/src/components/provider-catalog.tsx
@@ -1,6 +1,6 @@
-import { Link } from "@tanstack/react-router";
 import { ExternalLink } from "lucide-react";
 
+import { DocsVersionLink } from "@/components/docs-version-link";
 import { providers } from "@/lib/providers";
 
 export function ProviderGrid() {
@@ -20,14 +20,12 @@ export function ProviderGrid() {
           </div>
           <code className="mt-3 block text-xs text-fd-muted-foreground">{provider.importPath}</code>
           <div className="mt-4 flex items-center gap-2">
-            <Link
+            <DocsVersionLink
               className="inline-flex h-8 items-center justify-center rounded-md border border-fd-border px-3 text-xs font-medium transition hover:bg-fd-accent"
-              params={{ _splat: provider.docs.replace("/docs/", "") }}
-              preload="intent"
-              to="/docs/$"
+              docsPath={provider.docs}
             >
               Docs
-            </Link>
+            </DocsVersionLink>
             <a
               className="inline-flex h-8 items-center justify-center gap-1.5 rounded-md border border-fd-border px-3 text-xs font-medium transition hover:bg-fd-accent"
               href={provider.website}

--- a/apps/fumadocs/src/components/version-picker.tsx
+++ b/apps/fumadocs/src/components/version-picker.tsx
@@ -1,75 +1,75 @@
 import { Check, ChevronDown, ExternalLink, PackageCheck } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
+import { Popover, PopoverContent, PopoverTrigger } from "fumadocs-ui/components/ui/popover";
+import { usePathname } from "fumadocs-core/framework";
 
-import { docsVersion, docsVersions, sdkPackageName, versionLinks } from "@/lib/versions";
+import { rememberDocsVersion, useSelectedDocsVersion } from "@/lib/docs-version-state";
+import { docsVersions, getDocsVersionHref, getVersionLinks, sdkPackageName } from "@/lib/versions";
 
-export function VersionPicker() {
+type VersionPickerProps = {
+  variant?: "nav" | "sidebar";
+};
+
+export function VersionPicker({ variant = "nav" }: VersionPickerProps) {
   const [open, setOpen] = useState(false);
-  const detailsRef = useRef<HTMLDetailsElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    function handlePointerDown(event: PointerEvent) {
-      if (!detailsRef.current?.contains(event.target as Node)) {
-        setOpen(false);
-      }
-    }
-
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setOpen(false);
-      }
-    }
-
-    document.addEventListener("pointerdown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-
-    return () => {
-      document.removeEventListener("pointerdown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [open]);
+  const pathname = usePathname();
+  const currentVersion = useSelectedDocsVersion();
+  const isSidebar = variant === "sidebar";
+  const versionLinks = getVersionLinks(currentVersion);
 
   return (
-    <details
-      className="group/version relative block"
-      onToggle={(event) => {
-        setOpen(event.currentTarget.open);
-      }}
-      open={open}
-      ref={detailsRef}
-    >
-      <summary className="flex h-9 cursor-pointer list-none items-center gap-2 rounded-md border border-fd-border bg-fd-background px-3 text-sm font-medium text-fd-foreground transition hover:bg-fd-accent [&::-webkit-details-marker]:hidden">
+    <Popover onOpenChange={setOpen} open={open}>
+      <PopoverTrigger
+        className={`group/version inline-flex h-9 items-center gap-2 rounded-md border border-fd-border px-3 text-sm font-medium text-fd-foreground transition hover:bg-fd-accent data-[state=open]:bg-fd-accent data-[state=open]:text-fd-accent-foreground ${
+          isSidebar ? "w-full justify-start bg-fd-secondary/50" : "bg-fd-background"
+        }`}
+      >
         <PackageCheck className="size-4 text-fd-muted-foreground" strokeWidth={2} />
-        <span>{docsVersion}</span>
+        <span className="leading-none">{currentVersion.label}</span>
+        {currentVersion.label !== currentVersion.version ? (
+          <span className="rounded-sm bg-fd-muted px-1.5 py-0.5 text-[11px] leading-none text-fd-muted-foreground">
+            {currentVersion.version}
+          </span>
+        ) : null}
         <ChevronDown
-          className="size-3.5 text-fd-muted-foreground transition group-open/version:rotate-180"
+          className={`size-3.5 text-fd-muted-foreground transition group-data-[state=open]/version:rotate-180 ${
+            isSidebar ? "ms-auto" : ""
+          }`}
           strokeWidth={2}
         />
-      </summary>
+      </PopoverTrigger>
 
-      <div className="absolute right-0 z-50 mt-2 w-72 overflow-hidden rounded-lg border border-fd-border bg-fd-popover text-fd-popover-foreground shadow-xl shadow-black/10">
-        <div className="border-b border-fd-border px-3 py-2">
+      <PopoverContent align={isSidebar ? "start" : "end"} className="w-80 p-0">
+        <div className="border-b border-fd-border px-3 py-2.5">
           <p className="text-xs font-medium uppercase text-fd-muted-foreground">Docs version</p>
           <p className="mt-0.5 truncate text-sm">{sdkPackageName}</p>
         </div>
 
-        <div className="p-1.5">
+        <div className="max-h-64 overflow-y-auto p-1.5 fd-scroll-container">
           {docsVersions.map((version) => (
             <a
-              className="flex items-start gap-2 rounded-md px-2 py-2 text-sm transition hover:bg-fd-accent"
-              href={version.href}
+              className="flex items-start gap-2 rounded-md px-2 py-2 text-sm transition hover:bg-fd-accent hover:text-fd-accent-foreground"
+              href={getDocsVersionHref(version, pathname)}
               key={version.label}
               onClick={() => {
+                rememberDocsVersion(version);
                 setOpen(false);
               }}
             >
               <span className="mt-0.5 grid size-4 place-items-center text-fd-primary">
-                {version.current ? <Check className="size-3.5" strokeWidth={2.2} /> : null}
+                {version === currentVersion ? (
+                  <Check className="size-3.5" strokeWidth={2.2} />
+                ) : null}
               </span>
-              <span>
-                <span className="block font-medium">{version.label}</span>
+              <span className="min-w-0 flex-1">
+                <span className="flex items-center gap-2 font-medium">
+                  {version.label}
+                  {version.label !== version.version ? (
+                    <span className="text-xs font-normal text-fd-muted-foreground">
+                      {version.version}
+                    </span>
+                  ) : null}
+                </span>
                 <span className="block text-xs text-fd-muted-foreground">
                   {version.description}
                 </span>
@@ -95,7 +95,7 @@ export function VersionPicker() {
             </a>
           ))}
         </div>
-      </div>
-    </details>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/fumadocs/src/lib/docs-version-state.ts
+++ b/apps/fumadocs/src/lib/docs-version-state.ts
@@ -1,0 +1,67 @@
+import { usePathname } from "fumadocs-core/framework";
+import { useEffect, useState } from "react";
+
+import {
+  type DocsVersion,
+  docsVersionStorageKey,
+  getDocsVersionByStoredValue,
+  getDocsVersionFromPathname,
+  getDocsVersionSlug,
+  latestDocsVersion,
+} from "./versions";
+
+const docsVersionChangeEvent = "email-sdk-docs-version-change";
+
+function getPathnameVersion(pathname: string) {
+  if (!pathname.startsWith("/docs")) return undefined;
+
+  return getDocsVersionFromPathname(pathname);
+}
+
+function readStoredDocsVersion() {
+  if (typeof window === "undefined") return undefined;
+
+  return getDocsVersionByStoredValue(window.localStorage.getItem(docsVersionStorageKey));
+}
+
+export function rememberDocsVersion(version: DocsVersion) {
+  if (typeof window === "undefined") return;
+
+  window.localStorage.setItem(docsVersionStorageKey, getDocsVersionSlug(version));
+  window.dispatchEvent(new CustomEvent(docsVersionChangeEvent));
+}
+
+export function useSelectedDocsVersion() {
+  const pathname = usePathname();
+  const [selectedVersion, setSelectedVersion] = useState(
+    () => getPathnameVersion(pathname) ?? latestDocsVersion,
+  );
+
+  useEffect(() => {
+    const pathnameVersion = getPathnameVersion(pathname);
+
+    if (pathnameVersion) {
+      rememberDocsVersion(pathnameVersion);
+      setSelectedVersion(pathnameVersion);
+      return;
+    }
+
+    setSelectedVersion(readStoredDocsVersion() ?? latestDocsVersion);
+  }, [pathname]);
+
+  useEffect(() => {
+    function syncStoredVersion() {
+      setSelectedVersion(readStoredDocsVersion() ?? latestDocsVersion);
+    }
+
+    window.addEventListener("storage", syncStoredVersion);
+    window.addEventListener(docsVersionChangeEvent, syncStoredVersion);
+
+    return () => {
+      window.removeEventListener("storage", syncStoredVersion);
+      window.removeEventListener(docsVersionChangeEvent, syncStoredVersion);
+    };
+  }, []);
+
+  return selectedVersion;
+}

--- a/apps/fumadocs/src/lib/layout.shared.tsx
+++ b/apps/fumadocs/src/lib/layout.shared.tsx
@@ -4,7 +4,11 @@ import { VersionPicker } from "@/components/version-picker";
 
 import { appName, gitConfig } from "./shared";
 
-export function baseOptions(): BaseLayoutProps {
+type BaseOptionsConfig = {
+  versionPicker?: boolean;
+};
+
+export function baseOptions({ versionPicker = true }: BaseOptionsConfig = {}): BaseLayoutProps {
   return {
     nav: {
       title: (
@@ -13,8 +17,16 @@ export function baseOptions(): BaseLayoutProps {
           <span>{appName}</span>
         </span>
       ),
-      children: <VersionPicker />,
     },
+    links: versionPicker
+      ? [
+          {
+            type: "custom",
+            secondary: true,
+            children: <VersionPicker />,
+          },
+        ]
+      : undefined,
     githubUrl: `https://github.com/${gitConfig.user}/${gitConfig.repo}`,
   };
 }

--- a/apps/fumadocs/src/lib/source.ts
+++ b/apps/fumadocs/src/lib/source.ts
@@ -1,14 +1,43 @@
-import { docs } from "collections/server";
+import { docs, docsV020, docsV021 } from "collections/server";
 import { loader } from "fumadocs-core/source";
 
 import { resolveDocsIcon } from "./docs-icons";
 import { docsRoute } from "./shared";
+import { type DocsVersion, docsVersions, getDocsVersionBase, latestDocsVersion } from "./versions";
 
-export const source = loader({
-  source: docs.toFumadocsSource(),
-  baseUrl: docsRoute,
-  icon: resolveDocsIcon,
-});
+const v020DocsVersion = docsVersions.find((version) => version.collection === "docsV020");
+if (!v020DocsVersion) {
+  throw new Error("Missing docs source config for v0.2.0");
+}
+
+const v021DocsVersion = docsVersions.find((version) => version.collection === "docsV021");
+if (!v021DocsVersion) {
+  throw new Error("Missing docs source config for v0.2.1");
+}
+
+const sources = {
+  docs: loader({
+    source: docs.toFumadocsSource(),
+    baseUrl: docsRoute,
+    icon: resolveDocsIcon,
+  }),
+  docsV021: loader({
+    source: docsV021.toFumadocsSource(),
+    baseUrl: getDocsVersionBase(v021DocsVersion),
+    icon: resolveDocsIcon,
+  }),
+  docsV020: loader({
+    source: docsV020.toFumadocsSource(),
+    baseUrl: getDocsVersionBase(v020DocsVersion),
+    icon: resolveDocsIcon,
+  }),
+};
+
+export const source = sources[latestDocsVersion.collection];
+
+export function getDocsSource(version: DocsVersion) {
+  return sources[version.collection];
+}
 
 export function markdownPathToSlugs(segs: string[]) {
   if (segs.length === 0) return [];
@@ -19,7 +48,7 @@ export function markdownPathToSlugs(segs: string[]) {
   return out;
 }
 
-export function slugsToMarkdownPath(slugs: string[]) {
+export function slugsToMarkdownPath(slugs: string[], version: DocsVersion = latestDocsVersion) {
   const segments = [...slugs];
   if (segments.length === 0) {
     segments.push("index.md");
@@ -29,7 +58,7 @@ export function slugsToMarkdownPath(slugs: string[]) {
 
   return {
     segments,
-    url: `${docsRoute}/${segments.join("/")}`,
+    url: `${getDocsVersionBase(version)}/${segments.join("/")}`,
   };
 }
 
@@ -47,8 +76,14 @@ export function getPageMarkdownUrl(slugs: string[]) {
   };
 }
 
-export async function getLLMText(page: (typeof source)["$inferPage"]) {
-  const processed = await page.data.getText("processed");
+export async function getLLMText(
+  page: (typeof source)["$inferPage"],
+  version: DocsVersion = latestDocsVersion,
+) {
+  const docsBasePath = getDocsVersionBase(version);
+  const processed = (await page.data.getText("processed"))
+    .replaceAll("](/docs/", `](${docsBasePath}/`)
+    .replaceAll('href="/docs/', `href="${docsBasePath}/`);
 
   return `# ${page.data.title} (${page.url})
 

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -1,7 +1,8 @@
 import emailSdkPackage from "../../../../packages/email-sdk/package.json";
 
 export const sdkPackageName = emailSdkPackage.name;
-export const latestPublishedVersion = "0.3.0";
+export const publishedDocsVersions = ["0.2.0", "0.2.1", "0.3.0"] as const;
+export const latestPublishedVersion = publishedDocsVersions[publishedDocsVersions.length - 1];
 export const docsVersion = `v${latestPublishedVersion}`;
 export const docsVersionRoutePrefix = "v";
 export const docsVersionStorageKey = "email-sdk-docs-version";
@@ -60,9 +61,7 @@ export function getDocsVersionSlug(version: DocsVersion) {
 }
 
 export function getDocsVersionBase(version: DocsVersion) {
-  if (version.current) return "/docs";
-
-  return `/docs/${docsVersionRoutePrefix}/${getDocsVersionSlug(version)}`;
+  return version.href;
 }
 
 export function resolveDocsVersionedSlugs(slugs: string[]) {
@@ -77,7 +76,7 @@ export function resolveDocsVersionedSlugs(slugs: string[]) {
   if (!version) {
     return {
       version: latestDocsVersion,
-      slugs,
+      slugs: slugs.slice(2),
     };
   }
 

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -1,25 +1,130 @@
 import emailSdkPackage from "../../../../packages/email-sdk/package.json";
 
 export const sdkPackageName = emailSdkPackage.name;
-export const sdkVersion = emailSdkPackage.version;
-export const docsVersion = `v${sdkVersion}`;
+export const latestPublishedVersion = "0.3.0";
+export const docsVersion = `v${latestPublishedVersion}`;
+export const docsVersionRoutePrefix = "v";
+export const docsVersionStorageKey = "email-sdk-docs-version";
 
 export const docsVersions = [
   {
-    label: docsVersion,
+    label: "latest",
+    version: docsVersion,
     description: "Current SDK, CLI, and docs",
     href: "/docs",
+    collection: "docs",
+    contentPath: "content/docs",
     current: true,
+    external: false,
+  },
+  {
+    label: "v0.2.1",
+    version: "v0.2.1",
+    description: "Docs for the pre-plugin public package",
+    href: "/docs/v/0.2.1",
+    collection: "docsV021",
+    contentPath: "content/docs-v/0.2.1",
+    current: false,
+    external: false,
+  },
+  {
+    label: "v0.2.0",
+    version: "v0.2.0",
+    description: "Package docs for the first public scoped release",
+    href: "/docs/v/0.2.0",
+    collection: "docsV020",
+    contentPath: "content/docs-v/0.2.0",
+    current: false,
+    external: false,
   },
 ] as const;
 
-export const versionLinks = [
-  {
-    label: "npm package",
-    href: `https://www.npmjs.com/package/${sdkPackageName}/v/${sdkVersion}`,
-  },
-  {
-    label: "Changelog",
-    href: "https://github.com/opencoredev/email-sdk/blob/main/packages/email-sdk/CHANGELOG.md",
-  },
-] as const;
+export type DocsVersion = (typeof docsVersions)[number];
+
+export const latestDocsVersion = docsVersions[0];
+
+export type DocsVersionCollection = DocsVersion["collection"];
+
+export function getDocsVersionBySlug(slug: string) {
+  return docsVersions.find((version) => getDocsVersionSlug(version) === slug);
+}
+
+export function getDocsVersionByStoredValue(value: string | null | undefined) {
+  if (!value) return undefined;
+
+  return getDocsVersionBySlug(value.replace(/^v/, ""));
+}
+
+export function getDocsVersionSlug(version: DocsVersion) {
+  return version.version.replace(/^v/, "");
+}
+
+export function getDocsVersionBase(version: DocsVersion) {
+  if (version.current) return "/docs";
+
+  return `/docs/${docsVersionRoutePrefix}/${getDocsVersionSlug(version)}`;
+}
+
+export function resolveDocsVersionedSlugs(slugs: string[]) {
+  if (slugs[0] !== docsVersionRoutePrefix || !slugs[1]) {
+    return {
+      version: latestDocsVersion,
+      slugs,
+    };
+  }
+
+  const version = getDocsVersionBySlug(slugs[1]);
+  if (!version) {
+    return {
+      version: latestDocsVersion,
+      slugs,
+    };
+  }
+
+  return {
+    version,
+    slugs: slugs.slice(2),
+  };
+}
+
+export function getDocsVersionHref(version: DocsVersion, pathname = "/docs") {
+  const cleanPathname = pathname.split(/[?#]/, 1)[0] ?? "/docs";
+  const docsPath = cleanPathname.startsWith("/docs") ? cleanPathname : "/docs";
+  const slugs = docsPath
+    .replace(/^\/docs\/?/, "")
+    .split("/")
+    .filter(Boolean);
+  const resolved = resolveDocsVersionedSlugs(slugs);
+  const pageSlugs = resolved.slugs.join("/");
+
+  if (version.current) {
+    return pageSlugs ? `/docs/${pageSlugs}` : "/docs";
+  }
+
+  const versionBase = getDocsVersionBase(version);
+  return pageSlugs ? `${versionBase}/${pageSlugs}` : versionBase;
+}
+
+export function getDocsVersionFromPathname(pathname: string) {
+  const slugs = pathname
+    .replace(/^\/docs\/?/, "")
+    .split("/")
+    .filter(Boolean);
+
+  return resolveDocsVersionedSlugs(slugs).version;
+}
+
+export function getVersionLinks(version: DocsVersion) {
+  return [
+    {
+      label: "npm package",
+      href: `https://www.npmjs.com/package/${sdkPackageName}/v/${getDocsVersionSlug(version)}`,
+    },
+    {
+      label: "Changelog",
+      href: "https://github.com/opencoredev/email-sdk/blob/main/packages/email-sdk/CHANGELOG.md",
+    },
+  ] as const;
+}
+
+export const versionLinks = getVersionLinks(latestDocsVersion);

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -1,6 +1,9 @@
 import emailSdkPackage from "../../../../packages/email-sdk/package.json";
 
 export const sdkPackageName = emailSdkPackage.name;
+// Keep this in sync with the npm-published versions that have matching docs archives.
+// It is intentionally decoupled from package.json because the workspace version can
+// lag or lead the live docs during Changesets release flows.
 export const publishedDocsVersions = ["0.2.0", "0.2.1", "0.3.0"] as const;
 export const latestPublishedVersion = publishedDocsVersions[publishedDocsVersions.length - 1];
 export const docsVersion = `v${latestPublishedVersion}`;

--- a/apps/fumadocs/src/routes/docs/$.tsx
+++ b/apps/fumadocs/src/routes/docs/$.tsx
@@ -14,15 +14,25 @@ import {
 } from "fumadocs-ui/layouts/docs/page";
 
 import { useMDXComponents } from "@/components/mdx";
+import { VersionPicker } from "@/components/version-picker";
 import { baseOptions } from "@/lib/layout.shared";
 import { appName, gitConfig } from "@/lib/shared";
-import { slugsToMarkdownPath, source } from "@/lib/source";
+import { getDocsSource, slugsToMarkdownPath, source } from "@/lib/source";
+import {
+  type DocsVersionCollection,
+  getDocsVersionBase,
+  getDocsVersionHref,
+  resolveDocsVersionedSlugs,
+} from "@/lib/versions";
 
 type DocsLoaderData = {
   title: string;
   description?: string;
   path: string;
   markdownUrl: string;
+  versionCollection: DocsVersionCollection;
+  contentPath: string;
+  docsBasePath: string;
   pageTree: Awaited<ReturnType<typeof source.serializePageTree>>;
 };
 
@@ -45,9 +55,9 @@ export const Route = createFileRoute("/docs/$")({
   },
   component: Page,
   loader: async ({ params }) => {
-    const slugs = params._splat?.split("/") ?? [];
+    const slugs = params._splat?.split("/").filter(Boolean) ?? [];
     const data = await loader({ data: slugs });
-    await clientLoader.preload(data.path);
+    await getClientLoader(data.versionCollection).preload(data.path);
     return data;
   },
 });
@@ -58,58 +68,114 @@ const loader = createServerFn({
   .inputValidator((slugs: string[]) => slugs)
   .middleware([staticFunctionMiddleware])
   .handler(async ({ data: slugs }) => {
-    const page = source.getPage(slugs);
+    const resolved = resolveDocsVersionedSlugs(slugs);
+    const docsSource = getDocsSource(resolved.version);
+    const page = docsSource.getPage(resolved.slugs);
     if (!page) throw notFound();
+    const rawPageTree = await docsSource.serializePageTree(docsSource.getPageTree());
 
     return {
       title: page.data.title,
       description: page.data.description,
       path: page.path,
-      markdownUrl: slugsToMarkdownPath(page.slugs).url,
-      pageTree: await source.serializePageTree(source.getPageTree()),
+      markdownUrl: slugsToMarkdownPath(page.slugs, resolved.version).url,
+      versionCollection: resolved.version.collection,
+      contentPath: resolved.version.contentPath,
+      docsBasePath: getDocsVersionBase(resolved.version),
+      pageTree: withVersionedTreeUrls(rawPageTree, resolved.version),
     };
   });
 
-const clientLoader = browserCollections.docs.createClientLoader({
-  component(
-    { toc, frontmatter, default: MDX },
-    // you can define props for the component
-    {
-      markdownUrl,
-      path,
-    }: {
-      markdownUrl: string;
-      path: string;
+function withVersionedTreeUrls<T>(tree: T, version: Parameters<typeof getDocsVersionHref>[0]): T {
+  if (Array.isArray(tree)) {
+    return tree.map((item) => withVersionedTreeUrls(item, version)) as T;
+  }
+
+  if (!tree || typeof tree !== "object") {
+    return tree;
+  }
+
+  const next = { ...tree } as Record<string, unknown>;
+
+  if (typeof next.url === "string") {
+    next.url = getDocsVersionHref(version, next.url);
+  }
+
+  for (const [key, value] of Object.entries(next)) {
+    if (key !== "url" && value && typeof value === "object") {
+      next[key] = withVersionedTreeUrls(value, version);
+    }
+  }
+
+  return next as T;
+}
+
+function createDocsClientLoader(collection: (typeof browserCollections)[DocsVersionCollection]) {
+  return collection.createClientLoader({
+    component(
+      { toc, frontmatter, default: MDX },
+      // you can define props for the component
+      {
+        contentPath,
+        docsBasePath,
+        markdownUrl,
+        path,
+      }: {
+        contentPath: string;
+        docsBasePath: string;
+        markdownUrl: string;
+        path: string;
+      },
+    ) {
+      return (
+        <DocsPage toc={toc}>
+          <DocsTitle>{frontmatter.title}</DocsTitle>
+          <DocsDescription>{frontmatter.description}</DocsDescription>
+          <div className="flex flex-row gap-2 items-center border-b -mt-4 pb-6">
+            <MarkdownCopyButton markdownUrl={markdownUrl} />
+            <ViewOptionsPopover
+              markdownUrl={markdownUrl}
+              githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/${contentPath}/${path}`}
+            />
+          </div>
+          <DocsBody>
+            <MDX components={useMDXComponents(undefined, { docsBasePath })} />
+          </DocsBody>
+        </DocsPage>
+      );
     },
-  ) {
-    return (
-      <DocsPage toc={toc}>
-        <DocsTitle>{frontmatter.title}</DocsTitle>
-        <DocsDescription>{frontmatter.description}</DocsDescription>
-        <div className="flex flex-row gap-2 items-center border-b -mt-4 pb-6">
-          <MarkdownCopyButton markdownUrl={markdownUrl} />
-          <ViewOptionsPopover
-            markdownUrl={markdownUrl}
-            githubUrl={`https://github.com/${gitConfig.user}/${gitConfig.repo}/blob/${gitConfig.branch}/content/docs/${path}`}
-          />
-        </div>
-        <DocsBody>
-          <MDX components={useMDXComponents()} />
-        </DocsBody>
-      </DocsPage>
-    );
-  },
-});
+  });
+}
+
+const clientLoaders = {
+  docs: createDocsClientLoader(browserCollections.docs),
+  docsV021: createDocsClientLoader(browserCollections.docsV021),
+  docsV020: createDocsClientLoader(browserCollections.docsV020),
+};
+
+function getClientLoader(collection: DocsVersionCollection) {
+  return clientLoaders[collection];
+}
 
 function Page() {
-  const { pageTree, path, markdownUrl } = useFumadocsLoader(
-    Route.useLoaderData() as DocsLoaderData,
-  );
+  const { contentPath, docsBasePath, markdownUrl, pageTree, path, versionCollection } =
+    useFumadocsLoader(Route.useLoaderData() as DocsLoaderData);
+  const contentLoader = getClientLoader(versionCollection);
 
   return (
-    <DocsLayout {...baseOptions()} tree={pageTree}>
+    <DocsLayout
+      {...baseOptions({ versionPicker: false })}
+      sidebar={{
+        footer: (
+          <div className="mt-2">
+            <VersionPicker variant="sidebar" />
+          </div>
+        ),
+      }}
+      tree={pageTree}
+    >
       <Link to={markdownUrl} hidden />
-      {clientLoader.useContent(path, { markdownUrl, path })}
+      {contentLoader.useContent(path, { contentPath, docsBasePath, markdownUrl, path })}
     </DocsLayout>
   );
 }

--- a/apps/fumadocs/src/routes/docs/$.tsx
+++ b/apps/fumadocs/src/routes/docs/$.tsx
@@ -21,7 +21,6 @@ import { getDocsSource, slugsToMarkdownPath, source } from "@/lib/source";
 import {
   type DocsVersionCollection,
   getDocsVersionBase,
-  getDocsVersionHref,
   resolveDocsVersionedSlugs,
 } from "@/lib/versions";
 
@@ -72,7 +71,6 @@ const loader = createServerFn({
     const docsSource = getDocsSource(resolved.version);
     const page = docsSource.getPage(resolved.slugs);
     if (!page) throw notFound();
-    const rawPageTree = await docsSource.serializePageTree(docsSource.getPageTree());
 
     return {
       title: page.data.title,
@@ -82,33 +80,9 @@ const loader = createServerFn({
       versionCollection: resolved.version.collection,
       contentPath: resolved.version.contentPath,
       docsBasePath: getDocsVersionBase(resolved.version),
-      pageTree: withVersionedTreeUrls(rawPageTree, resolved.version),
+      pageTree: await docsSource.serializePageTree(docsSource.getPageTree()),
     };
   });
-
-function withVersionedTreeUrls<T>(tree: T, version: Parameters<typeof getDocsVersionHref>[0]): T {
-  if (Array.isArray(tree)) {
-    return tree.map((item) => withVersionedTreeUrls(item, version)) as T;
-  }
-
-  if (!tree || typeof tree !== "object") {
-    return tree;
-  }
-
-  const next = { ...tree } as Record<string, unknown>;
-
-  if (typeof next.url === "string") {
-    next.url = getDocsVersionHref(version, next.url);
-  }
-
-  for (const [key, value] of Object.entries(next)) {
-    if (key !== "url" && value && typeof value === "object") {
-      next[key] = withVersionedTreeUrls(value, version);
-    }
-  }
-
-  return next as T;
-}
 
 function createDocsClientLoader(collection: (typeof browserCollections)[DocsVersionCollection]) {
   return collection.createClientLoader({

--- a/apps/fumadocs/src/routes/docs/{$}[.]md.ts
+++ b/apps/fumadocs/src/routes/docs/{$}[.]md.ts
@@ -1,16 +1,18 @@
 import { createFileRoute, notFound } from "@tanstack/react-router";
 
-import { getLLMText, markdownPathToSlugs, source } from "@/lib/source";
+import { getDocsSource, getLLMText, markdownPathToSlugs } from "@/lib/source";
+import { resolveDocsVersionedSlugs } from "@/lib/versions";
 
 export const Route = createFileRoute("/docs/{$}.md")({
   server: {
     handlers: {
       GET: async ({ params }) => {
         const slugs = markdownPathToSlugs(params._splat?.split("/") ?? []);
-        const page = source.getPage(slugs);
+        const resolved = resolveDocsVersionedSlugs(slugs);
+        const page = getDocsSource(resolved.version).getPage(resolved.slugs);
         if (!page) throw notFound();
 
-        return new Response(await getLLMText(page), {
+        return new Response(await getLLMText(page, resolved.version), {
           headers: {
             "Content-Type": "text/markdown",
           },

--- a/apps/fumadocs/src/routes/index.tsx
+++ b/apps/fumadocs/src/routes/index.tsx
@@ -1,9 +1,10 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import { ArrowRight, Check, Copy, Terminal } from "lucide-react";
 import type { ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 
+import { DocsVersionLink } from "@/components/docs-version-link";
 import { baseOptions } from "@/lib/layout.shared";
 
 export const Route = createFileRoute("/")({
@@ -52,25 +53,16 @@ function Home() {
             </p>
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-              <Link
-                className="inline-flex h-11 items-center justify-center gap-2 rounded-md bg-fd-primary px-4 text-sm font-medium text-fd-primary-foreground transition hover:opacity-90"
-                params={{
-                  _splat: "",
-                }}
-                to="/docs/$"
-              >
+              <DocsVersionLink className="inline-flex h-11 items-center justify-center gap-2 rounded-md bg-fd-primary px-4 text-sm font-medium text-fd-primary-foreground transition hover:opacity-90">
                 Read the docs
                 <ArrowRight className="size-4" strokeWidth={2} />
-              </Link>
-              <Link
+              </DocsVersionLink>
+              <DocsVersionLink
                 className="inline-flex h-11 items-center justify-center gap-2 rounded-md border border-fd-border bg-fd-card px-4 text-sm font-medium text-fd-foreground transition hover:bg-fd-accent"
-                params={{
-                  _splat: "adapters",
-                }}
-                to="/docs/$"
+                docsPath="/docs/adapters"
               >
                 Browse adapters
-              </Link>
+              </DocsVersionLink>
             </div>
 
             <div className="mt-10 divide-y divide-fd-border/80 border-y border-fd-border/80 text-sm">

--- a/apps/fumadocs/src/routes/llms-full[.]txt.ts
+++ b/apps/fumadocs/src/routes/llms-full[.]txt.ts
@@ -6,7 +6,7 @@ export const Route = createFileRoute("/llms-full.txt")({
   server: {
     handlers: {
       GET: async () => {
-        const scan = source.getPages().map(getLLMText);
+        const scan = source.getPages().map((page) => getLLMText(page));
         const scanned = await Promise.all(scan);
         return new Response(scanned.join("\n\n"));
       },

--- a/apps/fumadocs/vite.config.ts
+++ b/apps/fumadocs/vite.config.ts
@@ -1,3 +1,6 @@
+import { readdirSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackStart } from "@tanstack/react-start/plugin/vite";
 import react from "@vitejs/plugin-react";
@@ -7,11 +10,46 @@ import { defineConfig } from "vite";
 
 import { docsVersions, getDocsVersionHref } from "./src/lib/versions";
 
-const versionedDocsPages = docsVersions
-  .filter((version) => !version.current)
-  .map((version) => ({
-    path: getDocsVersionHref(version),
+function collectContentPages(dir: string) {
+  const pages: string[] = [];
+
+  function walk(currentDir: string) {
+    for (const entry of readdirSync(currentDir)) {
+      const fullPath = join(currentDir, entry);
+      const stat = statSync(fullPath);
+
+      if (stat.isDirectory()) {
+        walk(fullPath);
+        continue;
+      }
+
+      if (!entry.endsWith(".mdx")) continue;
+
+      const pagePath = relative(dir, fullPath)
+        .replace(/\.mdx$/, "")
+        .split(sep)
+        .filter((part) => part !== "index")
+        .join("/");
+
+      pages.push(pagePath ? `/docs/${pagePath}` : "/docs");
+    }
+  }
+
+  walk(dir);
+
+  return pages;
+}
+
+const versionedDocsPages = docsVersions.flatMap((version) => {
+  if (version.current) return [];
+
+  const contentDir = join(import.meta.dirname, version.contentPath);
+  const pages = collectContentPages(contentDir);
+
+  return pages.map((path) => ({
+    path: getDocsVersionHref(version, path),
   }));
+});
 
 export default defineConfig({
   server: {

--- a/apps/fumadocs/vite.config.ts
+++ b/apps/fumadocs/vite.config.ts
@@ -5,6 +5,14 @@ import mdx from "fumadocs-mdx/vite";
 import { nitro } from "nitro/vite";
 import { defineConfig } from "vite";
 
+import { docsVersions, getDocsVersionHref } from "./src/lib/versions";
+
+const versionedDocsPages = docsVersions
+  .filter((version) => !version.current)
+  .map((version) => ({
+    path: getDocsVersionHref(version),
+  }));
+
 export default defineConfig({
   server: {
     port: 3000,
@@ -25,6 +33,7 @@ export default defineConfig({
         {
           path: "/docs",
         },
+        ...versionedDocsPages,
         {
           path: "/api/search",
         },


### PR DESCRIPTION
## Summary
- Adds versioned Fumadocs content for `0.2.0` and `0.2.1`, including adapters, concepts, reference pages, and getting started material.
- Expands the main docs IA with new guides, plugins documentation, community registry pages, and updated landing/reference navigation.
- Adds docs infrastructure updates for version-aware routing, version picker behavior, and community plugin registry rendering.
- Refreshes existing docs pages to align with the new versioned structure and link flow.

## Testing
- Not run (docs/content and routing changes only).
- Not run: build or typecheck.
- Not run: local Fumadocs preview.