### PR TITLE
fix: restore v0.3.0 docs archive

### DIFF
--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/brevo.mdx
@@ -1,0 +1,26 @@
+---
+title: Brevo
+description: Configure the Brevo transactional email adapter.
+icon: brevo
+---
+
+<ProviderBadge adapter="brevo" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { brevo } from "@opencoredev/email-sdk/brevo";
+
+const email = createEmailClient({
+  adapters: [brevo({ apiKey: process.env.BREVO_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                |
+| --------- | -------------- | -------- | ------------------------------------ |
+| `apiKey`  | `string`       | Yes      | Brevo API key.                       |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.brevo.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes. |
+
+See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/cloudflare.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/cloudflare.mdx
@@ -1,0 +1,49 @@
+---
+title: Cloudflare Email Sending
+description: Configure the Cloudflare Email Sending REST API adapter.
+icon: cloudflare
+---
+
+<ProviderBadge adapter="cloudflare" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { cloudflare } from "@opencoredev/email-sdk/cloudflare";
+
+const email = createEmailClient({
+  adapters: [
+    cloudflare({
+      apiToken: process.env.CLOUDFLARE_API_TOKEN!,
+      accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option      | Type           | Required | Notes                                                     |
+| ----------- | -------------- | -------- | --------------------------------------------------------- |
+| `apiToken`  | `string`       | Yes      | Cloudflare API token with Email Sending permission.       |
+| `accountId` | `string`       | Yes      | Cloudflare account ID used in the Email Sending endpoint. |
+| `baseUrl`   | `string`       | No       | Defaults to `https://api.cloudflare.com/client/v4`.       |
+| `fetch`     | `typeof fetch` | No       | Useful for tests or custom runtimes.                      |
+
+## CLI
+
+```bash
+bunx --yes @opencoredev/email-sdk send \
+  --adapter cloudflare \
+  --api-token "$CLOUDFLARE_API_TOKEN" \
+  --account-id "$CLOUDFLARE_ACCOUNT_ID" \
+  --from "hello@example.com" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works"
+```
+
+Cloudflare Email Sending requires a Cloudflare DNS domain onboarded to Email Service. New accounts may be limited to verified recipient addresses, and Email Sending is available on Workers Paid plans.
+
+Cloudflare's REST API accepts `to`, `cc`, and `bcc` as plain email-address strings. The adapter preserves display names for `from` and `replyTo`, and rejects named recipients before the request instead of silently dropping the names.
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/field-support.mdx
@@ -1,0 +1,105 @@
+---
+title: SDK field support
+description: See which EmailMessage fields Email SDK maps for each adapter.
+icon: Table
+---
+
+Email SDK keeps one message shape, but email APIs do not all expose the same features. This page documents what each Email SDK adapter maps today. Stable adapters either map a field or reject it with a validation error. They should not silently drop message data.
+
+## How to read this page
+
+- `Yes` means the adapter maps that `EmailMessage` field.
+- `No` means the adapter rejects that field before calling the provider.
+- `Values` means Email SDK sends each tag's value to the provider.
+- `One tag` means only one tag can be represented by that provider API. Sending more than one tag fails before the provider request.
+
+## Best fits
+
+| Need                             | Start with                                         |
+| -------------------------------- | -------------------------------------------------- |
+| Most complete API field mapping  | Postmark, SendGrid, AWS SES, Mailgun, Brevo        |
+| Resend-style DX with attachments | Resend                                             |
+| Cheap or self-managed delivery   | SMTP                                               |
+| Product/event email              | Loops, Plunk                                       |
+| Provider fallback for production | Resend plus SMTP, or one primary API plus Postmark |
+| Attachment-heavy transactional   | Resend, Postmark, SendGrid, Mailgun, MailerSend    |
+
+## API adapters
+
+These adapters cover most transactional email fields. They are the best fit when your app needs CC, BCC, reply-to, custom headers, tags, metadata, or attachments.
+
+| Adapter                 | CC  | BCC | Reply-To | Headers | Metadata | Tags    | Attachments |
+| ----------------------- | --- | --- | -------- | ------- | -------- | ------- | ----------- |
+| Resend                  | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         |
+| Postmark                | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         |
+| SendGrid                | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
+| AWS SES                 | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         |
+| Mailgun                 | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
+| MailerSend              | Yes | Yes | Yes      | Yes     | No       | Values  | Yes         |
+| Brevo                   | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
+| Mailchimp Transactional | Yes | Yes | No       | Yes     | Yes      | Values  | Yes         |
+| Mailtrap                | Yes | Yes | No       | Yes     | No       | One tag | Yes         |
+
+## Narrow adapters
+
+These adapters are useful, but their public APIs do not match the full `EmailMessage` shape. Email SDK keeps them stable by rejecting fields it cannot represent.
+
+| Adapter   | CC  | BCC | Reply-To | Headers | Metadata | Tags   | Attachments |
+| --------- | --- | --- | -------- | ------- | -------- | ------ | ----------- |
+| SparkPost | No  | No  | Yes      | Yes     | Yes      | Values | Yes         |
+| Loops     | No  | No  | No       | No      | Yes      | No     | No          |
+| Plunk     | No  | No  | No       | No      | Yes      | No     | No          |
+| Scaleway  | Yes | Yes | No       | Yes     | No       | No     | No          |
+| ZeptoMail | Yes | Yes | Yes      | No      | No       | No     | Yes         |
+| MailPace  | Yes | Yes | Yes      | No      | No       | No     | No          |
+
+## SMTP transport
+
+SMTP is built in and does not use Nodemailer. It maps address fields and headers directly to the SMTP message, but it does not map provider-only concepts like tags or metadata.
+
+| Adapter | CC  | BCC | Reply-To | Headers | Metadata | Tags | Attachments |
+| ------- | --- | --- | -------- | ------- | -------- | ---- | ----------- |
+| SMTP    | Yes | Yes | Yes      | Yes     | No       | No   | No          |
+
+## Validation behavior
+
+Unsupported fields fail fast. For example, Resend rejects `metadata`, Mailchimp Transactional rejects `replyTo`, and SMTP rejects attachments. That keeps production behavior boring: if a field matters, you find out before the provider request.
+
+## Attachment rules
+
+Attachment `content` is treated as raw content by default and encoded to Base64 for API adapters that require Base64.
+
+```ts
+attachments: [
+  {
+    filename: "receipt.txt",
+    content: "Thanks for your order.",
+    contentType: "text/plain",
+  },
+];
+```
+
+If you already have Base64 content, mark it:
+
+```ts
+attachments: [
+  {
+    filename: "receipt.pdf",
+    content: base64Pdf,
+    contentEncoding: "base64",
+    contentType: "application/pdf",
+  },
+];
+```
+
+Adapters that support attachments can also read a local path:
+
+```ts
+attachments: [
+  {
+    filename: "receipt.pdf",
+    path: "./receipt.pdf",
+    contentType: "application/pdf",
+  },
+];
+```

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Adapters
+description: Supported email service adapters and transports.
+icon: Cable
+---
+
+Email SDK ships with fifteen adapters. Import only the adapter you use; the package does not ask you
+to configure providers that are not on your send path.
+
+Every adapter follows the same contract: map the fields it supports and throw a validation error for
+fields the provider API cannot represent. Use the [SDK field support guide](/docs/adapters/field-support)
+before choosing fallback routes.
+
+<ProviderGrid />
+
+## Import pattern
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: process.env.SMTP_HOST!,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  fallback: ["smtp"],
+});
+```
+
+## Adapter groups
+
+| Group          | Adapters                                                                        |
+| -------------- | ------------------------------------------------------------------------------- |
+| Popular APIs   | Resend, Postmark, SendGrid, Mailgun, MailerSend, Brevo, Mailchimp Transactional |
+| Infrastructure | SparkPost, Mailtrap, Scaleway, ZeptoMail, MailPace                              |
+| Product-led    | Loops, Plunk                                                                    |
+| Transport      | Built-in SMTP                                                                   |

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/loops.mdx
@@ -1,0 +1,34 @@
+---
+title: Loops
+description: Configure the Loops transactional email adapter.
+icon: loops
+---
+
+<ProviderBadge adapter="loops" />
+
+Loops transactional sends normally use a `transactionalId`.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { loops } from "@opencoredev/email-sdk/loops";
+
+const email = createEmailClient({
+  adapters: [
+    loops({
+      apiKey: process.env.LOOPS_API_KEY!,
+      transactionalId: process.env.LOOPS_TRANSACTIONAL_ID!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option            | Type           | Required | Notes                                |
+| ----------------- | -------------- | -------- | ------------------------------------ |
+| `apiKey`          | `string`       | Yes      | Loops API key.                       |
+| `transactionalId` | `string`       | Usually  | Transactional email ID.              |
+| `baseUrl`         | `string`       | No       | Defaults to `https://app.loops.so`.  |
+| `fetch`           | `typeof fetch` | No       | Useful for tests or custom runtimes. |
+
+Loops transactional sends support one recipient and metadata through `dataVariables`. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/mailchimp.mdx
@@ -1,0 +1,28 @@
+---
+title: Mailchimp Transactional
+description: Configure the Mailchimp Transactional adapter.
+icon: mailchimp
+---
+
+<ProviderBadge adapter="mailchimp" />
+
+Mailchimp Transactional is the API formerly known as Mandrill.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailchimp } from "@opencoredev/email-sdk/mailchimp";
+
+const email = createEmailClient({
+  adapters: [mailchimp({ apiKey: process.env.MAILCHIMP_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                          |
+| --------- | -------------- | -------- | ---------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailchimp Transactional API key.               |
+| `baseUrl` | `string`       | No       | Defaults to `https://mandrillapp.com/api/1.0`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/mailersend.mdx
@@ -1,0 +1,26 @@
+---
+title: MailerSend
+description: Configure the MailerSend Email API adapter.
+icon: mailersend
+---
+
+<ProviderBadge adapter="mailersend" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailersend } from "@opencoredev/email-sdk/mailersend";
+
+const email = createEmailClient({
+  adapters: [mailersend({ apiKey: process.env.MAILERSEND_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                     |
+| --------- | -------------- | -------- | ----------------------------------------- |
+| `apiKey`  | `string`       | Yes      | MailerSend API token.                     |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.mailersend.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.      |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/mailgun.mdx
@@ -1,0 +1,32 @@
+---
+title: Mailgun
+description: Configure the Mailgun Messages API adapter.
+icon: mailgun
+---
+
+<ProviderBadge adapter="mailgun" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailgun } from "@opencoredev/email-sdk/mailgun";
+
+const email = createEmailClient({
+  adapters: [
+    mailgun({
+      apiKey: process.env.MAILGUN_API_KEY!,
+      domain: process.env.MAILGUN_DOMAIN!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                                                                              |
+| --------- | -------------- | -------- | -------------------------------------------------------------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailgun API key.                                                                                   |
+| `domain`  | `string`       | Yes      | Sending domain.                                                                                    |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.mailgun.net`. Use the EU API base URL if your domain is in the EU region. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                                               |
+
+Mailgun sends attachments as multipart form data. See <a href="/docs/adapters/field-support">field support</a> for the full mapping.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/mailpace.mdx
@@ -1,0 +1,26 @@
+---
+title: MailPace
+description: Configure the MailPace send API adapter.
+icon: mailpace
+---
+
+<ProviderBadge adapter="mailpace" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailpace } from "@opencoredev/email-sdk/mailpace";
+
+const email = createEmailClient({
+  adapters: [mailpace({ apiKey: process.env.MAILPACE_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                          |
+| --------- | -------------- | -------- | ---------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | MailPace server token.                         |
+| `baseUrl` | `string`       | No       | Defaults to `https://app.mailpace.com/api/v1`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
+
+MailPace supports CC, BCC, and reply-to. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/mailtrap.mdx
@@ -1,0 +1,26 @@
+---
+title: Mailtrap
+description: Configure the Mailtrap Email Sending API adapter.
+icon: mailtrap
+---
+
+<ProviderBadge adapter="mailtrap" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailtrap } from "@opencoredev/email-sdk/mailtrap";
+
+const email = createEmailClient({
+  adapters: [mailtrap({ apiKey: process.env.MAILTRAP_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                       |
+| --------- | -------------- | -------- | ------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Mailtrap API token.                         |
+| `baseUrl` | `string`       | No       | Defaults to `https://send.api.mailtrap.io`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.        |
+
+See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/meta.json
@@ -1,0 +1,25 @@
+{
+  "title": "Adapters",
+  "icon": "Cable",
+  "pages": [
+    "index",
+    "field-support",
+    "resend",
+    "postmark",
+    "sendgrid",
+    "cloudflare",
+    "ses",
+    "mailgun",
+    "mailersend",
+    "brevo",
+    "mailchimp",
+    "sparkpost",
+    "loops",
+    "plunk",
+    "mailtrap",
+    "scaleway",
+    "zeptomail",
+    "mailpace",
+    "smtp"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/plunk.mdx
@@ -1,0 +1,26 @@
+---
+title: Plunk
+description: Configure the Plunk send API adapter.
+icon: plunk
+---
+
+<ProviderBadge adapter="plunk" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { plunk } from "@opencoredev/email-sdk/plunk";
+
+const email = createEmailClient({
+  adapters: [plunk({ apiKey: process.env.PLUNK_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                        |
+| --------- | -------------- | -------- | -------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | Plunk API key.                               |
+| `baseUrl` | `string`       | No       | Defaults to `https://next-api.useplunk.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.         |
+
+Plunk maps `metadata` to `data`. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/postmark.mdx
@@ -1,0 +1,51 @@
+---
+title: Postmark
+description: Configure the fetch-based Postmark adapter.
+icon: postmark
+---
+
+The Postmark adapter calls the Postmark Email API directly. It does not add a runtime dependency.
+
+<ProviderBadge adapter="postmark" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { postmark } from "@opencoredev/email-sdk/postmark";
+
+const email = createEmailClient({
+  adapters: [
+    postmark({
+      serverToken: process.env.POSTMARK_SERVER_TOKEN!,
+      messageStream: "outbound",
+    }),
+  ],
+});
+```
+
+## Send
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  html: "<p>Thanks for your order.</p>",
+  metadata: {
+    orderId: "ord_123",
+  },
+});
+```
+
+## Options
+
+| Option          | Type                     | Required | Notes                                      |
+| --------------- | ------------------------ | -------- | ------------------------------------------ |
+| `serverToken`   | `string`                 | Yes      | Postmark server token.                     |
+| `baseUrl`       | `string`                 | No       | Defaults to `https://api.postmarkapp.com`. |
+| `messageStream` | `string`                 | No       | Postmark message stream.                   |
+| `fetch`         | `typeof fetch`           | No       | Useful for tests or custom runtimes.       |
+| `headers`       | `Record<string, string>` | No       | Extra request headers.                     |
+
+## Response
+
+The adapter maps Postmark `MessageID` to `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/resend.mdx
@@ -1,0 +1,48 @@
+---
+title: Resend
+description: Configure the fetch-based Resend adapter.
+icon: resend
+---
+
+The Resend adapter calls the Resend Email API directly. It does not add a runtime dependency.
+
+<ProviderBadge adapter="resend" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+await email.send(
+  {
+    from: "Acme <hello@acme.com>",
+    to: "user@example.com",
+    subject: "Welcome",
+    html: "<p>Your workspace is ready.</p>",
+    tags: [{ name: "type", value: "welcome" }],
+  },
+  {
+    idempotencyKey: "welcome:user_123",
+  },
+);
+```
+
+## Options
+
+| Option    | Type                     | Required | Notes                                 |
+| --------- | ------------------------ | -------- | ------------------------------------- |
+| `apiKey`  | `string`                 | Yes      | Resend API key.                       |
+| `baseUrl` | `string`                 | No       | Defaults to `https://api.resend.com`. |
+| `fetch`   | `typeof fetch`           | No       | Useful for tests or custom runtimes.  |
+| `headers` | `Record<string, string>` | No       | Extra request headers.                |
+
+## Response
+
+The adapter returns the Resend `id` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/scaleway.mdx
@@ -1,0 +1,33 @@
+---
+title: Scaleway
+description: Configure the Scaleway Transactional Email adapter.
+icon: scaleway
+---
+
+<ProviderBadge adapter="scaleway" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { scaleway } from "@opencoredev/email-sdk/scaleway";
+
+const email = createEmailClient({
+  adapters: [
+    scaleway({
+      secretKey: process.env.SCALEWAY_SECRET_KEY!,
+      projectId: process.env.SCALEWAY_PROJECT_ID!,
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option      | Type           | Required | Notes                                   |
+| ----------- | -------------- | -------- | --------------------------------------- |
+| `secretKey` | `string`       | Yes      | Scaleway secret key.                    |
+| `projectId` | `string`       | Yes      | Scaleway project ID.                    |
+| `region`    | `string`       | No       | Defaults to `fr-par`.                   |
+| `baseUrl`   | `string`       | No       | Defaults to `https://api.scaleway.com`. |
+| `fetch`     | `typeof fetch` | No       | Useful for tests or custom runtimes.    |
+
+Scaleway supports a narrower message shape than full API-first providers. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/sendgrid.mdx
@@ -1,0 +1,32 @@
+---
+title: SendGrid
+description: Configure the Twilio SendGrid Mail Send API adapter.
+icon: sendgrid
+---
+
+<ProviderBadge adapter="sendgrid" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sendgrid } from "@opencoredev/email-sdk/sendgrid";
+
+const email = createEmailClient({
+  adapters: [sendgrid({ apiKey: process.env.SENDGRID_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                   |
+| --------- | -------------- | -------- | --------------------------------------- |
+| `apiKey`  | `string`       | Yes      | SendGrid API key.                       |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.sendgrid.com`. |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.    |
+
+See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.
+
+## CLI
+
+```bash
+bunx --yes @opencoredev/email-sdk send --adapter sendgrid --from hello@example.com --to user@example.com --subject "Hello" --text "It works"
+```

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/ses.mdx
@@ -1,0 +1,67 @@
+---
+title: AWS SES
+description: Configure the AWS SES v2 SendEmail adapter.
+icon: Cloud
+---
+
+The AWS SES adapter calls the SES v2 SendEmail API directly with SigV4-signed fetch requests. It does not add a runtime dependency on the AWS SDK.
+
+<ProviderBadge adapter="ses" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { ses } from "@opencoredev/email-sdk/ses";
+
+const email = createEmailClient({
+  adapters: [
+    ses({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      sessionToken: process.env.AWS_SESSION_TOKEN,
+      region: process.env.AWS_REGION!,
+    }),
+  ],
+});
+```
+
+## Send
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
+  tags: [{ name: "type", value: "welcome" }],
+});
+```
+
+## Options
+
+| Option                 | Type           | Required | Notes                                                 |
+| ---------------------- | -------------- | -------- | ----------------------------------------------------- |
+| `accessKeyId`          | `string`       | Yes      | AWS access key ID.                                    |
+| `secretAccessKey`      | `string`       | Yes      | AWS secret access key.                                |
+| `region`               | `string`       | Yes      | SES region, for example `us-east-1`.                  |
+| `sessionToken`         | `string`       | No       | Required for temporary credentials.                   |
+| `baseUrl`              | `string`       | No       | Defaults to `https://email.{region}.amazonaws.com`.   |
+| `fetch`                | `typeof fetch` | No       | Useful for tests or custom runtimes.                  |
+| `charset`              | `string`       | No       | Defaults to `UTF-8`.                                  |
+| `configurationSetName` | `string`       | No       | SES configuration set for sends through this adapter. |
+
+## CLI
+
+```bash
+AWS_ACCESS_KEY_ID=... \
+AWS_SECRET_ACCESS_KEY=... \
+AWS_REGION=us-east-1 \
+bunx --yes @opencoredev/email-sdk send --adapter ses \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Welcome" \
+  --html "<p>Your workspace is ready.</p>"
+```
+
+## Response
+
+The adapter returns the SES `MessageId` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/smtp.mdx
@@ -1,0 +1,77 @@
+---
+title: SMTP
+description: Configure generic SMTP for PurelyMail or a custom server.
+icon: smtp
+---
+
+The SMTP adapter is built in. It uses Node/Bun TCP and TLS sockets directly, so it does not need Nodemailer.
+
+<ProviderBadge adapter="smtp" />
+
+When `auth` is configured with `secure: false`, the adapter sends `STARTTLS` before authenticating. Set `allowInsecureAuth: true` only for a trusted local server that does not support TLS.
+
+## Configure
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+});
+```
+
+## Options
+
+| Option              | Type                             | Required | Notes                                     |
+| ------------------- | -------------------------------- | -------- | ----------------------------------------- |
+| `host`              | `string`                         | Yes      | SMTP host.                                |
+| `port`              | `number`                         | No       | Common values are `587`, `465`, and `25`. |
+| `secure`            | `boolean`                        | No       | Use TLS from the start of the connection. |
+| `auth`              | `{ user: string; pass: string }` | No       | SMTP credentials.                         |
+| `defaults`          | `{ replyTo?: string }`           | No       | Default reply-to header.                  |
+| `tls`               | `Record<string, unknown>`        | No       | TLS options.                              |
+| `requireTLS`        | `boolean`                        | No       | Require STARTTLS.                         |
+| `allowInsecureAuth` | `boolean`                        | No       | Opt in to SMTP AUTH without TLS.          |
+| `name`              | `string`                         | No       | Defaults to `smtp`.                       |
+| `heloName`          | `string`                         | No       | EHLO name sent to the server.             |
+| `timeoutMs`         | `number`                         | No       | Socket timeout.                           |
+
+## Multiple SMTP routes
+
+Rename adapters when you have multiple SMTP routes.
+
+```ts
+const email = createEmailClient({
+  adapters: [
+    smtp({ name: "purelymail", host: "smtp.purelymail.com" }),
+    smtp({ name: "backup-smtp", host: "smtp.backup.example" }),
+  ],
+  defaultProvider: "purelymail",
+  fallback: ["backup-smtp"],
+});
+```
+
+## CLI
+
+```bash
+bunx --yes @opencoredev/email-sdk send \
+  --adapter smtp \
+  --host smtp.purelymail.com \
+  --user hello@example.com \
+  --pass "$SMTP_PASS" \
+  --from "Acme <hello@example.com>" \
+  --to user@example.com \
+  --subject "SMTP test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/sparkpost.mdx
@@ -1,0 +1,27 @@
+---
+title: SparkPost
+description: Configure the SparkPost Transmissions API adapter.
+icon: sparkpost
+---
+
+<ProviderBadge adapter="sparkpost" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sparkpost } from "@opencoredev/email-sdk/sparkpost";
+
+const email = createEmailClient({
+  adapters: [sparkpost({ apiKey: process.env.SPARKPOST_API_KEY! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                           |
+| --------- | -------------- | -------- | ----------------------------------------------- |
+| `apiKey`  | `string`       | Yes      | SparkPost API key.                              |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.sparkpost.com/api/v1`. |
+| `sandbox` | `boolean`      | No       | Enables SparkPost sandbox mode.                 |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.            |
+
+SparkPost does not expose normalized CC/BCC in this adapter. See <a href="/docs/adapters/field-support">field support</a>.

--- a/apps/fumadocs/content/docs-v/0.3.0/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/adapters/zeptomail.mdx
@@ -1,0 +1,26 @@
+---
+title: ZeptoMail
+description: Configure the Zoho ZeptoMail adapter.
+icon: zeptomail
+---
+
+<ProviderBadge adapter="zeptomail" />
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { zeptomail } from "@opencoredev/email-sdk/zeptomail";
+
+const email = createEmailClient({
+  adapters: [zeptomail({ token: process.env.ZEPTOMAIL_TOKEN! })],
+});
+```
+
+## Options
+
+| Option    | Type           | Required | Notes                                                                         |
+| --------- | -------------- | -------- | ----------------------------------------------------------------------------- |
+| `token`   | `string`       | Yes      | ZeptoMail API token. The adapter adds the `Zoho-enczapikey` prefix if needed. |
+| `baseUrl` | `string`       | No       | Defaults to `https://api.zeptomail.com`.                                      |
+| `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                          |
+
+ZeptoMail supports recipients, reply-to, and attachments. Unsupported fields throw before the API call.

--- a/apps/fumadocs/content/docs-v/0.3.0/agents/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/agents/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Agents",
+  "icon": "Bot",
+  "pages": ["skill"]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/agents/skill.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/agents/skill.mdx
@@ -1,0 +1,41 @@
+---
+title: Agent skill
+description: Use the repo-local Email SDK skill when agents add or review email integrations.
+icon: Bot
+---
+
+This repo includes an agent skill at:
+
+```txt
+skills/email-sdk/SKILL.md
+```
+
+Install it with the skills.sh CLI:
+
+```bash
+npx skills add opencoredev/email-sdk --skill email-sdk
+```
+
+Use it when an agent wires Email SDK into an app, reviews adapter setup, or updates these docs.
+
+## What it tells agents
+
+- Use `bun` and `bunx`.
+- Refresh the current README, package version, package exports, Fumadocs pages, and TypeScript declarations before implementing.
+- Keep adapter credentials in environment variables.
+- Import adapters from their own entry points.
+- Do not add Nodemailer for SMTP; Email SDK includes its own SMTP transport.
+- Use fallbacks only when the backup adapter can send the same class of email.
+- Add idempotency keys for externally visible transactional sends.
+- Run a narrow validation before calling the work done.
+
+## Prompt example
+
+```txt
+Use the repo-local Email SDK skill at skills/email-sdk/SKILL.md.
+Wire Resend as the primary adapter and SMTP as fallback.
+Keep secrets in environment variables.
+Add one narrow test around the send path.
+```
+
+The skill is dynamic on purpose. It teaches agents where to fetch the current docs and source first, so the skill does not need a manual update every time the SDK gains another adapter or option.

--- a/apps/fumadocs/content/docs-v/0.3.0/concepts/adapter-model.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/concepts/adapter-model.mdx
@@ -1,0 +1,71 @@
+---
+title: Adapter model
+description: How Email SDK adapters, routing names, and escape hatches work.
+icon: Plug
+---
+
+An adapter is an Email SDK module that knows how to send through one service or transport.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { postmark } from "@opencoredev/email-sdk/postmark";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    postmark({ serverToken: process.env.POSTMARK_SERVER_TOKEN! }),
+  ],
+});
+```
+
+## Routing names
+
+Each adapter registers a routing name. Email SDK uses that name for defaults, fallbacks, and per-send overrides.
+
+| Adapter                 | Routing name |
+| ----------------------- | ------------ |
+| Resend                  | `resend`     |
+| SMTP                    | `smtp`       |
+| Postmark                | `postmark`   |
+| SendGrid                | `sendgrid`   |
+| AWS SES                 | `ses`        |
+| Mailgun                 | `mailgun`    |
+| MailerSend              | `mailersend` |
+| Brevo                   | `brevo`      |
+| Mailchimp Transactional | `mailchimp`  |
+| SparkPost               | `sparkpost`  |
+| Loops                   | `loops`      |
+| Plunk                   | `plunk`      |
+| Mailtrap                | `mailtrap`   |
+| Scaleway                | `scaleway`   |
+| ZeptoMail               | `zeptomail`  |
+| MailPace                | `mailpace`   |
+
+## Send with one adapter
+
+```ts
+await email.send(message, {
+  adapter: "postmark",
+});
+```
+
+## Bind one adapter
+
+```ts
+const transactional = email.withAdapter("postmark");
+
+await transactional.send(message);
+```
+
+## Use adapter escape hatches
+
+Every adapter can expose `raw`. Keep provider-specific code close to the adapter and keep normal application code on the shared `send` path.
+
+```ts
+const adapter = email.adapter("resend");
+
+console.log(adapter.raw);
+```
+
+The older `provider`, `defaultProvider`, `email.provider()`, and `email.withProvider()` names still work as aliases.

--- a/apps/fumadocs/content/docs-v/0.3.0/concepts/fallbacks-and-retries.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/concepts/fallbacks-and-retries.mdx
@@ -1,0 +1,66 @@
+---
+title: Fallbacks and retries
+description: Retry transient failures and use a backup adapter.
+icon: Repeat2
+---
+
+Retries happen inside one adapter. Fallbacks happen after an adapter fails.
+
+```ts
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  retry: {
+    retries: 1,
+  },
+  fallback: ["smtp"],
+});
+```
+
+In this setup, Email SDK tries Resend first. If Resend fails with a retryable error, it retries once. If it still fails, it tries SMTP.
+
+## Override fallback for one send
+
+```ts
+await email.send(message, {
+  provider: "resend",
+  fallbackAdapters: ["smtp"],
+});
+```
+
+## Override retries for one send
+
+```ts
+await email.send(message, {
+  retries: 2,
+});
+```
+
+## Retryable HTTP responses
+
+The fetch-based adapters mark these responses as retryable:
+
+| Status | Meaning                         |
+| ------ | ------------------------------- |
+| `408`  | Request timeout                 |
+| `409`  | Conflict                        |
+| `425`  | Too early                       |
+| `429`  | Rate limited                    |
+| `5xx`  | Adapter or network-side failure |
+
+Use an idempotency key for email that may be retried.
+
+```ts
+await email.send(message, {
+  idempotencyKey: "receipt:order_123",
+});
+```

--- a/apps/fumadocs/content/docs-v/0.3.0/concepts/hooks.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/concepts/hooks.mdx
@@ -1,0 +1,44 @@
+---
+title: Hooks
+description: Observe sends without changing adapter code.
+icon: Activity
+---
+
+Hooks are for logs, metrics, tracing, and retry visibility.
+
+```ts
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  hooks: {
+    beforeSend(event) {
+      console.log("email.send", event.provider, event.message.subject);
+    },
+    afterSend(event) {
+      console.log("email.sent", event.response.id);
+    },
+    onRetry(event) {
+      console.warn("email.retry", event.provider, event.nextAttempt);
+    },
+    onError(event) {
+      console.error("email.error", event.provider, event.error);
+    },
+  },
+});
+```
+
+## Hook events
+
+Each hook receives:
+
+| Field      | Notes                               |
+| ---------- | ----------------------------------- |
+| `provider` | Routing name used for this attempt. |
+| `message`  | The original `EmailMessage`.        |
+| `attempt`  | Current attempt number.             |
+| `metadata` | Optional metadata passed to `send`. |
+
+`afterSend` also receives `response`. `onRetry` receives `nextAttempt` and `delayMs`. `onError` receives `error`.
+
+## Keep logs safe
+
+Do not log API keys, SMTP passwords, raw tokens, full message bodies, or unnecessary recipient data. For most production logs, routing name, status, subject category, template name, and message ID are enough.

--- a/apps/fumadocs/content/docs-v/0.3.0/concepts/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/concepts/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Concepts",
+  "icon": "BookOpen",
+  "pages": ["adapter-model", "fallbacks-and-retries", "hooks"]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/getting-started/install.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/getting-started/install.mdx
@@ -1,0 +1,60 @@
+---
+title: Install
+description: Install the SDK package and run the email-sdk CLI.
+icon: Package
+---
+
+Email SDK is published on npm as `@opencoredev/email-sdk`.
+
+The command-line binary is named `email-sdk`. That means the package name and the command name are different on purpose:
+
+| What you want                  | Use this                                |
+| ------------------------------ | --------------------------------------- |
+| Install the package            | `bun add @opencoredev/email-sdk`        |
+| Run the installed CLI          | `bun email-sdk ...`                     |
+| Run the CLI without installing | `bunx --yes @opencoredev/email-sdk ...` |
+
+Do not install the unscoped `email-sdk` package from npm. It is a different package.
+
+## Install in your app
+
+```bash
+bun add @opencoredev/email-sdk
+```
+
+Then import the client and adapters from the scoped package:
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+```
+
+## Run the CLI once
+
+Use `bunx` when you want a quick adapter check without adding the package to a project.
+
+```bash
+bunx --yes @opencoredev/email-sdk adapters
+```
+
+Check a provider configuration:
+
+```bash
+RESEND_API_KEY="re_..." bunx --yes @opencoredev/email-sdk doctor --adapter resend
+```
+
+## Run the CLI from an installed project
+
+After `bun add @opencoredev/email-sdk`, Bun can run the installed binary:
+
+```bash
+bun email-sdk adapters
+```
+
+The command is still `email-sdk`; the package you installed is still `@opencoredev/email-sdk`. Avoid `bunx email-sdk` outside an installed project because the unscoped npm package is unrelated.
+
+## Prerequisites
+
+- Bun is required for the CLI because the binary runs with `#!/usr/bin/env bun`.
+- Node 20 or newer is supported for SDK usage.
+- Provider credentials must be set in environment variables or passed with CLI flags.

--- a/apps/fumadocs/content/docs-v/0.3.0/getting-started/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/getting-started/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Getting started",
+  "icon": "Rocket",
+  "pages": ["install", "quickstart"]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/getting-started/quickstart.mdx
@@ -1,0 +1,115 @@
+---
+title: Quickstart
+description: Create a client, send a first transactional email, and verify the CLI path.
+icon: Rocket
+---
+
+Start with the scoped package:
+
+```bash
+bun add @opencoredev/email-sdk
+```
+
+The installed CLI command is named `email-sdk`. If you only need the CLI for a quick check, run `bunx --yes @opencoredev/email-sdk ...` instead. See <a href="/docs/getting-started/install">Install</a> for the package and CLI distinction.
+
+## Send through Resend
+
+Set `RESEND_API_KEY`, then create a client with the Resend adapter.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome to Acme",
+  text: "Your account is ready.",
+});
+```
+
+## Check the send result
+
+`send` resolves with the normalized adapter response. The `provider` value tells you which adapter
+actually handled the send.
+
+```ts
+const result = await email.send(message);
+
+console.log(result.provider);
+console.log(result.id);
+```
+
+If the adapter returns a message ID, Email SDK exposes it as both `id` and `messageId`. Provider
+responses are still available through `raw` when an adapter includes them.
+
+## Verify from the CLI
+
+Use `doctor` to check that the selected adapter has the required environment variables.
+
+```bash
+RESEND_API_KEY="re_..." bunx --yes @opencoredev/email-sdk doctor --adapter resend
+```
+
+Use `--dry-run` to validate the message shape without sending email.
+
+```bash
+bunx --yes @opencoredev/email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works" \
+  --dry-run
+```
+
+When the package is installed in your project, the same command can run through the installed binary:
+
+```bash
+bun email-sdk doctor --adapter resend
+```
+
+## Add SMTP fallback
+
+Add SMTP when you want a second route for the same transactional email. The SMTP adapter is built in
+and does not require Nodemailer. When SMTP auth is configured on a non-secure connection, Email SDK
+upgrades with STARTTLS before authenticating.
+
+Only use fallback adapters that can send the same message shape. For example, SMTP supports address
+fields and headers, but not provider-only fields like tags, metadata, or attachments.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+export const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  fallback: ["smtp"],
+});
+```
+
+Your application still sends the same way:
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  text: "Thanks for your order.",
+});
+```

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/create-adapter.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/create-adapter.mdx
@@ -1,0 +1,170 @@
+---
+title: Create an adapter
+description: Write your first custom provider adapter.
+icon: Cable
+---
+
+An adapter connects Email SDK's normalized `EmailMessage` to one provider API. Start with a plain adapter. Wrap it as a plugin only when you want package-style reuse.
+
+## Adapter shape
+
+```ts
+import type { EmailProvider } from "@opencoredev/email-sdk";
+
+export type AcmeMailOptions = {
+  apiKey: string;
+  fetch?: typeof fetch;
+};
+
+export function acmeMail(options: AcmeMailOptions): EmailProvider {
+  const request = options.fetch ?? fetch;
+
+  return {
+    name: "acme-mail",
+    async send(message, context) {
+      const response = await request("https://api.acme-mail.example/send", {
+        method: "POST",
+        signal: context.signal,
+        headers: {
+          Authorization: `Bearer ${options.apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(toAcmePayload(message, context)),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Acme Mail send failed: ${response.status}`);
+      }
+
+      const body = await response.json();
+
+      return {
+        provider: "acme-mail",
+        id: body.id,
+        messageId: body.message_id,
+        accepted: body.accepted,
+        rejected: body.rejected,
+        raw: body,
+      };
+    },
+  };
+}
+```
+
+## Map the payload
+
+Keep provider-specific mapping in a helper. That keeps the adapter easy to test.
+
+```ts
+import type { EmailMessage, EmailProviderContext } from "@opencoredev/email-sdk";
+
+function toAcmePayload(message: EmailMessage, context: EmailProviderContext) {
+  return {
+    from: message.from,
+    to: message.to,
+    subject: message.subject,
+    html: message.html,
+    text: message.text,
+    headers: message.headers,
+    tags: message.tags,
+    metadata: {
+      ...message.metadata,
+      idempotencyKey: context.idempotencyKey,
+      attempt: context.attempt,
+    },
+  };
+}
+```
+
+## Use the adapter directly
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { acmeMail } from "./acme-mail";
+
+const email = createEmailClient({
+  adapters: [acmeMail({ apiKey: process.env.ACME_MAIL_API_KEY! })],
+});
+```
+
+## Wrap it as an adapter plugin
+
+Adapter plugins are best for community packages and shared internal packages.
+
+```ts
+import type { EmailPlugin } from "@opencoredev/email-sdk";
+import { acmeMail, type AcmeMailOptions } from "./acme-mail";
+
+export function acmeMailPlugin(options: AcmeMailOptions): EmailPlugin {
+  return {
+    id: "acme-mail",
+    adapters: [acmeMail(options)],
+  };
+}
+```
+
+Consumers can now mount it with the same `plugins` array as other extensions:
+
+```ts
+const email = createEmailClient({
+  plugins: [acmeMailPlugin({ apiKey: process.env.ACME_MAIL_API_KEY! })],
+});
+```
+
+## Handle unsupported fields
+
+Do not silently drop fields your provider cannot send. Throw a clear error instead.
+
+```ts
+if (message.attachments?.length) {
+  throw new Error("Acme Mail adapter does not support attachments.");
+}
+```
+
+This is especially important for fallback routes. A backup adapter that drops attachments, tags, or reply-to values can make a send look successful while changing the email.
+
+## Test the adapter
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { acmeMail } from "./acme-mail";
+
+describe("acmeMail", () => {
+  test("sends a normalized message", async () => {
+    const calls: unknown[] = [];
+    const adapter = acmeMail({
+      apiKey: "test",
+      fetch: async (_url, init) => {
+        calls.push(JSON.parse(String(init?.body)));
+        return Response.json({ id: "provider_123", message_id: "msg_123" });
+      },
+    });
+
+    const response = await adapter.send(
+      {
+        from: "test@example.com",
+        to: "user@example.com",
+        subject: "Hello",
+        text: "Hi",
+      },
+      { attempt: 1 },
+    );
+
+    expect(response.messageId).toBe("msg_123");
+    expect(calls).toHaveLength(1);
+  });
+});
+```
+
+If your adapter accepts injected `fetch`, document it. It makes tests easier and keeps users from reaching for global mocks.
+
+## Checklist
+
+- Use one stable adapter `name`.
+- Return `provider`, `id` or `messageId`, and `raw`.
+- Pass `context.signal` into provider requests.
+- Respect `context.idempotencyKey` when the provider supports it.
+- Throw on unsupported fields instead of dropping them.
+- Add tests for payload mapping and provider response mapping.
+
+See [Adapter contract](/docs/reference/adapter-contract) for the exact type reference.

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/create-first-plugin.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/create-first-plugin.mdx
@@ -1,0 +1,132 @@
+---
+title: Create your first plugin
+description: Build a reusable send policy plugin.
+icon: PackagePlus
+---
+
+This guide builds a small policy plugin that requires each send to include a metadata value. The same shape works for tenant checks, route enforcement, audit defaults, or environment-specific guardrails.
+
+## What you will build
+
+The plugin will:
+
+1. Accept a required metadata key.
+2. Run before provider validation.
+3. Block the send when the key is missing.
+4. Add a tiny typed helper to the returned client.
+
+## Create the plugin file
+
+```ts
+import type { EmailPlugin } from "@opencoredev/email-sdk";
+
+export type RequireMetadataPluginOptions = {
+  key: string;
+};
+
+export function requireMetadataPlugin(
+  options: RequireMetadataPluginOptions,
+): EmailPlugin<{ requiredEmailMetadata: string }> {
+  return {
+    id: `require-metadata:${options.key}`,
+    middleware: [
+      {
+        beforeSend(event) {
+          const value = event.options?.metadata?.[options.key];
+
+          if (value === undefined || value === null || value === "") {
+            throw new Error(`Missing email metadata: ${options.key}`);
+          }
+        },
+      },
+    ],
+    extendClient() {
+      return {
+        requiredEmailMetadata: options.key,
+      };
+    },
+  };
+}
+```
+
+## Use it
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { requireMetadataPlugin } from "./require-metadata-plugin";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  plugins: [requireMetadataPlugin({ key: "tenantId" })],
+});
+
+await email.send(
+  {
+    from: "billing@example.com",
+    to: "user@example.com",
+    subject: "Receipt",
+    text: "Thanks for your order.",
+  },
+  {
+    metadata: {
+      tenantId: "tenant_123",
+    },
+  },
+);
+```
+
+The returned client now has a typed `email.requiredEmailMetadata` property.
+
+## Block a send
+
+```ts
+await email.send({
+  from: "billing@example.com",
+  to: "user@example.com",
+  subject: "Receipt",
+  text: "Thanks for your order.",
+});
+```
+
+That call throws before any adapter is called. `beforeSend` errors are not swallowed because policy plugins need to be able to stop unsafe sends.
+
+## Add tests
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { memoryProvider } from "@opencoredev/email-sdk/testing";
+import { requireMetadataPlugin } from "./require-metadata-plugin";
+
+describe("requireMetadataPlugin", () => {
+  test("blocks sends without the required metadata", async () => {
+    const memory = memoryProvider();
+    const email = createEmailClient({
+      adapters: [memory],
+      plugins: [requireMetadataPlugin({ key: "tenantId" })],
+    });
+
+    await expect(
+      email.send({
+        from: "test@example.com",
+        to: "user@example.com",
+        subject: "Hello",
+        text: "Hi",
+      }),
+    ).rejects.toThrow("Missing email metadata: tenantId");
+
+    expect(memory.raw.sent).toHaveLength(0);
+  });
+});
+```
+
+## Plugin rules
+
+- Use a stable `id`.
+- Make IDs unique when mounting multiple instances.
+- Use `beforeSend` for behavior that can block a send.
+- Use `afterSend`, `onError`, and hooks for observability work.
+- Keep client extensions small and avoid names like `send`, `adapter`, or `defaultAdapter`.
+
+For exact types, see [Plugin API](/docs/plugins/api).

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Build",
+  "icon": "Wrench",
+  "pages": [
+    "create-first-plugin",
+    "create-adapter",
+    "publish-community-plugin",
+    "publish-community-adapter"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/publish-community-adapter.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/publish-community-adapter.mdx
@@ -1,0 +1,123 @@
+---
+title: Publish a community adapter
+description: Package a custom adapter for other Email SDK users.
+icon: BadgeCheck
+---
+
+Community adapters should feel like built-in adapters: predictable names, clear field support, narrow dependencies, and a plugin export for clean setup.
+
+Adapter packages follow the same registry process as other plugins. Start with [Publish a community plugin](/docs/guides/authoring/publish-community-plugin), then add the adapter-specific requirements on this page.
+
+## Recommended package shape
+
+```txt
+email-sdk-acme-mail/
+  src/
+    index.ts
+    acme-mail.ts
+    acme-mail.test.ts
+  package.json
+  README.md
+```
+
+## Export both forms
+
+Export a plain adapter factory and an adapter plugin factory.
+
+```ts
+export { acmeMail } from "./acme-mail";
+export { acmeMailPlugin } from "./plugin";
+export type { AcmeMailOptions } from "./acme-mail";
+```
+
+The plain adapter keeps advanced users close to the provider. The plugin form gives most apps the cleanest setup:
+
+```ts
+createEmailClient({
+  plugins: [acmeMailPlugin({ apiKey: process.env.ACME_MAIL_API_KEY! })],
+});
+```
+
+## Package exports
+
+```json
+{
+  "name": "email-sdk-acme-mail",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "peerDependencies": {
+    "@opencoredev/email-sdk": "^0.1.0"
+  }
+}
+```
+
+Use a peer dependency for Email SDK so apps do not accidentally install two copies of the core types.
+
+## Naming
+
+| Thing     | Recommendation                       |
+| --------- | ------------------------------------ |
+| Package   | `email-sdk-{provider}`               |
+| Adapter   | Provider slug, such as `acme-mail`   |
+| Plugin ID | Same slug unless you need variants   |
+| Env var   | Provider slug in uppercase, plus key |
+| Export    | `{provider}` and `{provider}Plugin`  |
+
+## Document field support
+
+Every adapter README should say whether these fields are supported:
+
+- `html` and `text`
+- `cc`, `bcc`, and `replyTo`
+- `headers`
+- `attachments`
+- `tags`
+- `metadata`
+- `idempotencyKey`
+
+If a field is not supported, say whether the adapter throws. Community adapters should throw on unsupported non-empty fields instead of dropping them.
+
+## Include a smoke test
+
+At minimum, test:
+
+1. Payload mapping.
+2. Response mapping.
+3. Unsupported field errors.
+4. `AbortSignal` forwarding.
+5. Plugin registration through `createEmailClient`.
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { acmeMailPlugin } from "./index";
+
+describe("acmeMailPlugin", () => {
+  test("registers an adapter", () => {
+    const email = createEmailClient({
+      plugins: [acmeMailPlugin({ apiKey: "test" })],
+    });
+
+    expect(email.adapters.has("acme-mail")).toBe(true);
+    expect(email.defaultAdapter).toBe("acme-mail");
+  });
+});
+```
+
+## README checklist
+
+- Install command.
+- Minimal `createEmailClient` example.
+- Required environment variables.
+- Field support table.
+- Error behavior for unsupported fields.
+- Test command.
+- Link to Email SDK adapter contract.
+
+Keep the README short enough that a user can decide if the adapter fits their fallback route.

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/publish-community-plugin.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/authoring/publish-community-plugin.mdx
@@ -1,0 +1,103 @@
+---
+title: Publish a community plugin
+description: Package and list a third-party Email SDK plugin.
+icon: PackageCheck
+---
+
+Community plugins are npm packages that export an `EmailPlugin` factory. The docs site lists them from a static JSON registry; there is no hosted plugin service.
+
+## Package shape
+
+```txt
+email-sdk-require-metadata/
+  src/
+    index.ts
+    require-metadata.ts
+    require-metadata.test.ts
+  package.json
+  README.md
+```
+
+Export the plugin factory from the package root.
+
+```ts
+export { requireMetadataPlugin } from "./require-metadata";
+export type { RequireMetadataOptions } from "./require-metadata";
+```
+
+Apps should be able to use the package in one line inside `plugins`.
+
+```ts
+createEmailClient({
+  plugins: [requireMetadataPlugin({ key: "tenantId" })],
+});
+```
+
+## Package requirements
+
+Use `@opencoredev/email-sdk` as a peer dependency.
+
+```json
+{
+  "name": "email-sdk-require-metadata",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "peerDependencies": {
+    "@opencoredev/email-sdk": "^0.2.0"
+  }
+}
+```
+
+Verified packages must not define `preinstall`, `install`, or `postinstall` scripts.
+
+## Security expectations
+
+Verified packages must be boring:
+
+- Public source repository.
+- npm trusted publishing or provenance.
+- No install scripts.
+- No binaries.
+- Small runtime dependency surface.
+- No network calls during import or plugin construction.
+- Tests that prove the plugin registers with `createEmailClient`.
+
+These checks reduce supply-chain risk, but they do not make third-party code risk-free.
+
+## Registry entry
+
+Add the package to `apps/fumadocs/content/community/plugins.json`.
+
+```json
+{
+  "name": "Require metadata",
+  "package": "email-sdk-require-metadata",
+  "kind": "plugin",
+  "status": "community",
+  "description": "Blocks sends unless required metadata is present.",
+  "href": "https://www.npmjs.com/package/email-sdk-require-metadata",
+  "repo": "https://github.com/acme/email-sdk-require-metadata",
+  "maintainer": "acme",
+  "pluginId": "require-metadata"
+}
+```
+
+Use `status: "verified"` only after the package passes the verification checklist for one published version.
+
+## Verify locally
+
+```bash
+bun run community:check
+```
+
+CI runs the same registry check. Verified entries also get a package tarball audit in CI.
+
+## Next
+
+Adapter packages follow the same process, but should also document field support. See [Publish a community adapter](/docs/guides/authoring/publish-community-adapter).

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Guides
+description: Task-based guides for extending Email SDK.
+icon: BookOpen
+---
+
+Use these guides when you are building something that should live outside one send call: a reusable plugin, a custom provider adapter, a community package, or test helpers around email behavior.
+
+## Build
+
+<Cards>
+  <Card
+    title="Create your first plugin"
+    href="/docs/guides/authoring/create-first-plugin"
+    description="Build a policy plugin that blocks sends missing required metadata."
+  />
+  <Card
+    title="Create an adapter"
+    href="/docs/guides/authoring/create-adapter"
+    description="Implement a provider adapter and expose it as a plugin."
+  />
+  <Card
+    title="Publish a community adapter"
+    href="/docs/guides/authoring/publish-community-adapter"
+    description="Shape package exports, docs, names, and tests for reuse."
+  />
+</Cards>
+
+## Test
+
+<Cards>
+  <Card
+    title="Test email behavior"
+    href="/docs/guides/test-email-behavior"
+    description="Use memory providers and capture plugins to assert send behavior."
+  />
+</Cards>
+
+## Where reference lives
+
+Guides are procedural. Use the reference pages when you need exact fields and contracts:
+
+| Need                       | Page                                                 |
+| -------------------------- | ---------------------------------------------------- |
+| Client options             | [Client](/docs/reference/client)                     |
+| Message shape              | [Message](/docs/reference/message)                   |
+| Adapter contract           | [Adapter contract](/docs/reference/adapter-contract) |
+| Plugin types and lifecycle | [Plugin API](/docs/plugins/api)                      |
+| Provider field limits      | [Field support](/docs/adapters/field-support)        |

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Guides",
+  "icon": "BookOpen",
+  "pages": ["authoring", "test-email-behavior"]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/guides/test-email-behavior.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/guides/test-email-behavior.mdx
@@ -1,0 +1,129 @@
+---
+title: Test email behavior
+description: Assert sends, retries, fallbacks, and plugin behavior.
+icon: FlaskConical
+---
+
+Use the memory provider when you want to replace the provider. Use the capture plugin when you want to observe the normal send pipeline.
+
+## Memory provider
+
+The memory provider stores successful sends and never calls an external API.
+
+```ts
+import { describe, expect, test } from "bun:test";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { memoryProvider } from "@opencoredev/email-sdk/testing";
+
+describe("welcome email", () => {
+  test("sends the expected subject", async () => {
+    const memory = memoryProvider();
+    const email = createEmailClient({
+      adapters: [memory],
+    });
+
+    await email.send({
+      from: "test@example.com",
+      to: "user@example.com",
+      subject: "Welcome",
+      text: "Hello",
+    });
+
+    expect(memory.raw.sent[0]?.message.subject).toBe("Welcome");
+  });
+});
+```
+
+## Capture plugin
+
+The capture plugin records lifecycle events. It can be used with the memory provider or with a custom test adapter.
+
+```ts
+import { capturePlugin } from "@opencoredev/email-sdk/plugins/capture";
+
+const memory = memoryProvider();
+const email = createEmailClient({
+  adapters: [memory],
+  plugins: [capturePlugin()],
+});
+
+await email.send({
+  from: "test@example.com",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Hello",
+});
+
+expect(email.capture.events.map((event) => event.type)).toEqual(["beforeSend", "afterSend"]);
+```
+
+## Assert defaults
+
+Defaults run before message validation, so tests can assert the final message that reached the provider.
+
+```ts
+import { defaultsPlugin } from "@opencoredev/email-sdk/plugins/defaults";
+
+const memory = memoryProvider();
+const email = createEmailClient({
+  adapters: [memory],
+  plugins: [
+    defaultsPlugin({
+      headers: { "X-App": "billing" },
+      sendMetadata: { service: "billing" },
+    }),
+  ],
+});
+
+await email.send(
+  {
+    from: "billing@example.com",
+    to: "user@example.com",
+    subject: "Receipt",
+    text: "Thanks.",
+  },
+  {
+    metadata: { route: "receipt" },
+  },
+);
+
+expect(memory.raw.sent[0]?.message.headers).toMatchObject({ "X-App": "billing" });
+```
+
+## Assert fallback
+
+Use a small failing adapter plus a memory adapter.
+
+```ts
+import type { EmailProvider } from "@opencoredev/email-sdk";
+
+const failing: EmailProvider = {
+  name: "failing",
+  async send() {
+    throw new Error("provider down");
+  },
+};
+
+const backup = memoryProvider("backup");
+const email = createEmailClient({
+  adapters: [failing, backup],
+  fallback: ["backup"],
+});
+
+await email.send({
+  from: "test@example.com",
+  to: "user@example.com",
+  subject: "Fallback",
+  text: "Hello",
+});
+
+expect(backup.raw.sent).toHaveLength(1);
+```
+
+## Test checklist
+
+- Use `memoryProvider()` for app tests that should not call real providers.
+- Use `capturePlugin()` when you need lifecycle events.
+- Assert provider field support with adapter unit tests.
+- Add one test for fallback if the route matters.
+- Add one test for plugin ordering when multiple plugins mutate the same message.

--- a/apps/fumadocs/content/docs-v/0.3.0/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/index.mdx
@@ -1,0 +1,85 @@
+---
+title: Email SDK
+description: A small TypeScript email client with swappable adapters, plugins, and explicit provider limits.
+icon: Mail
+---
+
+Email SDK is a small TypeScript package for transactional email. It gives your application one client and one message shape while keeping provider-specific behavior visible in the adapter docs.
+
+Use Resend for a simple API path, SMTP when you want a cheap or self-managed route, or another provider when its field support fits your app better. Add plugins for shared defaults, observability, capture, or community adapters. Your application code still calls `send`; the adapter decides how that message maps to the provider.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+```
+
+## Start here
+
+<Cards>
+  <Card
+    title="Install package and CLI"
+    href="/docs/getting-started/install"
+    description="Use the scoped npm package and the email-sdk command."
+  />
+  <Card
+    title="Send your first email"
+    href="/docs/getting-started/quickstart"
+    description="Install the SDK, create a client, and send a message."
+  />
+  <Card
+    title="Understand adapters"
+    href="/docs/concepts/adapter-model"
+    description="Learn how adapters and routing names work."
+  />
+  <Card
+    title="Browse adapters"
+    href="/docs/adapters"
+    description="See all supported email services."
+  />
+  <Card
+    title="Use plugins"
+    href="/docs/plugins"
+    description="Add defaults, observability, capture, adapter plugins, and reusable send behavior."
+  />
+  <Card
+    title="Build an adapter"
+    href="/docs/guides/authoring/create-adapter"
+    description="Write your first custom provider adapter and package it for reuse."
+  />
+  <Card
+    title="Read the API reference"
+    href="/docs/reference/client"
+    description="Look up client options, messages, errors, and the CLI."
+  />
+</Cards>
+
+## What is included
+
+- `createEmailClient` for one shared email client.
+- `email.send()` for one message.
+- `email.sendBatch()` for small batches where each result is reported separately.
+- Fifteen adapters, including Resend, SMTP, Postmark, SendGrid, Mailgun, and MailerSend.
+- Retry and fallback options that run in the order you configure.
+- Hooks for logs, metrics, tracing, and retry visibility.
+- Plugins for defaults, observability, capture, community adapters, and reusable send behavior.
+- A small CLI for setup checks, dry runs, and smoke-test sends.
+- A repo-local agent skill for future coding agents.
+
+## What stays small
+
+Email SDK does not try to be a template engine, campaign tool, queue, analytics platform, or full email operations suite. It is the layer many apps keep rebuilding: adapter setup, a consistent send call, typed errors, and a fallback path that is explicit enough to debug.
+
+## Provider behavior is not hidden
+
+Email providers do not all support the same fields. A fallback route is only safe when the backup adapter can represent the same class of message. Before choosing routes, read the <a href="/docs/adapters/field-support">field support guide</a>; unsupported fields should fail fast instead of being silently dropped.

--- a/apps/fumadocs/content/docs-v/0.3.0/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "Email SDK",
+  "pages": [
+    "index",
+    "getting-started",
+    "concepts",
+    "adapters",
+    "plugins",
+    "guides",
+    "reference",
+    "agents"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/api.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/api.mdx
@@ -1,0 +1,93 @@
+---
+title: Plugin API
+description: Type reference for EmailPlugin and EmailSendMiddleware.
+icon: Braces
+---
+
+This page is the type reference. For examples, start with Writing plugins.
+
+## EmailPlugin
+
+```ts
+type EmailPlugin<TExtension extends object = object> = {
+  id: string;
+  adapters?: EmailProvider[] | ((ctx: EmailPluginContext) => EmailProvider[]);
+  hooks?: EmailHooks;
+  middleware?: EmailSendMiddleware[];
+  extendClient?: (ctx: EmailPluginContext) => TExtension;
+};
+```
+
+| Field          | Notes                                                 |
+| -------------- | ----------------------------------------------------- |
+| `id`           | Required stable plugin ID. Duplicate IDs throw.       |
+| `adapters`     | Providers to register. Duplicate adapter names throw. |
+| `hooks`        | Observability callbacks that run before user `hooks`. |
+| `middleware`   | Send-pipeline middleware.                             |
+| `extendClient` | Adds non-conflicting helper properties to the client. |
+
+`createEmailClient` is synchronous, so plugin adapter factories must return adapters synchronously.
+
+## EmailPluginContext
+
+```ts
+type EmailPluginContext = {
+  adapters: ReadonlyMap<string, EmailProvider>;
+  defaultAdapter: string;
+  addAdapter(adapter: EmailProvider): void;
+};
+```
+
+## EmailSendMiddleware
+
+```ts
+type EmailSendMiddleware = {
+  beforeSend?: (event: EmailBeforeSendEvent) => MaybePromise<EmailBeforeSendResult | void>;
+  afterSend?: (event: EmailAfterSendEvent) => MaybePromise<void>;
+  onError?: (event: EmailErrorEvent) => MaybePromise<void>;
+};
+```
+
+## beforeSend
+
+Runs once per `send` call before message validation and before any adapter is called.
+
+```ts
+beforeSend(event) {
+  return {
+    message: {
+      ...event.message,
+      headers: { "X-App": "billing" },
+    },
+    options: {
+      metadata: { template: "receipt" },
+    },
+  };
+}
+```
+
+Thrown errors stop the send.
+
+## afterSend
+
+Runs after a provider returns a normalized response.
+
+```ts
+afterSend(event) {
+  console.log(event.provider, event.response.id);
+}
+```
+
+Thrown errors are swallowed.
+
+## onError
+
+Runs after a provider attempt fails.
+
+```ts
+onError(event) {
+  console.error(event.provider, event.error);
+}
+```
+
+Fallback adapters can still run after this callback. Thrown errors are swallowed.

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/capture.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/capture.mdx
@@ -1,0 +1,81 @@
+---
+title: Capture plugin
+description: Record email events in tests.
+icon: ClipboardCheck
+---
+
+Use the capture plugin in tests when you need to assert what the email client tried to do.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { capturePlugin } from "@opencoredev/email-sdk/plugins/capture";
+import { memoryProvider } from "@opencoredev/email-sdk/testing";
+
+const memory = memoryProvider();
+const email = createEmailClient({
+  adapters: [memory],
+  plugins: [capturePlugin()],
+});
+
+await email.send({
+  from: "test@example.com",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Hello",
+});
+
+expect(email.capture.events).toHaveLength(2);
+expect(memory.raw.sent).toHaveLength(1);
+```
+
+## What gets captured
+
+| Event        | Meaning                                    |
+| ------------ | ------------------------------------------ |
+| `beforeSend` | The message entered the send pipeline.     |
+| `afterSend`  | A provider returned a normalized response. |
+| `retry`      | Email SDK scheduled another attempt.       |
+| `error`      | A provider attempt failed.                 |
+
+Captured events include the message and whichever provider, attempt, metadata, response, or error details exist at that point in the lifecycle.
+
+## Clear events
+
+```ts
+email.capture.clear();
+```
+
+## Bring your own store
+
+```ts
+import { capturePlugin, createEmailCaptureStore } from "@opencoredev/email-sdk/plugins/capture";
+
+const store = createEmailCaptureStore();
+const email = createEmailClient({
+  adapters: [memoryProvider()],
+  plugins: [capturePlugin(store)],
+});
+```
+
+## Multiple capture stores
+
+Use a custom `id` for plugin identity and a custom `clientKey` for the typed client property.
+
+```ts
+const email = createEmailClient({
+  adapters: [memoryProvider()],
+  plugins: [
+    capturePlugin({ id: "capture:primary", clientKey: "primaryCapture" }),
+    capturePlugin({ id: "capture:audit", clientKey: "auditCapture" }),
+  ],
+});
+
+email.primaryCapture.clear();
+email.auditCapture.clear();
+```
+
+## Capture vs memory provider
+
+`capturePlugin()` records lifecycle events. It does not stop real provider calls.
+
+`memoryProvider()` is the adapter you use when a test should avoid external email. In most tests, use both: memory avoids the network, capture proves the SDK pipeline behaved correctly.

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/defaults.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/defaults.mdx
@@ -1,0 +1,86 @@
+---
+title: Defaults plugin
+description: Apply shared message and send-option defaults.
+icon: Settings
+---
+
+Use the defaults plugin when many sends need the same headers, tags, metadata, reply-to address, or idempotency key format.
+
+```ts
+import { defaultsPlugin } from "@opencoredev/email-sdk/plugins/defaults";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  plugins: [
+    defaultsPlugin({
+      headers: { "X-App": "billing" },
+      tags: [{ name: "service", value: "billing" }],
+      sendMetadata: { service: "billing" },
+      replyTo: "support@example.com",
+      idempotencyKeyPrefix: "billing_",
+    }),
+  ],
+});
+```
+
+## Use it for
+
+- App or service headers.
+- Shared tags for routing or provider dashboards.
+- Hook metadata such as `service`, `route`, or `template`.
+- A default reply-to address.
+- Idempotency key prefixes.
+
+## Options
+
+| Option                 | Writes to                | Override rule                                                   |
+| ---------------------- | ------------------------ | --------------------------------------------------------------- |
+| `headers`              | `message.headers`        | Message headers win.                                            |
+| `tags`                 | `message.tags`           | Message tags are appended after default tags.                   |
+| `metadata`             | `message.metadata`       | Message metadata wins.                                          |
+| `sendMetadata`         | `sendOptions.metadata`   | Per-send metadata wins.                                         |
+| `replyTo`              | `message.replyTo`        | Used only when the message has no `replyTo`.                    |
+| `idempotencyKey`       | Message and send options | Used only when no idempotency key exists.                       |
+| `idempotencyKeyPrefix` | Message and send options | Added only when the key does not already start with the prefix. |
+
+## Override a default
+
+```ts
+await email.send(
+  {
+    from: "billing@example.com",
+    to: "user@example.com",
+    subject: "Receipt",
+    text: "Thanks for your order.",
+    headers: {
+      "X-App": "checkout",
+    },
+  },
+  {
+    metadata: {
+      route: "checkout.receipt",
+    },
+  },
+);
+```
+
+Here, `X-App: checkout` wins over the default `X-App: billing`.
+
+## Stack defaults
+
+Use custom IDs for multiple defaults layers.
+
+```ts
+plugins: [
+  defaultsPlugin({
+    id: "defaults:app",
+    headers: { "X-App": "acme" },
+  }),
+  defaultsPlugin({
+    id: "defaults:billing",
+    tags: [{ name: "team", value: "billing" }],
+  }),
+];
+```
+
+Defaults run before adapter validation. If a default adds a field the selected adapter cannot represent, Email SDK throws before calling the provider.

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Built-in",
+  "icon": "PackagePlus",
+  "pages": ["defaults", "observability", "capture"]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/observability.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/built-in/observability.mdx
@@ -1,0 +1,84 @@
+---
+title: Observability plugin
+description: Emit redacted log, metric, and trace events.
+icon: Activity
+---
+
+Use the observability plugin when you want to see email behavior without logging recipients or message bodies.
+
+```ts
+import { observabilityPlugin } from "@opencoredev/email-sdk/plugins/observability";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  plugins: [
+    observabilityPlugin({
+      log(event) {
+        console.log(event.type, event.provider);
+      },
+      metric(event) {
+        statsd.increment(event.type, {
+          provider: event.provider,
+        });
+      },
+      trace(event) {
+        tracer.event("email", event);
+      },
+    }),
+  ],
+});
+```
+
+## Events
+
+| Event         | Fires when                                 |
+| ------------- | ------------------------------------------ |
+| `email.sent`  | A provider returns a normalized response.  |
+| `email.retry` | Email SDK schedules another retry attempt. |
+| `email.error` | A provider attempt fails.                  |
+
+Each event includes provider name, attempt number, metadata, and a redacted message summary.
+
+## Redacted message shape
+
+```ts
+type RedactedEmailMessage = {
+  subject: string;
+  toCount: number;
+  ccCount: number;
+  bccCount: number;
+  hasHtml: boolean;
+  hasText: boolean;
+  attachmentCount: number;
+  tagNames: string[];
+  metadataKeys: string[];
+};
+```
+
+By default, the plugin does not include recipient addresses, HTML, text, attachment content, or metadata values.
+
+## Custom redaction
+
+```ts
+observabilityPlugin({
+  redactMessage(message) {
+    return {
+      subject: message.subject,
+      toCount: Array.isArray(message.to) ? message.to.length : 1,
+      template: message.metadata?.template ?? "unknown",
+      hasAttachments: Boolean(message.attachments?.length),
+    };
+  },
+  log(event) {
+    console.log(event);
+  },
+});
+```
+
+Keep secrets, raw tokens, recipient lists, and body content out of logs unless your app explicitly needs and protects that data.
+
+## Failure behavior
+
+Observability callbacks are non-blocking. If `log`, `metric`, or `trace` throws, Email SDK swallows that error so logging failures do not hide provider failures.
+
+Use a custom `beforeSend` middleware plugin when a rule should block a send.

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/community.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/community.mdx
@@ -1,0 +1,26 @@
+---
+title: Community plugins
+description: Static registry for community Email SDK plugins and adapters.
+icon: Users
+---
+
+Community plugins are third-party npm packages. The registry is static and maintained in this repository by pull request.
+
+<CommunityPluginRegistry />
+
+## Labels
+
+| Label     | Meaning                                                    |
+| --------- | ---------------------------------------------------------- |
+| Community | Listed by pull request. The package is not endorsed.       |
+| Verified  | Passed the registry checks for a specific package version. |
+| Official  | Maintained by OpenCore or in this repository.              |
+
+Verified does not mean risk-free. It means the package passed the static checks documented in the registry schema.
+
+## Add a package
+
+Publish a package to npm, then open a pull request that adds an entry to `apps/fumadocs/content/community/plugins.json`.
+If you want feedback before writing the entry, open the `Community plugin listing` issue template with the package and source links.
+
+Start with [Publish a community plugin](/docs/guides/authoring/publish-community-plugin).

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/index.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/index.mdx
@@ -1,0 +1,113 @@
+---
+title: Plugins
+description: Built-in plugins and extension points for Email SDK.
+icon: Plug
+---
+
+Plugins are add-ons for an email client. They can register adapters, change a message before validation, record send activity, or expose a small typed helper on the client.
+
+Most apps should start with the built-in plugins. If a behavior should be reused across apps, move it into a plugin.
+
+## Built-in plugins
+
+| Plugin        | Import                                         | Use it when                                                                         |
+| ------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Defaults      | `@opencoredev/email-sdk/plugins/defaults`      | Every send needs shared headers, tags, metadata, reply-to, or idempotency defaults. |
+| Observability | `@opencoredev/email-sdk/plugins/observability` | You want logs, metrics, or traces without leaking recipients or email body content. |
+| Capture       | `@opencoredev/email-sdk/plugins/capture`       | Tests need to inspect attempted sends, retries, responses, and errors.              |
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { defaultsPlugin } from "@opencoredev/email-sdk/plugins/defaults";
+import { observabilityPlugin } from "@opencoredev/email-sdk/plugins/observability";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  plugins: [
+    defaultsPlugin({
+      headers: { "X-App": "billing" },
+      sendMetadata: { service: "billing" },
+    }),
+    observabilityPlugin({
+      log(event) {
+        console.log(event.type, event.provider);
+      },
+    }),
+  ],
+});
+```
+
+## What plugins can do
+
+| Capability        | Example                                                           |
+| ----------------- | ----------------------------------------------------------------- |
+| Register adapters | A community provider package can add its own `EmailProvider`.     |
+| Change a message  | Defaults can add headers before provider validation.              |
+| Observe sends     | Observability can emit redacted success, retry, and error events. |
+| Capture tests     | Capture can expose `email.capture.events`.                        |
+| Add helpers       | A plugin can add a small typed property to the returned client.   |
+
+## What plugins cannot do
+
+Email SDK plugins do not add databases, migrations, HTTP endpoints, route middleware, rate limits, or server/client plugin pairs. Those are framework-level features. Email SDK plugins stay focused on sending email.
+
+## Common plugin shapes
+
+| Shape             | Where to start                                                                        |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| Shared defaults   | Use the [defaults plugin](/docs/plugins/built-in/defaults).                           |
+| Redacted logging  | Use the [observability plugin](/docs/plugins/built-in/observability).                 |
+| Test capture      | Use the [capture plugin](/docs/plugins/built-in/capture).                             |
+| Custom provider   | Follow [Create an adapter](/docs/guides/authoring/create-adapter).                    |
+| Reusable behavior | Follow [Create your first plugin](/docs/guides/authoring/create-first-plugin).        |
+| Community package | Follow [Publish a community plugin](/docs/guides/authoring/publish-community-plugin). |
+
+## Order
+
+Plugin order is deterministic.
+
+1. Direct `adapters` register first.
+2. Plugins run in array order.
+3. Plugin adapters register in plugin order.
+4. Duplicate plugin IDs throw.
+5. Duplicate adapter names throw.
+6. `beforeSend` middleware runs before message validation.
+7. Plugin hooks run before user `hooks`.
+
+Use a custom `id` when mounting more than one instance of the same plugin type. If the plugin extends the client, also give each instance a distinct extension key, such as `capturePlugin({ id: "capture:audit", clientKey: "auditCapture" })`.
+
+## Next
+
+<Cards>
+  <Card
+    title="Defaults plugin"
+    href="/docs/plugins/built-in/defaults"
+    description="Apply shared message and send-option defaults."
+  />
+  <Card
+    title="Observability plugin"
+    href="/docs/plugins/built-in/observability"
+    description="Emit redacted log, metric, and trace events."
+  />
+  <Card
+    title="Capture plugin"
+    href="/docs/plugins/built-in/capture"
+    description="Record email behavior in tests."
+  />
+  <Card
+    title="Community plugins"
+    href="/docs/plugins/community"
+    description="Browse static community plugin listings and verification labels."
+  />
+  <Card
+    title="Writing plugins"
+    href="/docs/guides/authoring/create-first-plugin"
+    description="Build a reusable policy plugin step by step."
+  />
+  <Card
+    title="Create an adapter"
+    href="/docs/guides/authoring/create-adapter"
+    description="Write a custom provider adapter and wrap it as a plugin."
+  />
+</Cards>

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Plugins",
+  "icon": "Plug",
+  "pages": ["built-in", "community", "writing-plugins", "api"]
+}

--- a/apps/fumadocs/content/docs-v/0.3.0/plugins/writing-plugins.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/plugins/writing-plugins.mdx
@@ -1,0 +1,145 @@
+---
+title: Writing plugins
+description: Create adapter, middleware, and community plugins.
+icon: PackagePlus
+---
+
+Write a plugin when email behavior should be reused across clients, apps, or packages.
+
+Start with one of these shapes:
+
+| Shape             | Use it for                                                    |
+| ----------------- | ------------------------------------------------------------- |
+| Adapter plugin    | Package a provider as `plugins: [providerPlugin()]`.          |
+| Middleware plugin | Add defaults, policy, capture, or observability around sends. |
+| Hook plugin       | Reuse existing `EmailHooks` callbacks.                        |
+| Client extension  | Add a small typed helper to the returned client.              |
+
+## Adapter plugin
+
+Adapter plugins are the best shape for community providers.
+
+```ts
+import type { EmailPlugin } from "@opencoredev/email-sdk";
+
+export function communityMail(options: { apiKey: string }): EmailPlugin {
+  return {
+    id: "community-mail",
+    adapters: [
+      {
+        name: "community-mail",
+        async send(message, context) {
+          const response = await fetch("https://api.example.com/send", {
+            method: "POST",
+            signal: context.signal,
+            headers: {
+              Authorization: `Bearer ${options.apiKey}`,
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(message),
+          });
+
+          const body = await response.json();
+
+          return {
+            provider: "community-mail",
+            id: body.id,
+            messageId: body.id,
+            raw: body,
+          };
+        },
+      },
+    ],
+  };
+}
+```
+
+Application code stays clean:
+
+```ts
+const email = createEmailClient({
+  plugins: [communityMail({ apiKey: process.env.COMMUNITY_MAIL_API_KEY! })],
+});
+```
+
+## Middleware plugin
+
+Use `beforeSend` when the plugin needs to change or block a message.
+
+```ts
+import type { EmailPlugin } from "@opencoredev/email-sdk";
+
+export function requireMetadata(key: string): EmailPlugin {
+  return {
+    id: `require-metadata:${key}`,
+    middleware: [
+      {
+        beforeSend(event) {
+          if (!event.options?.metadata?.[key]) {
+            throw new Error(`Missing email metadata: ${key}`);
+          }
+        },
+      },
+    ],
+  };
+}
+```
+
+`beforeSend` errors are not swallowed. Use it for policy.
+
+Use `afterSend` and `onError` for observability work that should not block provider behavior.
+
+## Programmatic adapter registration
+
+Use `ctx.addAdapter` when a plugin creates adapters dynamically.
+
+```ts
+export function regionalMail(options: RegionOptions): EmailPlugin {
+  return {
+    id: "regional-mail",
+    adapters(ctx) {
+      ctx.addAdapter(createRegionAdapter("mail-us", options.us));
+      ctx.addAdapter(createRegionAdapter("mail-eu", options.eu));
+
+      return [];
+    },
+  };
+}
+```
+
+Duplicate adapter names throw. If a factory both calls `ctx.addAdapter(adapter)` and returns the same adapter object, Email SDK registers it once.
+
+## Client extension
+
+Use `extendClient` for tiny helpers or stores. Keep it boring.
+
+```ts
+export function routeNamesPlugin(): EmailPlugin<{
+  routeNames: string[];
+}> {
+  return {
+    id: "route-names",
+    extendClient(ctx) {
+      return {
+        routeNames: [...ctx.adapters.keys()],
+      };
+    },
+  };
+}
+```
+
+Extension keys cannot collide with built-in client keys like `send`, `sendBatch`, `adapter`, or `defaultAdapter`.
+
+## Community adapter checklist
+
+- Use a stable plugin `id` and adapter `name`.
+- Keep credentials in plugin options.
+- Support `context.signal` for network requests.
+- Pass `context.idempotencyKey` when the provider supports idempotency.
+- Return normalized `id`, `messageId`, `accepted`, or `rejected` fields when available.
+- Put provider responses in `raw` when useful for debugging.
+- Map every supported `EmailMessage` field.
+- Reject unsupported fields before calling the provider.
+- Test payloads with injected `fetch` or a local test server.
+
+Community packages can export both a plain provider factory and an adapter plugin. Use the plugin shape when you want the one-call setup path.

--- a/apps/fumadocs/content/docs-v/0.3.0/reference/adapter-contract.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/reference/adapter-contract.mdx
@@ -1,0 +1,85 @@
+---
+title: Adapter contract
+description: Reference for writing a custom Email SDK adapter.
+icon: Plug
+---
+
+Custom adapters are plain objects.
+
+```ts
+import type { EmailProvider } from "@opencoredev/email-sdk";
+
+export const customAdapter: EmailProvider = {
+  name: "custom",
+  async send(message, context) {
+    const response = await fetch("https://api.example.com/email", {
+      method: "POST",
+      signal: context.signal,
+      body: JSON.stringify(message),
+    });
+
+    const body = await response.json();
+
+    return {
+      provider: "custom",
+      id: body.id,
+      raw: body,
+    };
+  },
+};
+```
+
+Use a plain adapter directly:
+
+```ts
+createEmailClient({ adapters: [customAdapter] });
+```
+
+Or package it as an adapter plugin:
+
+```ts
+import type { EmailPlugin } from "@opencoredev/email-sdk";
+
+export function customAdapterPlugin(): EmailPlugin {
+  return {
+    id: "custom",
+    adapters: [customAdapter],
+  };
+}
+
+createEmailClient({ plugins: [customAdapterPlugin()] });
+```
+
+## `EmailProvider`
+
+```ts
+type EmailProvider<TRaw = unknown> = {
+  name: string;
+  send(message: EmailMessage, context: EmailProviderContext): MaybePromise<EmailProviderResponse>;
+  raw?: TRaw;
+};
+```
+
+## `EmailProviderContext`
+
+| Field            | Type                      | Notes                                          |
+| ---------------- | ------------------------- | ---------------------------------------------- |
+| `signal`         | `AbortSignal`             | Optional abort signal.                         |
+| `idempotencyKey` | `string`                  | Optional key from the message or send options. |
+| `attempt`        | `number`                  | Attempt number for this adapter.               |
+| `metadata`       | `Record<string, unknown>` | Metadata passed to `send`.                     |
+
+## Adapter responses
+
+```ts
+type EmailProviderResponse = {
+  id?: string;
+  provider: string;
+  messageId?: string;
+  accepted?: string[];
+  rejected?: string[];
+  raw?: unknown;
+};
+```
+
+Return the provider's raw response in `raw` when it helps callers debug or inspect provider-specific fields.

--- a/apps/fumadocs/content/docs-v/0.3.0/reference/cli.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/reference/cli.mdx
@@ -1,0 +1,137 @@
+---
+title: CLI
+description: Reference for the email-sdk command-line smoke test.
+icon: Terminal
+---
+
+The CLI is intentionally small. Use it to inspect adapters, check environment variables, validate a message with `--dry-run`, and send a smoke-test email from your terminal.
+
+The npm package is `@opencoredev/email-sdk`; the CLI command it installs is `email-sdk`.
+
+## Install or run
+
+Run the CLI once with `bunx`:
+
+```bash
+bunx --yes @opencoredev/email-sdk adapters
+```
+
+Install the SDK in a project:
+
+```bash
+bun add @opencoredev/email-sdk
+```
+
+Then run the installed binary:
+
+```bash
+bun email-sdk adapters
+```
+
+The CLI requires Bun on your `PATH`. Check the installed version before comparing behavior against
+the docs:
+
+```bash
+bun email-sdk version
+```
+
+## Send
+
+```bash
+bunx --yes @opencoredev/email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to "user@example.com" \
+  --subject "Hello" \
+  --text "It works"
+```
+
+## Adapters
+
+```bash
+bunx --yes @opencoredev/email-sdk adapters
+```
+
+| Adapter      | Required environment                                       |
+| ------------ | ---------------------------------------------------------- |
+| `resend`     | `RESEND_API_KEY`                                           |
+| `postmark`   | `POSTMARK_SERVER_TOKEN`                                    |
+| `sendgrid`   | `SENDGRID_API_KEY`                                         |
+| `ses`        | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| `mailgun`    | `MAILGUN_API_KEY`, `MAILGUN_DOMAIN`                        |
+| `mailersend` | `MAILERSEND_API_KEY`                                       |
+| `brevo`      | `BREVO_API_KEY`                                            |
+| `mailchimp`  | `MAILCHIMP_API_KEY`                                        |
+| `sparkpost`  | `SPARKPOST_API_KEY`                                        |
+| `loops`      | `LOOPS_API_KEY`, `LOOPS_TRANSACTIONAL_ID`                  |
+| `plunk`      | `PLUNK_API_KEY`                                            |
+| `mailtrap`   | `MAILTRAP_API_KEY`                                         |
+| `scaleway`   | `SCALEWAY_SECRET_KEY`, `SCALEWAY_PROJECT_ID`               |
+| `zeptomail`  | `ZEPTOMAIL_TOKEN`                                          |
+| `mailpace`   | `MAILPACE_API_KEY`                                         |
+| `smtp`       | `SMTP_HOST`, plus SMTP auth variables when needed          |
+
+If `--adapter` is omitted, the CLI selects the first adapter with all required environment variables set.
+
+## Doctor
+
+```bash
+bunx --yes @opencoredev/email-sdk doctor --adapter resend
+```
+
+`doctor` checks whether the selected adapter has the required environment variables.
+
+## Version
+
+```bash
+bun email-sdk version
+bun email-sdk --version
+bun email-sdk -v
+bun email-sdk version --json
+```
+
+`version` reads the installed `@opencoredev/email-sdk` package metadata, so it reports the SDK and CLI version from the package currently on your machine. The docs version picker in the top navigation uses the same package version from this repository.
+
+## Flags
+
+| Flag                    | Adapter           | Notes                                                  |
+| ----------------------- | ----------------- | ------------------------------------------------------ |
+| `--adapter`             | all               | Adapter routing name.                                  |
+| `--provider`            | all               | Alias for `--adapter`.                                 |
+| `--from`                | all               | Sender address.                                        |
+| `--to`                  | all               | Recipient address. Comma-separated values are allowed. |
+| `--subject`             | all               | Message subject.                                       |
+| `--text`                | all               | Plain text body.                                       |
+| `--html`                | all               | HTML body.                                             |
+| `--cc`                  | send              | Comma-separated CC addresses.                          |
+| `--bcc`                 | send              | Comma-separated BCC addresses.                         |
+| `--reply-to`            | send              | Comma-separated reply-to addresses.                    |
+| `--header`              | send              | Header in `Name: value` format. Repeatable.            |
+| `--tag`                 | send              | Tag in `name=value` format. Repeatable.                |
+| `--metadata`            | send              | Metadata in `key=value` format. Repeatable.            |
+| `--attachment`          | send              | Local file path, optionally `path:content/type`.       |
+| `--message`             | send              | Read an `EmailMessage` JSON payload from a file.       |
+| `--dry-run`             | all               | Validate and print the send plan without sending.      |
+| `--json`                | version, adapters | Print output as JSON.                                  |
+| `--api-key`             | many              | Overrides the adapter API key variable.                |
+| `--server-token`        | Postmark          | Overrides `POSTMARK_SERVER_TOKEN`.                     |
+| `--message-stream`      | Postmark          | Optional message stream.                               |
+| `--access-key-id`       | AWS SES           | Overrides `AWS_ACCESS_KEY_ID`.                         |
+| `--secret-access-key`   | AWS SES           | Overrides `AWS_SECRET_ACCESS_KEY`.                     |
+| `--region`              | AWS SES           | Overrides `AWS_REGION`.                                |
+| `--session-token`       | AWS SES           | Overrides `AWS_SESSION_TOKEN`.                         |
+| `--configuration-set`   | AWS SES           | Overrides `AWS_SES_CONFIGURATION_SET`.                 |
+| `--domain`              | Mailgun           | Overrides `MAILGUN_DOMAIN`.                            |
+| `--transactional-id`    | Loops             | Overrides `LOOPS_TRANSACTIONAL_ID`.                    |
+| `--project-id`          | Scaleway          | Overrides `SCALEWAY_PROJECT_ID`.                       |
+| `--secret-key`          | Scaleway          | Overrides `SCALEWAY_SECRET_KEY`.                       |
+| `--token`               | ZeptoMail         | Overrides `ZEPTOMAIL_TOKEN`.                           |
+| `--host`                | SMTP              | Overrides `SMTP_HOST`.                                 |
+| `--port`                | SMTP              | Overrides `SMTP_PORT`.                                 |
+| `--secure`              | SMTP              | Set to `true` for secure SMTP.                         |
+| `--require-tls`         | SMTP              | Require STARTTLS.                                      |
+| `--allow-insecure-auth` | SMTP              | Allow SMTP AUTH without TLS.                           |
+| `--user`                | SMTP              | Overrides `SMTP_USER`.                                 |
+| `--pass`                | SMTP              | Overrides `SMTP_PASS`.                                 |
+
+The CLI prints the normalized adapter response as JSON.

--- a/apps/fumadocs/content/docs-v/0.3.0/reference/client.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/reference/client.mdx
@@ -1,0 +1,92 @@
+---
+title: Client
+description: Reference for createEmailClient, send, sendBatch, and adapter helpers.
+icon: Braces
+---
+
+## `createEmailClient(options)`
+
+Creates an email client.
+
+```ts
+const email = createEmailClient({
+  adapters,
+  defaultAdapter,
+  fallback,
+  retry,
+  hooks,
+  plugins,
+});
+```
+
+| Option            | Type               | Default              |
+| ----------------- | ------------------ | -------------------- |
+| `adapters`        | `EmailProvider[]`  | `[]`                 |
+| `providers`       | `EmailProvider[]`  | Alias for `adapters` |
+| `defaultAdapter`  | `string`           | First adapter        |
+| `defaultProvider` | `string`           | First adapter        |
+| `fallback`        | `string[]`         | `[]`                 |
+| `retry`           | `EmailRetryConfig` | No retries           |
+| `hooks`           | `EmailHooks`       | No hooks             |
+| `plugins`         | `EmailPlugin[]`    | `[]`                 |
+
+Routing names must be unique. At least one adapter must be registered directly or through a plugin.
+
+## `email.send(message, options?)`
+
+Sends one message.
+
+```ts
+const result = await email.send(message, {
+  adapter: "resend",
+  fallbackAdapters: ["smtp"],
+  retries: 2,
+  idempotencyKey: "receipt:order_123",
+  metadata: {
+    route: "checkout.receipt",
+  },
+});
+```
+
+| Option              | Type                      | Notes                                     |
+| ------------------- | ------------------------- | ----------------------------------------- |
+| `adapter`           | `string`                  | Override the default routing name.        |
+| `provider`          | `string`                  | Alias for `adapter`.                      |
+| `fallbackAdapters`  | `string[]`                | Override fallback adapters for this send. |
+| `fallbackProviders` | `string[]`                | Alias for `fallbackAdapters`.             |
+| `retries`           | `number`                  | Override retry count for this send.       |
+| `signal`            | `AbortSignal`             | Abort provider work when supported.       |
+| `idempotencyKey`    | `string`                  | Passed to adapters that support it.       |
+| `metadata`          | `Record<string, unknown>` | Passed to hooks.                          |
+
+## `email.sendBatch(messages, options?)`
+
+Sends messages one at a time and returns one result per item.
+
+```ts
+const results = await email.sendBatch([messageA, messageB]);
+```
+
+`sendBatch` does not throw for the first failed item. Failed sends are returned as `{ ok: false, index, error }`.
+
+## `email.adapter(name)`
+
+Returns a registered adapter or throws `EmailProviderNotFoundError`.
+
+```ts
+const resendAdapter = email.adapter("resend");
+```
+
+`email.provider(name)` is kept as an alias.
+
+## `email.withAdapter(name)`
+
+Returns a small client bound to one adapter.
+
+```ts
+const transactional = email.withAdapter("postmark");
+
+await transactional.send(message);
+```
+
+`email.withProvider(name)` is kept as an alias.

--- a/apps/fumadocs/content/docs-v/0.3.0/reference/community-registry.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/reference/community-registry.mdx
@@ -1,0 +1,66 @@
+---
+title: Community registry
+description: Static schema and verification rules for community plugin listings.
+icon: ShieldCheck
+---
+
+The community registry lives at `apps/fumadocs/content/community/plugins.json`. It is a static JSON file rendered by the docs site.
+
+## Entry shape
+
+```ts
+type CommunityRegistryEntry = {
+  name: string;
+  package: string;
+  kind: "adapter" | "plugin" | "hybrid";
+  status: "community" | "verified" | "official";
+  description: string;
+  href: string;
+  repo: string;
+  maintainer: string;
+  pluginId?: string;
+  adapter?: string;
+  importName?: string;
+  verifiedVersion?: string;
+  verification?: {
+    reviewedAt: string;
+    reviewedBy: string;
+    provenance: boolean;
+    noInstallScripts: boolean;
+    runtimeDependencies: number;
+    notes?: string;
+  };
+};
+```
+
+## Status labels
+
+| Status      | Meaning                                                 |
+| ----------- | ------------------------------------------------------- |
+| `community` | Listed package. The package is not endorsed or audited. |
+| `verified`  | Passed registry checks for `verifiedVersion`.           |
+| `official`  | Maintained by OpenCore or in the Email SDK repository.  |
+
+Verification applies to one package version. New releases must be checked before the registry entry updates `verifiedVersion`.
+
+## Verified package rules
+
+Verified entries must:
+
+1. Use npm trusted publishing or provenance.
+2. Use a public source repository that matches package metadata.
+3. Avoid `preinstall`, `install`, and `postinstall` scripts.
+4. Declare `@opencoredev/email-sdk` as a peer dependency.
+5. Avoid package binaries.
+6. Keep runtime dependencies small and documented.
+7. Avoid suspicious install-time or import-time behavior.
+
+Run the registry check before opening a pull request.
+
+```bash
+bun run community:check
+```
+
+In CI, verified and official entries also download the published npm tarball and check the package metadata, install scripts, peer dependency, binary field, repository link, runtime dependency count, and a small set of suspicious JavaScript tokens.
+
+The check is intentionally static. It lowers obvious supply-chain risk, but it does not prove that third-party code is harmless. Users should still read the source, pin versions, and apply their normal dependency review process.

--- a/apps/fumadocs/content/docs-v/0.3.0/reference/errors.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/reference/errors.mdx
@@ -1,0 +1,51 @@
+---
+title: Errors
+description: Reference for Email SDK error classes and retry flags.
+icon: TriangleAlert
+---
+
+Email SDK exports four error classes.
+
+```ts
+import {
+  EmailProviderError,
+  EmailProviderNotFoundError,
+  EmailSdkError,
+  EmailValidationError,
+} from "@opencoredev/email-sdk";
+```
+
+## Error fields
+
+`EmailSdkError` includes:
+
+| Field       | Type      | Notes                                   |
+| ----------- | --------- | --------------------------------------- |
+| `code`      | `string`  | Machine-readable error code.            |
+| `provider`  | `string`  | Routing name when available.            |
+| `status`    | `number`  | HTTP status when available.             |
+| `retryable` | `boolean` | Whether retry is reasonable.            |
+| `details`   | `unknown` | Adapter response body or extra context. |
+
+## Common errors
+
+| Error                        | When it happens                         |
+| ---------------------------- | --------------------------------------- |
+| `EmailValidationError`       | A message or client config is invalid.  |
+| `EmailProviderNotFoundError` | The selected adapter is not registered. |
+| `EmailProviderError`         | An adapter call fails.                  |
+| `EmailSdkError`              | A general SDK-level failure occurs.     |
+
+## Handling adapter errors
+
+```ts
+try {
+  await email.send(message);
+} catch (error) {
+  if (error instanceof EmailProviderError && error.retryable) {
+    // Queue a later retry, alert, or switch to another flow.
+  }
+
+  throw error;
+}
+```

--- a/apps/fumadocs/content/docs-v/0.3.0/reference/message.mdx
+++ b/apps/fumadocs/content/docs-v/0.3.0/reference/message.mdx
@@ -1,0 +1,75 @@
+---
+title: Message
+description: Reference for EmailMessage, addresses, attachments, headers, and tags.
+icon: Mail
+---
+
+## `EmailMessage`
+
+```ts
+type EmailMessage = {
+  from: EmailAddress;
+  to: EmailAddress | EmailAddress[];
+  subject: string;
+  html?: string;
+  text?: string;
+  cc?: EmailAddress | EmailAddress[];
+  bcc?: EmailAddress | EmailAddress[];
+  replyTo?: EmailAddress | EmailAddress[];
+  headers?: Record<string, string> | EmailHeader[];
+  attachments?: EmailAttachment[];
+  tags?: EmailTag[];
+  metadata?: Record<string, string | number | boolean | null>;
+  idempotencyKey?: string;
+};
+```
+
+Every message must include:
+
+- `from`
+- at least one `to`
+- `subject`
+- `html` or `text`
+
+## Addresses
+
+An address can be a string or an object with a display name.
+
+```ts
+const from = "Acme <hello@acme.com>";
+
+const to = {
+  email: "user@example.com",
+  name: "Ada Lovelace",
+};
+```
+
+## Attachments
+
+```ts
+type EmailAttachment = {
+  filename: string;
+  content?: string | Uint8Array | ArrayBuffer | Blob;
+  contentEncoding?: "raw" | "base64";
+  path?: string;
+  contentType?: string;
+  contentId?: string;
+  disposition?: "attachment" | "inline";
+};
+```
+
+Use `content` for in-memory attachments. String content is treated as raw content and encoded to Base64 for API providers that require it. Use `contentEncoding: "base64"` when the string is already Base64.
+
+Use `path` when you want Email SDK to read a local file before sending. See <a href="/docs/adapters/field-support">field support</a> for adapter-specific attachment support.
+
+## Headers and tags
+
+Headers can be an object or a list:
+
+```ts
+headers: {
+  "X-Order-ID": "ord_123";
+}
+```
+
+Tags are provider-specific. Resend accepts `tags`. Postmark maps the first tag to its `Tag` field.

--- a/apps/fumadocs/content/docs-v/0.3.0/reference/meta.json
+++ b/apps/fumadocs/content/docs-v/0.3.0/reference/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Reference",
+  "icon": "LibraryBig",
+  "pages": ["client", "message", "adapter-contract", "community-registry", "errors", "cli"]
+}

--- a/apps/fumadocs/source.config.ts
+++ b/apps/fumadocs/source.config.ts
@@ -27,4 +27,13 @@ export const docsV021 = defineDocs({
   },
 });
 
+export const docsV030 = defineDocs({
+  dir: "content/docs-v/0.3.0",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
+});
+
 export default defineConfig();

--- a/apps/fumadocs/src/lib/source.ts
+++ b/apps/fumadocs/src/lib/source.ts
@@ -1,4 +1,4 @@
-import { docs, docsV020, docsV021 } from "collections/server";
+import { docs, docsV020, docsV021, docsV030 } from "collections/server";
 import { loader } from "fumadocs-core/source";
 
 import { resolveDocsIcon } from "./docs-icons";
@@ -15,10 +15,20 @@ if (!v021DocsVersion) {
   throw new Error("Missing docs source config for v0.2.1");
 }
 
+const v030DocsVersion = docsVersions.find((version) => version.collection === "docsV030");
+if (!v030DocsVersion) {
+  throw new Error("Missing docs source config for v0.3.0");
+}
+
 const sources = {
   docs: loader({
     source: docs.toFumadocsSource(),
     baseUrl: docsRoute,
+    icon: resolveDocsIcon,
+  }),
+  docsV030: loader({
+    source: docsV030.toFumadocsSource(),
+    baseUrl: getDocsVersionBase(v030DocsVersion),
     icon: resolveDocsIcon,
   }),
   docsV021: loader({

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -18,6 +18,16 @@ export const docsVersions = [
     external: false,
   },
   {
+    label: "v0.3.0",
+    version: "v0.3.0",
+    description: "Plugin system release docs",
+    href: "/docs/v/0.3.0",
+    collection: "docsV030",
+    contentPath: "content/docs-v/0.3.0",
+    current: false,
+    external: false,
+  },
+  {
     label: "v0.2.1",
     version: "v0.2.1",
     description: "Docs for the pre-plugin public package",

--- a/apps/fumadocs/src/routes/docs/$.tsx
+++ b/apps/fumadocs/src/routes/docs/$.tsx
@@ -138,6 +138,7 @@ function createDocsClientLoader(collection: (typeof browserCollections)[DocsVers
 
 const clientLoaders = {
   docs: createDocsClientLoader(browserCollections.docs),
+  docsV030: createDocsClientLoader(browserCollections.docsV030),
   docsV021: createDocsClientLoader(browserCollections.docsV021),
   docsV020: createDocsClientLoader(browserCollections.docsV020),
 };


### PR DESCRIPTION
## Summary
- restore the v0.3.0 docs archive so the docs version picker shows it again
- wire the v0.3.0 collection through Fumadocs server and browser loaders
- include the Cloudflare adapter page in the archive so version-picker links do not prerender into a 500

## Validation
- bun run release:ci
- checked release log for Failed to fetch / unhandledRejection / error markers
- verified generated version hrefs for latest, v0.3.0, v0.2.1, and v0.2.0