### PR TITLE
fix: show current docs version

### DIFF
--- a/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
@@ -52,7 +52,7 @@ createEmailClient({
     }
   },
   "peerDependencies": {
-    "@opencoredev/email-sdk": "^0.3.0"
+    "@opencoredev/email-sdk": "^0.4.0"
   }
 }
 ```

--- a/apps/fumadocs/content/docs/guides/authoring/publish-community-plugin.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/publish-community-plugin.mdx
@@ -49,7 +49,7 @@ Use `@opencoredev/email-sdk` as a peer dependency.
     }
   },
   "peerDependencies": {
-    "@opencoredev/email-sdk": "^0.3.0"
+    "@opencoredev/email-sdk": "^0.4.0"
   }
 }
 ```

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -1,11 +1,7 @@
 import emailSdkPackage from "../../../../packages/email-sdk/package.json";
 
 export const sdkPackageName = emailSdkPackage.name;
-// Keep this in sync with the npm-published versions that have matching docs archives.
-// It is intentionally decoupled from package.json because the workspace version can
-// lag or lead the live docs during Changesets release flows.
-export const publishedDocsVersions = ["0.2.0", "0.2.1", "0.3.0"] as const;
-export const latestPublishedVersion = publishedDocsVersions[publishedDocsVersions.length - 1];
+export const latestPublishedVersion = emailSdkPackage.version;
 export const docsVersion = `v${latestPublishedVersion}`;
 export const docsVersionRoutePrefix = "v";
 export const docsVersionStorageKey = "email-sdk-docs-version";


### PR DESCRIPTION
## Summary
- Derive the docs version picker's latest version from the published package version in package.json.
- Update community adapter/plugin peer dependency snippets to ^0.4.0.

## Testing
- bun run release:ci
- bun -e import check confirmed docsVersion is v0.4.0