### PR TITLE
Fix docs version fallback routing

### DIFF
--- a/apps/fumadocs/src/lib/source.ts
+++ b/apps/fumadocs/src/lib/source.ts
@@ -44,7 +44,7 @@ export function markdownPathToSlugs(segs: string[]) {
 
   const out = [...segs];
   out[out.length - 1] = out[out.length - 1].replace(/\.md$/, "");
-  if (out.length === 1 && out[0] === "index") out.pop();
+  if (out[out.length - 1] === "index") out.pop();
   return out;
 }
 

--- a/apps/fumadocs/src/routes/docs/$.tsx
+++ b/apps/fumadocs/src/routes/docs/$.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, notFound } from "@tanstack/react-router";
+import { createFileRoute, Link, notFound, redirect } from "@tanstack/react-router";
 import { createServerFn } from "@tanstack/react-start";
 import { staticFunctionMiddleware } from "@tanstack/start-static-server-functions";
 import browserCollections from "collections/browser";
@@ -21,6 +21,8 @@ import { getDocsSource, slugsToMarkdownPath, source } from "@/lib/source";
 import {
   type DocsVersionCollection,
   getDocsVersionBase,
+  getDocsVersionHref,
+  latestDocsVersion,
   resolveDocsVersionedSlugs,
 } from "@/lib/versions";
 
@@ -85,7 +87,9 @@ const loader = createServerFn({
     const resolved = resolveDocsVersionedSlugs(slugs);
     const docsSource = getDocsSource(resolved.version);
     const page = docsSource.getPage(resolved.slugs);
-    if (!page) throw notFound();
+    if (!page) {
+      throw resolveMissingVersionedDocsPage(resolved);
+    }
 
     return {
       title: page.data.title,
@@ -98,6 +102,27 @@ const loader = createServerFn({
       pageTree: await docsSource.serializePageTree(docsSource.getPageTree()),
     };
   });
+
+function resolveMissingVersionedDocsPage(
+  resolved: ReturnType<typeof resolveDocsVersionedSlugs>,
+) {
+  if (resolved.version.current) return notFound();
+
+  const latestPage = getDocsSource(latestDocsVersion).getPage(resolved.slugs);
+  if (latestPage) {
+    const docsPath = resolved.slugs.length > 0 ? `/docs/${resolved.slugs.join("/")}` : "/docs";
+
+    return redirect({
+      href: getDocsVersionHref(latestDocsVersion, docsPath),
+      statusCode: 302,
+    });
+  }
+
+  return redirect({
+    href: getDocsVersionBase(resolved.version),
+    statusCode: 302,
+  });
+}
 
 function createDocsClientLoader(collection: (typeof browserCollections)[DocsVersionCollection]) {
   return collection.createClientLoader({

--- a/apps/fumadocs/src/routes/docs/{$}[.]md.ts
+++ b/apps/fumadocs/src/routes/docs/{$}[.]md.ts
@@ -1,7 +1,7 @@
-import { createFileRoute, notFound } from "@tanstack/react-router";
+import { createFileRoute, notFound, redirect } from "@tanstack/react-router";
 
 import { getDocsSource, getLLMText, markdownPathToSlugs } from "@/lib/source";
-import { resolveDocsVersionedSlugs } from "@/lib/versions";
+import { getDocsVersionBase, latestDocsVersion, resolveDocsVersionedSlugs } from "@/lib/versions";
 
 export const Route = createFileRoute("/docs/{$}.md")({
   server: {
@@ -10,7 +10,9 @@ export const Route = createFileRoute("/docs/{$}.md")({
         const slugs = markdownPathToSlugs(params._splat?.split("/") ?? []);
         const resolved = resolveDocsVersionedSlugs(slugs);
         const page = getDocsSource(resolved.version).getPage(resolved.slugs);
-        if (!page) throw notFound();
+        if (!page) {
+          throw resolveMissingMarkdownPage(resolved);
+        }
 
         return new Response(await getLLMText(page, resolved.version), {
           headers: {
@@ -21,3 +23,23 @@ export const Route = createFileRoute("/docs/{$}.md")({
     },
   },
 });
+
+function resolveMissingMarkdownPage(resolved: ReturnType<typeof resolveDocsVersionedSlugs>) {
+  if (resolved.version.current) return notFound();
+
+  const latestPage = getDocsSource(latestDocsVersion).getPage(resolved.slugs);
+  if (latestPage) {
+    const suffix =
+      resolved.slugs.length > 0 ? `${resolved.slugs.join("/")}.md` : "index.md";
+
+    return redirect({
+      href: `${getDocsVersionBase(latestDocsVersion)}/${suffix}`,
+      statusCode: 302,
+    });
+  }
+
+  return redirect({
+    href: `${getDocsVersionBase(resolved.version)}/index.md`,
+    statusCode: 302,
+  });
+}


### PR DESCRIPTION
## Summary
- redirect archived docs misses to the latest matching page instead of throwing
- normalize nested index.md paths so versioned markdown links do not loop
- keep missing archived markdown requests on a stable version index fallback

## Validation
- bun run --filter fumadocs types:check
- bun run --filter fumadocs build
- bun run release:ci