### PR TITLE
fix: keep version picker on non-doc pages

### DIFF
--- a/apps/fumadocs/content/docs/adapters/cloudflare.mdx
+++ b/apps/fumadocs/content/docs/adapters/cloudflare.mdx
@@ -32,7 +32,7 @@ const email = createEmailClient({
 ## CLI
 
 ```bash
-bunx --yes @opencoredev/email-sdk send \
+npx --yes --package @opencoredev/email-sdk email-sdk send \
   --adapter cloudflare \
   --api-token "$CLOUDFLARE_API_TOKEN" \
   --account-id "$CLOUDFLARE_ACCOUNT_ID" \

--- a/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
+++ b/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
@@ -287,19 +287,19 @@ Test fallback routes with the same message fields your production route uses.
 List supported adapters:
 
 ```bash
-bunx --yes @opencoredev/email-sdk adapters
+npx --yes --package @opencoredev/email-sdk email-sdk adapters
 ```
 
 Check required configuration for one adapter:
 
 ```bash
-RESEND_API_KEY="re_..." bunx --yes @opencoredev/email-sdk doctor --adapter resend
+RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk doctor --adapter resend
 ```
 
 Validate message shape and adapter field support without sending:
 
 ```bash
-bunx --yes @opencoredev/email-sdk send \
+npx --yes --package @opencoredev/email-sdk email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to "user@example.com" \

--- a/apps/fumadocs/src/components/version-picker.tsx
+++ b/apps/fumadocs/src/components/version-picker.tsx
@@ -15,6 +15,7 @@ export function VersionPicker({ variant = "nav" }: VersionPickerProps) {
   const pathname = usePathname();
   const currentVersion = useSelectedDocsVersion();
   const isSidebar = variant === "sidebar";
+  const isDocsPath = pathname.startsWith("/docs");
   const versionLinks = getVersionLinks(currentVersion);
 
   return (
@@ -49,9 +50,10 @@ export function VersionPicker({ variant = "nav" }: VersionPickerProps) {
           {docsVersions.map((version) => (
             <a
               className="flex items-start gap-2 rounded-md px-2 py-2 text-sm transition hover:bg-fd-accent hover:text-fd-accent-foreground"
-              href={getDocsVersionHref(version, pathname)}
+              href={isDocsPath ? getDocsVersionHref(version, pathname) : pathname || "/"}
               key={version.label}
-              onClick={() => {
+              onClick={(event) => {
+                if (!isDocsPath) event.preventDefault();
                 rememberDocsVersion(version);
                 setOpen(false);
               }}


### PR DESCRIPTION
## Summary
- keep the version picker on the current non-doc page while still remembering the selected docs version
- preserve docs-page version switching for /docs routes
- align latest CLI examples with the verified scoped npx package command

## Validation
- bun run docs:versions:check
- bun run check-types
- bun run release:ci
- npm view @opencoredev/email-sdk version/bin/dist/provenance
- npx --yes --package @opencoredev/email-sdk@latest email-sdk version/adapters/doctor/send --dry-run
- clean temp npm install import smoke for SDK, testing adapter, Cloudflare adapter, and defaults plugin