### PR TITLE
feat: add cloudflare email sending adapter

### DIFF
--- a/.changeset/good-clouds-send.md
+++ b/.changeset/good-clouds-send.md
@@ -1,0 +1,5 @@
+---
+"@opencoredev/email-sdk": minor
+---
+
+Add a Cloudflare Email Sending adapter for the REST API, including the SDK subpath export, CLI adapter support, payload tests, and docs.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ See [packages/email-sdk/README.md](packages/email-sdk/README.md) for SDK usage e
 
 ## Adapter Entry Points
 
-`resend`, `postmark`, `sendgrid`, `mailgun`, `mailersend`, `brevo`, `mailchimp`, `sparkpost`, `loops`, `plunk`, `mailtrap`, `scaleway`, `zeptomail`, `mailpace`, `smtp`, and `testing` are exported from separate package entry points.
+`resend`, `postmark`, `sendgrid`, `mailgun`, `mailersend`, `brevo`, `mailchimp`, `sparkpost`, `loops`, `plunk`, `mailtrap`, `cloudflare`, `scaleway`, `zeptomail`, `mailpace`, `smtp`, and `testing` are exported from separate package entry points.
 
-If you are choosing your first adapter, start with Resend for the shortest path to a first send. Use Postmark, SendGrid, AWS SES, Mailgun, or Brevo when you need broader provider-specific controls. Use SMTP when you already have a trusted SMTP service and only need address fields, headers, and plain message delivery.
+If you are choosing your first adapter, start with Resend for the shortest path to a first send. Use Postmark, SendGrid, AWS SES, Mailgun, Cloudflare, or Brevo when you need broader provider-specific controls. Use SMTP when you already have a trusted SMTP service and only need address fields, headers, and plain message delivery.
 
 Plugin entry points:
 

--- a/apps/fumadocs/content/docs/adapters/meta.json
+++ b/apps/fumadocs/content/docs/adapters/meta.json
@@ -17,6 +17,7 @@
     "loops",
     "plunk",
     "mailtrap",
+    "cloudflare",
     "scaleway",
     "zeptomail",
     "mailpace",

--- a/apps/fumadocs/src/lib/metadata.ts
+++ b/apps/fumadocs/src/lib/metadata.ts
@@ -5,7 +5,7 @@ import { appDescription, appName, siteOgImageUrl, siteUrl } from "@/lib/shared";
 export const siteTitle = `${appName} - TypeScript email SDK for every provider`;
 export const siteImageAlt = "Email SDK unified email sending preview";
 export const siteKeywords =
-  "email SDK, TypeScript email SDK, transactional email SDK, unified email API, Resend SDK, SendGrid SDK, Postmark SDK, Mailgun SDK, AWS SES SDK, SMTP TypeScript";
+  "email SDK, TypeScript email SDK, transactional email SDK, unified email API, Resend SDK, SendGrid SDK, Postmark SDK, Mailgun SDK, AWS SES SDK, Cloudflare Email Sending SDK, SMTP TypeScript";
 
 export const siteMeta = [
   {
@@ -141,7 +141,7 @@ export const homeStructuredData = {
           name: "What is Email SDK?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Email SDK is a TypeScript email SDK that gives applications one typed client and one message shape for sending transactional email through providers such as Resend, SMTP, Postmark, SendGrid, Mailgun, and AWS SES.",
+            text: "Email SDK is a TypeScript email SDK that gives applications one typed client and one message shape for sending transactional email through providers such as Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare, and AWS SES.",
           },
         },
         {
@@ -149,7 +149,7 @@ export const homeStructuredData = {
           name: "Which email providers does Email SDK support?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Email SDK supports adapters for Resend, SMTP, Postmark, SendGrid, Mailgun, AWS SES, MailerSend, Brevo, Mailchimp Transactional, SparkPost, Loops, Plunk, Mailtrap, Scaleway, ZeptoMail, and MailPace.",
+            text: "Email SDK supports adapters for Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare Email Sending, AWS SES, MailerSend, Brevo, Mailchimp Transactional, SparkPost, Loops, Plunk, Mailtrap, Scaleway, ZeptoMail, and MailPace.",
           },
         },
         {

--- a/apps/fumadocs/src/lib/providers.ts
+++ b/apps/fumadocs/src/lib/providers.ts
@@ -130,6 +130,18 @@ export const providers = [
     liveStatus: "Live account required",
   },
   {
+    name: "Cloudflare Email Sending",
+    key: "cloudflare",
+    importPath: "@opencoredev/email-sdk/cloudflare",
+    docs: "/docs/adapters/cloudflare",
+    website: "https://developers.cloudflare.com/email-service/",
+    logo: "https://cdn.simpleicons.org/cloudflare",
+    category: "Infrastructure",
+    status: "Official",
+    testStatus: "Payload-tested",
+    liveStatus: "Live account required",
+  },
+  {
     name: "Scaleway",
     key: "scaleway",
     importPath: "@opencoredev/email-sdk/scaleway",

--- a/apps/fumadocs/src/routes/index.tsx
+++ b/apps/fumadocs/src/routes/index.tsx
@@ -339,7 +339,9 @@ function copyWithTextarea(text: string) {
   } catch {
     return false;
   } finally {
-    document.body.removeChild(textarea);
+    if (textarea.parentNode) {
+      textarea.parentNode.removeChild(textarea);
+    }
   }
 }
 

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -53,7 +53,7 @@ await email.send({
 
 Each adapter is exported from its own entry point so apps only import what they use.
 
-If you are choosing a first adapter, start with Resend for the shortest setup path. Use Postmark, SendGrid, AWS SES, Mailgun, or Brevo when your app needs broader provider-specific controls. Use SMTP when you already have a trusted SMTP service and only need address fields, headers, and plain message delivery.
+If you are choosing a first adapter, start with Resend for the shortest setup path. Use Postmark, SendGrid, AWS SES, Mailgun, Cloudflare, or Brevo when your app needs broader provider-specific controls. Use SMTP when you already have a trusted SMTP service and only need address fields, headers, and plain message delivery.
 
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -87,6 +87,7 @@ Available adapter entry points:
 | `@opencoredev/email-sdk/loops`      | Loops                            |
 | `@opencoredev/email-sdk/plunk`      | Plunk                            |
 | `@opencoredev/email-sdk/mailtrap`   | Mailtrap                         |
+| `@opencoredev/email-sdk/cloudflare` | Cloudflare Email Sending         |
 | `@opencoredev/email-sdk/scaleway`   | Scaleway                         |
 | `@opencoredev/email-sdk/zeptomail`  | ZeptoMail                        |
 | `@opencoredev/email-sdk/mailpace`   | MailPace                         |

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -212,6 +212,16 @@ describe("provider payloads", () => {
     ).rejects.toThrow("Recipient is not verified.");
   });
 
+  test("Cloudflare rejects unexpected success envelopes", async () => {
+    await expect(
+      cloudflare({
+        apiToken: "cf_token",
+        accountId: "account_123",
+        fetch: jsonCapture({ result: { delivered: ["ada@example.com"] } }).fetch,
+      }).send(cloudflareMessage, context),
+    ).rejects.toThrow("cloudflare failed.");
+  });
+
   test("Cloudflare surfaces HTTP error details", async () => {
     await expect(
       cloudflare({

--- a/packages/email-sdk/src/cloudflare.ts
+++ b/packages/email-sdk/src/cloudflare.ts
@@ -66,7 +66,7 @@ export function cloudflare(
         };
       },
       parseResponse(body) {
-        if (body.success === false) {
+        if (body.success !== true) {
           throw new EmailProviderError(cloudflareErrorMessage(body), {
             provider: "cloudflare",
             retryable: false,


### PR DESCRIPTION
Adds the Cloudflare Email Sending REST API adapter to the SDK, CLI, docs, and changeset metadata. Also hardens the docs clipboard fallback cleanup that could throw removeChild when the textarea was no longer attached.