### PR TITLE
chore: update Homebrew formula for 0.5.0

### DIFF
--- a/Formula/email-sdk.rb
+++ b/Formula/email-sdk.rb
@@ -1,8 +1,8 @@
 class EmailSdk < Formula
   desc "Lightweight TypeScript SDK and CLI for unified email sending"
   homepage "https://github.com/opencoredev/email-sdk"
-  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.3.0.tgz"
-  sha256 "e241c00e56cb63fce480ca296c593a9f2acb95d859f283394f5f18994d979e24"
+  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.5.0.tgz"
+  sha256 "c6155f76c538239fd32e13152a1a1cf75e3a8751283120fedbb50cf477083e4c"
   license "MIT"
 
   depends_on "bun"


### PR DESCRIPTION
Updates the Homebrew formula to install @opencoredev/email-sdk 0.5.0 from the published npm tarball.\n\nGenerated by the release workflow after publishing 0.5.0.