### PR TITLE
Fix Changesets release PR token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           title: "Version packages"
           commit: "Version packages"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
 
       - name: Update Homebrew formula checksum
         if: steps.changesets.outputs.published == 'true'


### PR DESCRIPTION
## Summary
- Use the repo-scoped CHANGESETS_TOKEN secret for the Changesets action instead of the org-blocked GITHUB_TOKEN path.
- Keeps npm trusted publishing unchanged while allowing future Version packages PRs to be created automatically.

## Testing
- Set CHANGESETS_TOKEN repository secret.
- Verified npm latest is @opencoredev/email-sdk 0.4.0 after the manual Version packages release.