### PR TITLE
docs: improve community adapter guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/community-plugin.yml
+++ b/.github/ISSUE_TEMPLATE/community-plugin.yml
@@ -1,7 +1,7 @@
 name: Community package listing
 description: Request a static docs listing for an Email SDK community plugin or adapter.
 title: "[Community package]: "
-labels: ["community-plugin", "needs-triage"]
+labels: ["documentation"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/community-plugin.yml
+++ b/.github/ISSUE_TEMPLATE/community-plugin.yml
@@ -1,6 +1,6 @@
-name: Community plugin listing
+name: Community package listing
 description: Request a static docs listing for an Email SDK community plugin or adapter.
-title: "[Community plugin]: "
+title: "[Community package]: "
 labels: ["community-plugin", "needs-triage"]
 body:
   - type: markdown

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -30,14 +30,14 @@ Do not add third-party provider experiments to the official package by default. 
 
 <Cards>
   <Card
-    title="Publish a community adapter"
-    href="/docs/guides/authoring/publish-community-adapter"
-    description="Build and publish a third-party provider package without making it official."
-  />
-  <Card
     title="Create an adapter"
     href="/docs/guides/authoring/create-adapter"
     description="Implement the provider mapping and wrap it as an adapter plugin."
+  />
+  <Card
+    title="Publish a community adapter"
+    href="/docs/guides/authoring/publish-community-adapter"
+    description="Build and publish a third-party provider package without making it official."
   />
 </Cards>
 

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -24,6 +24,23 @@ before choosing fallback routes.
 | A cheap or self-managed transport      | SMTP                                                      |
 | Heavy attachment support               | Resend, Postmark, SendGrid, Mailgun, MailerSend, Mailtrap |
 
+## Want to build a community adapter?
+
+Do not add third-party provider experiments to the official package by default. Publish a separate community package, export an adapter plugin, and list it in the community registry if you want discoverability.
+
+<Cards>
+  <Card
+    title="Publish a community adapter"
+    href="/docs/guides/authoring/publish-community-adapter"
+    description="Build and publish a third-party provider package without making it official."
+  />
+  <Card
+    title="Create an adapter"
+    href="/docs/guides/authoring/create-adapter"
+    description="Implement the provider mapping and wrap it as an adapter plugin."
+  />
+</Cards>
+
 ## What the status labels mean
 
 Provider cards use three labels:

--- a/apps/fumadocs/content/docs/guides/authoring/create-adapter.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/create-adapter.mdx
@@ -4,7 +4,16 @@ description: Write your first custom provider adapter.
 icon: Cable
 ---
 
-An adapter connects Email SDK's normalized `EmailMessage` to one provider API. Start with a plain adapter. Wrap it as a plugin only when you want package-style reuse.
+An adapter connects Email SDK's normalized `EmailMessage` to one provider API. It is the thing that actually sends.
+
+A plugin can register that adapter for package-style reuse. It is the thing most community packages should ask users to install.
+
+| You are writing... | It should do...                                                | Users mount it with... |
+| ------------------ | -------------------------------------------------------------- | ---------------------- |
+| Adapter            | Map `EmailMessage` into one provider request and response.     | `adapters: [...]`      |
+| Adapter plugin     | Register one adapter from a reusable package or shared module. | `plugins: [...]`       |
+
+Start with the plain adapter because it is easier to test. Wrap it as a plugin when the adapter should be reused across projects or published as a community package.
 
 ## Adapter shape
 
@@ -78,6 +87,8 @@ function toAcmePayload(message: EmailMessage, context: EmailProviderContext) {
 
 ## Use the adapter directly
 
+Direct adapter registration is useful inside one app, one monorepo, or tests.
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { acmeMail } from "./acme-mail";
@@ -89,7 +100,7 @@ const email = createEmailClient({
 
 ## Wrap it as an adapter plugin
 
-Adapter plugins are best for community packages and shared internal packages.
+Adapter plugins are best for community packages and shared internal packages. The plugin does not send by itself; it returns metadata and the adapter list Email SDK should register.
 
 ```ts
 import type { EmailPlugin } from "@opencoredev/email-sdk";
@@ -106,10 +117,15 @@ export function acmeMailPlugin(options: AcmeMailOptions): EmailPlugin {
 Consumers can now mount it with the same `plugins` array as other extensions:
 
 ```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { acmeMailPlugin } from "email-sdk-acme-mail";
+
 const email = createEmailClient({
   plugins: [acmeMailPlugin({ apiKey: process.env.ACME_MAIL_API_KEY! })],
 });
 ```
+
+If the package is public, follow [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) after the adapter tests pass.
 
 ## Handle unsupported fields
 
@@ -166,5 +182,7 @@ If your adapter accepts injected `fetch`, document it. It makes tests easier and
 - Respect `context.idempotencyKey` when the provider supports it.
 - Throw on unsupported fields instead of dropping them.
 - Add tests for payload mapping and provider response mapping.
+- If publishing, export both `{provider}` and `{provider}Plugin`.
+- If publishing, declare `@opencoredev/email-sdk` as a peer dependency.
 
 See [Adapter contract](/docs/reference/adapter-contract) for the exact type reference.

--- a/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
@@ -8,12 +8,12 @@ Community adapters are third-party npm packages. They let someone support a prov
 
 That split is intentional:
 
-| Surface                 | Who owns it                       | Where it lives                                  |
-| ----------------------- | --------------------------------- | ----------------------------------------------- |
-| Official adapter        | Email SDK maintainers             | `@opencoredev/email-sdk/{adapter}`              |
-| Community adapter       | The community package maintainer  | Their npm package, such as `email-sdk-acme`     |
-| Community docs listing  | Email SDK docs, by pull request   | `apps/fumadocs/content/community/plugins.json`  |
-| Verified listing        | Email SDK docs, for one version   | Same registry entry plus verification metadata  |
+| Surface                 | Who owns it                       | Where it lives                                   |
+| ----------------------- | --------------------------------- | ------------------------------------------------ |
+| Official adapter        | Email SDK maintainers             | `@opencoredev/email-sdk/{adapter}`               |
+| Community adapter       | The community package maintainer  | Their npm package, such as `email-sdk-acme-mail` |
+| Community docs listing  | Email SDK docs, by pull request   | `apps/fumadocs/content/community/plugins.json`   |
+| Verified listing        | Email SDK docs, for one version   | Same registry entry plus verification metadata   |
 
 Most community adapters should start as `status: "community"`. That means listed, discoverable, and clearly third-party. It does not mean endorsed, bundled, or maintained by OpenCore.
 
@@ -139,15 +139,16 @@ If a field is not supported, say whether the adapter throws. Community adapters 
 
 Use a small table in the package README:
 
-| Field            | Support | Notes                                  |
-| ---------------- | ------- | -------------------------------------- |
-| `html`, `text`   | Yes     | Sent as provider body fields.          |
-| `cc`, `bcc`      | Yes     | Mapped to provider recipient fields.   |
-| `replyTo`        | No      | Throws when provided.                  |
-| `attachments`    | No      | Throws when provided.                  |
-| `tags`           | Yes     | Mapped to provider tags.               |
-| `metadata`       | Partial | Included when values are strings.      |
-| `idempotencyKey` | No      | Provider does not expose this feature. |
+| Field            | Support | Notes                                      |
+| ---------------- | ------- | ------------------------------------------ |
+| `html`, `text`   | Yes     | Sent as provider body fields.              |
+| `cc`, `bcc`      | Yes     | Mapped to provider recipient fields.       |
+| `replyTo`        | No      | Throws when provided.                      |
+| `headers`        | No      | Provider does not support custom headers.  |
+| `attachments`    | No      | Throws when provided.                      |
+| `tags`           | Yes     | Mapped to provider tags.                   |
+| `metadata`       | Partial | Included when values are strings.          |
+| `idempotencyKey` | No      | Provider does not expose this feature.     |
 
 This is not paperwork. Field support determines whether the adapter is safe as a fallback route. A backup provider that silently drops attachments or reply-to addresses can make a send look successful while changing the email.
 

--- a/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
@@ -1,12 +1,52 @@
 ---
 title: Publish a community adapter
-description: Package a custom adapter for other Email SDK users.
+description: Build, publish, and list a third-party provider adapter without making it official.
 icon: BadgeCheck
 ---
 
-Community adapters should feel like built-in adapters: predictable names, clear field support, narrow dependencies, and a plugin export for clean setup.
+Community adapters are third-party npm packages. They let someone support a provider without adding that provider to `@opencoredev/email-sdk`, the official CLI, or the official adapter maintenance surface.
 
-Adapter packages follow the same registry process as other plugins. Start with [Publish a community plugin](/docs/guides/authoring/publish-community-plugin), then add the adapter-specific requirements on this page.
+That split is intentional:
+
+| Surface                 | Who owns it                       | Where it lives                                  |
+| ----------------------- | --------------------------------- | ----------------------------------------------- |
+| Official adapter        | Email SDK maintainers             | `@opencoredev/email-sdk/{adapter}`              |
+| Community adapter       | The community package maintainer  | Their npm package, such as `email-sdk-acme`     |
+| Community docs listing  | Email SDK docs, by pull request   | `apps/fumadocs/content/community/plugins.json`  |
+| Verified listing        | Email SDK docs, for one version   | Same registry entry plus verification metadata  |
+
+Most community adapters should start as `status: "community"`. That means listed, discoverable, and clearly third-party. It does not mean endorsed, bundled, or maintained by OpenCore.
+
+## Adapter or plugin?
+
+An adapter is the provider implementation. It maps Email SDK's normalized `EmailMessage` into one provider API request.
+
+```ts
+createEmailClient({
+  adapters: [acmeMail({ apiKey: process.env.ACME_MAIL_API_KEY! })],
+});
+```
+
+A plugin is the package-friendly wrapper. It registers the adapter through the `plugins` array, which is the cleanest setup for reusable community packages.
+
+```ts
+createEmailClient({
+  plugins: [acmeMailPlugin({ apiKey: process.env.ACME_MAIL_API_KEY! })],
+});
+```
+
+Ship both. The plain adapter keeps advanced users close to the provider. The plugin wrapper gives most users a stable one-line integration.
+
+## Publishing path
+
+1. Create a separate package owned by the community maintainer.
+2. Implement the adapter contract from [Create an adapter](/docs/guides/authoring/create-adapter).
+3. Export both the adapter factory and plugin factory.
+4. Publish the package to npm from the maintainer's own repo.
+5. Add a short README with install, setup, field support, and test instructions.
+6. Optionally open a pull request to list the package in the Email SDK community registry.
+
+Do not add community adapters to `packages/email-sdk/src`, the official adapter catalog, the official CLI adapter list, or the official package exports unless the project has agreed to maintain that provider as official.
 
 ## Recommended package shape
 
@@ -15,14 +55,16 @@ email-sdk-acme-mail/
   src/
     index.ts
     acme-mail.ts
+    plugin.ts
     acme-mail.test.ts
   package.json
+  tsconfig.json
   README.md
 ```
 
 ## Export both forms
 
-Export a plain adapter factory and an adapter plugin factory.
+Export a plain adapter factory and an adapter plugin factory from the package root.
 
 ```ts
 export { acmeMail } from "./acme-mail";
@@ -39,6 +81,8 @@ createEmailClient({
 ```
 
 ## Package exports
+
+Community packages should use Email SDK as a peer dependency. That keeps apps from installing two copies of the core types.
 
 ```json
 {
@@ -57,7 +101,7 @@ createEmailClient({
 }
 ```
 
-Use a peer dependency for Email SDK so apps do not accidentally install two copies of the core types.
+Avoid install scripts and binaries. Adapter packages should be boring library packages: importable code, types, tests, and provider docs.
 
 ## Naming
 
@@ -68,6 +112,16 @@ Use a peer dependency for Email SDK so apps do not accidentally install two copi
 | Plugin ID | Same slug unless you need variants   |
 | Env var   | Provider slug in uppercase, plus key |
 | Export    | `{provider}` and `{provider}Plugin`  |
+
+Example:
+
+| Thing     | Example                            |
+| --------- | ---------------------------------- |
+| Package   | `email-sdk-acme-mail`              |
+| Adapter   | `acme-mail`                        |
+| Plugin ID | `acme-mail`                        |
+| Env var   | `ACME_MAIL_API_KEY`                |
+| Export    | `acmeMail`, `acmeMailPlugin`       |
 
 ## Document field support
 
@@ -82,6 +136,20 @@ Every adapter README should say whether these fields are supported:
 - `idempotencyKey`
 
 If a field is not supported, say whether the adapter throws. Community adapters should throw on unsupported non-empty fields instead of dropping them.
+
+Use a small table in the package README:
+
+| Field            | Support | Notes                                  |
+| ---------------- | ------- | -------------------------------------- |
+| `html`, `text`   | Yes     | Sent as provider body fields.          |
+| `cc`, `bcc`      | Yes     | Mapped to provider recipient fields.   |
+| `replyTo`        | No      | Throws when provided.                  |
+| `attachments`    | No      | Throws when provided.                  |
+| `tags`           | Yes     | Mapped to provider tags.               |
+| `metadata`       | Partial | Included when values are strings.      |
+| `idempotencyKey` | No      | Provider does not expose this feature. |
+
+This is not paperwork. Field support determines whether the adapter is safe as a fallback route. A backup provider that silently drops attachments or reply-to addresses can make a send look successful while changing the email.
 
 ## Include a smoke test
 
@@ -112,12 +180,66 @@ describe("acmeMailPlugin", () => {
 
 ## README checklist
 
-- Install command.
+- Install command for the community package and `@opencoredev/email-sdk`.
 - Minimal `createEmailClient` example.
 - Required environment variables.
 - Field support table.
 - Error behavior for unsupported fields.
 - Test command.
 - Link to Email SDK adapter contract.
+- Link to the provider API docs used by the adapter.
 
 Keep the README short enough that a user can decide if the adapter fits their fallback route.
+
+## List it in Email SDK docs
+
+After publishing to npm, the maintainer can open a pull request that adds an entry to `apps/fumadocs/content/community/plugins.json`.
+
+```json
+{
+  "name": "Acme Mail",
+  "package": "email-sdk-acme-mail",
+  "kind": "adapter",
+  "status": "community",
+  "description": "Adds an Acme Mail provider adapter for Email SDK.",
+  "href": "https://www.npmjs.com/package/email-sdk-acme-mail",
+  "repo": "https://github.com/acme/email-sdk-acme-mail",
+  "maintainer": "acme",
+  "pluginId": "acme-mail",
+  "adapter": "acme-mail",
+  "importName": "acmeMailPlugin"
+}
+```
+
+Then run:
+
+```bash
+bun run community:check
+```
+
+That check validates the registry shape. In CI, verified and official entries also get a published package metadata check. Community entries are listed as third-party packages without verification metadata.
+
+## Community, verified, or official?
+
+| Status      | Use it when...                                                            |
+| ----------- | ------------------------------------------------------------------------- |
+| `community` | A third-party maintainer published the package and wants discoverability. |
+| `verified`  | A specific published version passed the registry verification checklist.  |
+| `official`  | The adapter is maintained by OpenCore or ships in this repository.        |
+
+Verification applies to one version. If the package releases again, the registry should keep the old `verifiedVersion` until the new version is reviewed.
+
+## What not to do
+
+- Do not publish under the `@opencoredev` scope.
+- Do not ask users to import from `@opencoredev/email-sdk/{community-provider}`.
+- Do not add provider secrets or live credentials to examples.
+- Do not hide provider limitations behind successful sends.
+- Do not mark a listing `verified` before a package version has actually passed verification.
+- Do not mark a third-party package `official`.
+
+## Next
+
+- [Create an adapter](/docs/guides/authoring/create-adapter) for implementation details.
+- [Adapter contract](/docs/reference/adapter-contract) for the exact TypeScript types.
+- [Community registry](/docs/reference/community-registry) for listing and verification fields.

--- a/apps/fumadocs/content/docs/guides/authoring/publish-community-plugin.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/publish-community-plugin.mdx
@@ -6,6 +6,8 @@ icon: PackageCheck
 
 Community plugins are npm packages that export an `EmailPlugin` factory. The docs site lists them from a static JSON registry; there is no hosted plugin service.
 
+If your package sends through a new provider, use [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) instead. Adapter packages still export plugins, but they need extra field-support and provider-mapping documentation.
+
 ## Package shape
 
 ```txt

--- a/apps/fumadocs/content/docs/guides/index.mdx
+++ b/apps/fumadocs/content/docs/guides/index.mdx
@@ -6,6 +6,8 @@ icon: BookOpen
 
 Use these guides when you are operating a production send path or building something that should live outside one send call: fallback routes, tests, reusable plugins, custom provider adapters, or community packages.
 
+If you want to support a provider that Email SDK does not officially maintain, start with [Publish a community adapter](/docs/guides/authoring/publish-community-adapter). Community adapters live in their own npm packages and can be listed in the docs without becoming official.
+
 ## Operate
 
 <Cards>
@@ -37,7 +39,7 @@ Use these guides when you are operating a production send path or building somet
   <Card
     title="Publish a community adapter"
     href="/docs/guides/authoring/publish-community-adapter"
-    description="Shape package exports, docs, names, and tests for reuse."
+    description="Publish a third-party provider package and list it without making it official."
   />
 </Cards>
 

--- a/apps/fumadocs/content/docs/plugins/community.mdx
+++ b/apps/fumadocs/content/docs/plugins/community.mdx
@@ -1,12 +1,24 @@
 ---
-title: Community plugins
-description: Static registry for community Email SDK plugins and adapters.
+title: Community plugins and adapters
+description: Static registry for third-party Email SDK plugins and provider adapters.
 icon: Users
 ---
 
-Community plugins are third-party npm packages. The registry is static and maintained in this repository by pull request.
+Community plugins and adapters are third-party npm packages. The registry is static and maintained in this repository by pull request.
+
+Use this page for discovery. Use the publishing guides when you want to create a package.
 
 <CommunityPluginRegistry />
+
+## What belongs here?
+
+| Package kind | What it adds                                      | Example setup                         |
+| ------------ | ------------------------------------------------- | ------------------------------------- |
+| Adapter      | A provider implementation for one email service.  | `plugins: [acmeMailPlugin(...)]`      |
+| Plugin       | Reusable send behavior, policy, hooks, or helpers. | `plugins: [requireMetadataPlugin()]`  |
+| Hybrid       | A package that includes both provider and behavior. | `plugins: [providerWithDefaults()]`   |
+
+Adapters are listed here even though users mount the package through `plugins`. The adapter is the provider implementation; the plugin is the reusable registration wrapper.
 
 ## Labels
 
@@ -21,6 +33,9 @@ Verified does not mean risk-free. It means the package passed the static checks 
 ## Add a package
 
 Publish a package to npm, then open a pull request that adds an entry to `apps/fumadocs/content/community/plugins.json`.
-If you want feedback before writing the entry, open the `Community plugin listing` issue template with the package and source links.
+If you want feedback before writing the entry, open the `Community package listing` issue template with the package and source links.
 
-Start with [Publish a community plugin](/docs/guides/authoring/publish-community-plugin).
+Start with:
+
+- [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) for provider packages.
+- [Publish a community plugin](/docs/guides/authoring/publish-community-plugin) for behavior packages.

--- a/apps/fumadocs/content/docs/plugins/index.mdx
+++ b/apps/fumadocs/content/docs/plugins/index.mdx
@@ -56,14 +56,15 @@ Email SDK plugins do not add databases, migrations, HTTP endpoints, route middle
 
 ## Common plugin shapes
 
-| Shape             | Where to start                                                                        |
-| ----------------- | ------------------------------------------------------------------------------------- |
-| Shared defaults   | Use the [defaults plugin](/docs/plugins/built-in/defaults).                           |
-| Redacted logging  | Use the [observability plugin](/docs/plugins/built-in/observability).                 |
-| Test capture      | Use the [capture plugin](/docs/plugins/built-in/capture).                             |
-| Custom provider   | Follow [Create an adapter](/docs/guides/authoring/create-adapter).                    |
-| Reusable behavior | Follow [Create your first plugin](/docs/guides/authoring/create-first-plugin).        |
-| Community package | Follow [Publish a community plugin](/docs/guides/authoring/publish-community-plugin). |
+| Shape                      | Where to start                                                                         |
+| -------------------------- | -------------------------------------------------------------------------------------- |
+| Shared defaults            | Use the [defaults plugin](/docs/plugins/built-in/defaults).                            |
+| Redacted logging           | Use the [observability plugin](/docs/plugins/built-in/observability).                  |
+| Test capture               | Use the [capture plugin](/docs/plugins/built-in/capture).                              |
+| Custom provider            | Follow [Create an adapter](/docs/guides/authoring/create-adapter).                     |
+| Reusable behavior          | Follow [Create your first plugin](/docs/guides/authoring/create-first-plugin).         |
+| Community adapter          | Follow [Publish a community adapter](/docs/guides/authoring/publish-community-adapter). |
+| Community behavior package | Follow [Publish a community plugin](/docs/guides/authoring/publish-community-plugin).  |
 
 ## Order
 
@@ -98,9 +99,9 @@ Use a custom `id` when mounting more than one instance of the same plugin type. 
     description="Record email behavior in tests."
   />
   <Card
-    title="Community plugins"
+    title="Community plugins and adapters"
     href="/docs/plugins/community"
-    description="Browse static community plugin listings and verification labels."
+    description="Browse third-party package listings and verification labels."
   />
   <Card
     title="Writing plugins"

--- a/apps/fumadocs/content/docs/reference/adapter-contract.mdx
+++ b/apps/fumadocs/content/docs/reference/adapter-contract.mdx
@@ -1,10 +1,17 @@
 ---
 title: Adapter contract
-description: Reference for writing a custom Email SDK adapter.
+description: Exact provider and plugin types for custom Email SDK adapters.
 icon: Plug
 ---
 
-Custom adapters are plain objects.
+Custom adapters are plain objects that implement `EmailProvider`. They send one normalized Email SDK message through one provider.
+
+Adapter plugins are `EmailPlugin` objects that register adapters. Use them when the adapter is packaged for reuse.
+
+| Contract        | Purpose                                              |
+| --------------- | ---------------------------------------------------- |
+| `EmailProvider` | Provider implementation. Maps and sends the message. |
+| `EmailPlugin`   | Registration wrapper. Adds adapters to a client.     |
 
 ```ts
 import type { EmailProvider } from "@opencoredev/email-sdk";
@@ -35,7 +42,7 @@ Use a plain adapter directly:
 createEmailClient({ adapters: [customAdapter] });
 ```
 
-Or package it as an adapter plugin:
+Or package it as an adapter plugin. The plugin should return a stable `id` and one or more adapters.
 
 ```ts
 import type { EmailPlugin } from "@opencoredev/email-sdk";
@@ -48,6 +55,13 @@ export function customAdapterPlugin(): EmailPlugin {
 }
 
 createEmailClient({ plugins: [customAdapterPlugin()] });
+```
+
+For community packages, export both forms from the package root:
+
+```ts
+export { customAdapter } from "./custom-adapter";
+export { customAdapterPlugin } from "./plugin";
 ```
 
 ## `EmailProvider`
@@ -83,3 +97,27 @@ type EmailProviderResponse = {
 ```
 
 Return the provider's raw response in `raw` when it helps callers debug or inspect provider-specific fields.
+
+## `EmailPlugin` for adapter packages
+
+```ts
+type EmailPlugin = {
+  id: string;
+  adapters?: EmailProvider[] | ((ctx: EmailPluginContext) => EmailProvider[]);
+};
+```
+
+Adapter plugins should keep `adapters` synchronous. If the adapter needs credentials, accept them in the plugin factory and construct the adapter immediately.
+
+```ts
+export function customAdapterPlugin(options: { apiKey: string }): EmailPlugin {
+  const adapter = createCustomAdapter(options);
+
+  return {
+    id: "custom",
+    adapters: [adapter],
+  };
+}
+```
+
+Duplicate plugin IDs and duplicate adapter names throw during `createEmailClient`. Use one stable adapter name so routing, fallbacks, logs, and tests all refer to the same provider.

--- a/apps/fumadocs/content/docs/reference/community-registry.mdx
+++ b/apps/fumadocs/content/docs/reference/community-registry.mdx
@@ -4,7 +4,9 @@ description: Static schema and verification rules for community plugin listings.
 icon: ShieldCheck
 ---
 
-The community registry lives at `apps/fumadocs/content/community/plugins.json`. It is a static JSON file rendered by the docs site.
+The community registry lives at `apps/fumadocs/content/community/plugins.json`. It is a static JSON file rendered by the docs site for third-party plugins, adapters, and hybrid packages.
+
+Adapter packages use this registry too. Set `kind: "adapter"`, include the adapter routing name in `adapter`, and include the plugin factory export in `importName` when the package exposes one.
 
 ## Entry shape
 

--- a/apps/fumadocs/src/lib/providers.ts
+++ b/apps/fumadocs/src/lib/providers.ts
@@ -37,15 +37,6 @@ export const providers = [
     liveStatus: "Live account required",
   },
   {
-    name: "Cloudflare Email Sending",
-    key: "cloudflare",
-    importPath: "@opencoredev/email-sdk/cloudflare",
-    docs: "/docs/adapters/cloudflare",
-    website: "https://developers.cloudflare.com/email-service/",
-    logo: "https://cdn.simpleicons.org/cloudflare",
-    category: "Infrastructure",
-  },
-  {
     name: "AWS SES",
     key: "ses",
     importPath: "@opencoredev/email-sdk/ses",


### PR DESCRIPTION
Improves the community adapter docs path so provider authors can understand adapter vs plugin, publish third-party adapters outside the official package, and list packages in the community registry.\n\nValidation:\n- bun run release:ci