### PR TITLE
Guard docs against DOM mutation crashes

### DIFF
--- a/apps/fumadocs/src/lib/dom-mutation-guard.test.ts
+++ b/apps/fumadocs/src/lib/dom-mutation-guard.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { domMutationGuardScript } from "./dom-mutation-guard";
+
+class FakeNode {
+  parentNode: FakeNode | null = null;
+  children: FakeNode[] = [];
+
+  appendChild(child: FakeNode) {
+    if (child.parentNode) {
+      child.parentNode.removeChild(child);
+    }
+
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  removeChild(child: FakeNode) {
+    if (child.parentNode !== this) {
+      throw new DOMException(
+        "The node to be removed is not a child of this node.",
+        "NotFoundError",
+      );
+    }
+
+    this.children = this.children.filter((item) => item !== child);
+    child.parentNode = null;
+    return child;
+  }
+
+  insertBefore(newNode: FakeNode, referenceNode: FakeNode | null) {
+    if (referenceNode === null) {
+      return this.appendChild(newNode);
+    }
+
+    if (referenceNode.parentNode !== this) {
+      throw new DOMException(
+        "The node before which the new node is to be inserted is not a child of this node.",
+        "NotFoundError",
+      );
+    }
+
+    if (newNode.parentNode) {
+      newNode.parentNode.removeChild(newNode);
+    }
+
+    const referenceIndex = this.children.indexOf(referenceNode);
+    newNode.parentNode = this;
+    this.children.splice(referenceIndex, 0, newNode);
+    return newNode;
+  }
+}
+
+function installGuard() {
+  const fakeWindow = {
+    Node: FakeNode,
+    __emailSdkDomMutationGuardInstalled: false,
+  };
+
+  new Function("window", domMutationGuardScript)(fakeWindow);
+
+  return fakeWindow;
+}
+
+describe("dom mutation guard", () => {
+  test("ignores removeChild when external DOM mutation already detached the child", () => {
+    installGuard();
+
+    const parent = new FakeNode();
+    const child = new FakeNode();
+
+    expect(parent.removeChild(child)).toBe(child);
+  });
+
+  test("keeps normal removeChild behavior for real children", () => {
+    installGuard();
+
+    const parent = new FakeNode();
+    const child = new FakeNode();
+    parent.appendChild(child);
+
+    expect(parent.removeChild(child)).toBe(child);
+    expect(parent.children).toEqual([]);
+    expect(child.parentNode).toBeNull();
+  });
+
+  test("falls back to append when external DOM mutation moved the reference node", () => {
+    installGuard();
+
+    const parent = new FakeNode();
+    const otherParent = new FakeNode();
+    const referenceNode = new FakeNode();
+    const newNode = new FakeNode();
+
+    otherParent.appendChild(referenceNode);
+
+    expect(parent.insertBefore(newNode, referenceNode)).toBe(newNode);
+    expect(parent.children).toEqual([newNode]);
+    expect(newNode.parentNode).toBe(parent);
+  });
+});

--- a/apps/fumadocs/src/lib/dom-mutation-guard.ts
+++ b/apps/fumadocs/src/lib/dom-mutation-guard.ts
@@ -1,0 +1,43 @@
+export const domMutationGuardScript = `
+(() => {
+  const win = window;
+
+  if (win.__emailSdkDomMutationGuardInstalled || !win.Node) {
+    return;
+  }
+
+  const nodePrototype = win.Node.prototype;
+  const removeChild = nodePrototype.removeChild;
+  const insertBefore = nodePrototype.insertBefore;
+
+  if (typeof removeChild !== "function" || typeof insertBefore !== "function") {
+    return;
+  }
+
+  win.__emailSdkDomMutationGuardInstalled = true;
+
+  nodePrototype.removeChild = function guardedRemoveChild(child) {
+    try {
+      return removeChild.call(this, child);
+    } catch (error) {
+      if (error && error.name === "NotFoundError") {
+        return child;
+      }
+
+      throw error;
+    }
+  };
+
+  nodePrototype.insertBefore = function guardedInsertBefore(newNode, referenceNode) {
+    try {
+      return insertBefore.call(this, newNode, referenceNode);
+    } catch (error) {
+      if (error && error.name === "NotFoundError" && referenceNode && referenceNode.parentNode !== this) {
+        return insertBefore.call(this, newNode, null);
+      }
+
+      throw error;
+    }
+  };
+})();
+`;

--- a/apps/fumadocs/src/routes/__root.tsx
+++ b/apps/fumadocs/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { RootProvider } from "fumadocs-ui/provider/tanstack";
 import * as React from "react";
 
 import SearchDialog from "@/components/search";
+import { domMutationGuardScript } from "@/lib/dom-mutation-guard";
 import { siteMeta } from "@/lib/metadata";
 
 import appCss from "@/styles/app.css?url";
@@ -38,6 +39,10 @@ function RootComponent() {
   return (
     <html suppressHydrationWarning>
       <head>
+        <script
+          // Browser translation/extensions can mutate React-owned DOM before hydration finishes.
+          dangerouslySetInnerHTML={{ __html: domMutationGuardScript }}
+        />
         <HeadContent />
       </head>
       <body className="flex flex-col min-h-screen">


### PR DESCRIPTION
## Summary
- add a pre-hydration DOM mutation guard in the docs root HTML
- prevent React/TanStack from taking down `/docs` when browser translation or extensions move/remove React-owned nodes

## Why
The screenshot error is the classic React DOM `removeChild` NotFoundError, which upstream React tracks as a failure mode when external scripts such as Chrome Translate mutate the DOM before React commits updates.

## Validation
- bun run --filter fumadocs types:check
- bun run --filter fumadocs build
- bun run release:ci