### PR TITLE
Recover docs from stale chunk loads

### DIFF
--- a/apps/fumadocs/src/lib/chunk-load-guard.test.ts
+++ b/apps/fumadocs/src/lib/chunk-load-guard.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from "bun:test";
+
+import { chunkLoadGuardScript } from "./chunk-load-guard";
+
+function installGuard() {
+  const listeners = new Map<string, EventListener[]>();
+  const storage = new Map<string, string>();
+  let reloads = 0;
+
+  const fakeWindow = {
+    __emailSdkChunkLoadGuardInstalled: false,
+    location: {
+      pathname: "/docs/guides/authoring/create-adapter",
+      search: "",
+      reload: () => {
+        reloads += 1;
+      },
+    },
+    sessionStorage: {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => {
+        storage.set(key, value);
+      },
+    },
+    addEventListener: (type: string, listener: EventListener) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), listener]);
+    },
+  };
+
+  new Function("window", chunkLoadGuardScript)(fakeWindow);
+
+  function dispatch(type: string, event: Record<string, unknown>) {
+    for (const listener of listeners.get(type) ?? []) {
+      listener(event as unknown as Event);
+    }
+  }
+
+  return {
+    dispatch,
+    get reloads() {
+      return reloads;
+    },
+  };
+}
+
+describe("chunk load guard", () => {
+  test("reloads on Vite preload errors", () => {
+    const guard = installGuard();
+    let prevented = false;
+
+    guard.dispatch("vite:preloadError", {
+      preventDefault: () => {
+        prevented = true;
+      },
+    });
+
+    expect(prevented).toBe(true);
+    expect(guard.reloads).toBe(1);
+  });
+
+  test("reloads once for dynamic import promise failures", () => {
+    const guard = installGuard();
+    const event = {
+      reason: new Error(
+        "error loading dynamically imported module: https://email-sdk.dev/assets/create-adapter-old.js",
+      ),
+      preventDefault: () => {},
+    };
+
+    guard.dispatch("unhandledrejection", event);
+    guard.dispatch("unhandledrejection", event);
+
+    expect(guard.reloads).toBe(1);
+  });
+
+  test("ignores unrelated runtime errors", () => {
+    const guard = installGuard();
+
+    guard.dispatch("unhandledrejection", {
+      reason: new Error("User profile request failed"),
+      preventDefault: () => {},
+    });
+
+    expect(guard.reloads).toBe(0);
+  });
+});

--- a/apps/fumadocs/src/lib/chunk-load-guard.ts
+++ b/apps/fumadocs/src/lib/chunk-load-guard.ts
@@ -1,0 +1,72 @@
+export const chunkLoadGuardScript = `
+(() => {
+  const win = window;
+
+  if (win.__emailSdkChunkLoadGuardInstalled) {
+    return;
+  }
+
+  win.__emailSdkChunkLoadGuardInstalled = true;
+
+  const reloadTtlMs = 60 * 1000;
+  const storageKey = "__emailSdkChunkLoadReload";
+  const chunkErrorPattern =
+    /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed|Loading chunk [\\w-]+ failed/i;
+
+  function getMessage(value) {
+    if (!value) {
+      return "";
+    }
+
+    if (typeof value === "string") {
+      return value;
+    }
+
+    return String(value.message || value.reason?.message || value.error?.message || value);
+  }
+
+  function shouldRecover(value) {
+    return chunkErrorPattern.test(getMessage(value));
+  }
+
+  function recover() {
+    const now = Date.now();
+    const key = storageKey + ":" + win.location.pathname + win.location.search;
+    const previous = Number(win.sessionStorage?.getItem(key) || 0);
+
+    if (previous && now - previous < reloadTtlMs) {
+      return;
+    }
+
+    win.sessionStorage?.setItem(key, String(now));
+    win.location.reload();
+  }
+
+  win.addEventListener("vite:preloadError", (event) => {
+    event.preventDefault();
+    recover();
+  });
+
+  win.addEventListener("unhandledrejection", (event) => {
+    if (!shouldRecover(event.reason)) {
+      return;
+    }
+
+    event.preventDefault();
+    recover();
+  });
+
+  win.addEventListener(
+    "error",
+    (event) => {
+      if (!shouldRecover(event)) {
+        return;
+      }
+
+      event.preventDefault();
+      recover();
+    },
+    true,
+  );
+})();
+`;

--- a/apps/fumadocs/src/routes/__root.tsx
+++ b/apps/fumadocs/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { RootProvider } from "fumadocs-ui/provider/tanstack";
 import * as React from "react";
 
 import SearchDialog from "@/components/search";
+import { chunkLoadGuardScript } from "@/lib/chunk-load-guard";
 import { domMutationGuardScript } from "@/lib/dom-mutation-guard";
 import { siteMeta } from "@/lib/metadata";
 
@@ -42,6 +43,10 @@ function RootComponent() {
         <script
           // Browser translation/extensions can mutate React-owned DOM before hydration finishes.
           dangerouslySetInnerHTML={{ __html: domMutationGuardScript }}
+        />
+        <script
+          // Stale clients can request chunks from a previous deployment; reload once onto current assets.
+          dangerouslySetInnerHTML={{ __html: chunkLoadGuardScript }}
         />
         <HeadContent />
       </head>


### PR DESCRIPTION
## Summary
- reload stale docs clients once when a Vite/dynamic import chunk fails to load
- keep the existing DOM mutation guard in place for extension/translation crashes
- add regression coverage for stale chunk recovery

## Validation
- bun run --filter fumadocs test
- bun run --filter fumadocs types:check