### PR TITLE
Fix static blog syntax highlighting

### DIFF
--- a/apps/fumadocs/src/routes/blog/$slug.tsx
+++ b/apps/fumadocs/src/routes/blog/$slug.tsx
@@ -1,5 +1,4 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock.core";
 import { HomeLayout } from "fumadocs-ui/layouts/home";
 import {
   ArrowRight,
@@ -667,22 +666,18 @@ function Checklist({ items }: { items: string[] }) {
 
 function CodeBlock({ children }: { children: string }) {
   return (
-    <DynamicCodeBlock
-      code={children}
-      codeblock={{
-        allowCopy: false,
-        className: "blog-code-block my-8 rounded-lg",
-        viewportProps: {
-          className: "max-h-none",
-        },
-      }}
-      highlighter={blogCodeHighlighter}
-      lang="ts"
-      options={{
-        themes: {
-          dark: "github-dark",
-          light: "github-light",
-        },
+    <figure
+      className="blog-code-block shiki not-prose my-8 overflow-hidden rounded-lg border border-fd-border text-sm shadow-sm"
+      dangerouslySetInnerHTML={{
+        __html: blogCodeHighlighter.codeToHtml(children, {
+          defaultColor: false,
+          lang: "ts",
+          tabindex: false,
+          themes: {
+            dark: "github-dark",
+            light: "github-light",
+          },
+        }),
       }}
     />
   );

--- a/apps/fumadocs/src/routes/blog/$slug.tsx
+++ b/apps/fumadocs/src/routes/blog/$slug.tsx
@@ -665,19 +665,37 @@ function Checklist({ items }: { items: string[] }) {
 }
 
 function CodeBlock({ children }: { children: string }) {
+  let highlightedCode: string | null = null;
+
+  try {
+    highlightedCode = blogCodeHighlighter.codeToHtml(children, {
+      defaultColor: false,
+      lang: "ts",
+      tabindex: false,
+      themes: {
+        dark: "github-dark",
+        light: "github-light",
+      },
+    });
+  } catch {
+    highlightedCode = null;
+  }
+
+  if (!highlightedCode) {
+    return (
+      <figure className="blog-code-block not-prose my-8 overflow-hidden rounded-lg border border-fd-border text-sm shadow-sm">
+        <pre>
+          <code>{children}</code>
+        </pre>
+      </figure>
+    );
+  }
+
   return (
     <figure
-      className="blog-code-block shiki not-prose my-8 overflow-hidden rounded-lg border border-fd-border text-sm shadow-sm"
+      className="blog-code-block not-prose my-8 overflow-hidden rounded-lg border border-fd-border text-sm shadow-sm"
       dangerouslySetInnerHTML={{
-        __html: blogCodeHighlighter.codeToHtml(children, {
-          defaultColor: false,
-          lang: "ts",
-          tabindex: false,
-          themes: {
-            dark: "github-dark",
-            light: "github-light",
-          },
-        }),
+        __html: highlightedCode,
       }}
     />
   );

--- a/apps/fumadocs/src/styles/app.css
+++ b/apps/fumadocs/src/styles/app.css
@@ -88,7 +88,15 @@ html > body[data-scroll-locked] {
   box-shadow: inset 0 1px 0 color-mix(in oklab, white 8%, transparent);
 }
 
+.blog-code-block pre {
+  margin: 0;
+  overflow-x: auto;
+  background: transparent !important;
+}
+
 .blog-code-block code {
+  display: block;
+  min-width: max-content;
   white-space: pre;
 }
 

--- a/apps/fumadocs/src/styles/app.css
+++ b/apps/fumadocs/src/styles/app.css
@@ -91,7 +91,7 @@ html > body[data-scroll-locked] {
 .blog-code-block pre {
   margin: 0;
   overflow-x: auto;
-  background: transparent !important;
+  background: transparent;
 }
 
 .blog-code-block code {


### PR DESCRIPTION
## Summary
- render blog code blocks through the existing Shiki highlighter during SSR/prerender
- keep the blog code block wrapper styling while letting generated Shiki spans carry token colors
- preserve horizontal scrolling for long code lines

## Verification
- bun run --filter fumadocs build
- rg -a "blog-code-block|shiki-themes|--shiki-dark|F97583|D73A49|createEmailClient" apps/fumadocs/.output/public/blog/introducing-email-sdk/index.html -n | head -80

Automated PR - Greptile review workflow