### PR TITLE
docs: show stale build refresh notice

### DIFF
--- a/apps/fumadocs/content/docs-v/0.4.0/adapters/meta.json
+++ b/apps/fumadocs/content/docs-v/0.4.0/adapters/meta.json
@@ -17,7 +17,6 @@
     "loops",
     "plunk",
     "mailtrap",
-    "cloudflare",
     "scaleway",
     "zeptomail",
     "mailpace",

--- a/apps/fumadocs/src/components/stale-build-notice.tsx
+++ b/apps/fumadocs/src/components/stale-build-notice.tsx
@@ -1,0 +1,99 @@
+import { RefreshCw, X } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { currentBuildInfo, isOutdatedBuild, type BuildInfo } from "@/lib/build-info";
+
+const checkIntervalMs = 5 * 60 * 1000;
+
+async function fetchBuildInfo() {
+  const response = await fetch(`/api/build-info?t=${Date.now()}`, {
+    cache: "no-store",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    return undefined;
+  }
+
+  return (await response.json()) as Partial<BuildInfo>;
+}
+
+export function StaleBuildNotice() {
+  const [outdated, setOutdated] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let canceled = false;
+
+    async function checkBuild() {
+      try {
+        const deployed = await fetchBuildInfo();
+        if (canceled) return;
+
+        if (isOutdatedBuild(currentBuildInfo.buildId, deployed?.buildId)) {
+          setOutdated(true);
+        }
+      } catch {
+        // Network failures should not interrupt docs reading.
+      }
+    }
+
+    const checkVisibleBuild = () => {
+      if (document.visibilityState === "visible") {
+        void checkBuild();
+      }
+    };
+
+    void checkBuild();
+    const interval = window.setInterval(checkBuild, checkIntervalMs);
+
+    window.addEventListener("focus", checkBuild);
+    document.addEventListener("visibilitychange", checkVisibleBuild);
+
+    return () => {
+      canceled = true;
+      window.clearInterval(interval);
+      window.removeEventListener("focus", checkBuild);
+      document.removeEventListener("visibilitychange", checkVisibleBuild);
+    };
+  }, []);
+
+  if (!outdated || dismissed) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-live="polite"
+      className="fixed inset-x-3 bottom-3 z-50 mx-auto flex max-w-md items-start gap-3 rounded-lg border border-fd-border bg-fd-card p-3 text-sm text-fd-foreground shadow-xl md:bottom-5"
+      role="status"
+    >
+      <div className="grid size-8 shrink-0 place-items-center rounded-md border border-fd-border bg-fd-muted text-fd-muted-foreground">
+        <RefreshCw className="size-4" strokeWidth={2} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="font-medium leading-5">A newer docs build is available.</p>
+        <p className="mt-0.5 text-xs leading-5 text-fd-muted-foreground">
+          Refresh this tab to clear stale cached navigation and load the latest pages.
+        </p>
+        <button
+          className="mt-2 inline-flex h-8 items-center justify-center rounded-md bg-fd-primary px-3 text-xs font-medium text-fd-primary-foreground transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+          onClick={() => window.location.reload()}
+          type="button"
+        >
+          Refresh docs
+        </button>
+      </div>
+      <button
+        aria-label="Dismiss update notice"
+        className="grid size-7 shrink-0 place-items-center rounded-md text-fd-muted-foreground transition hover:bg-fd-accent hover:text-fd-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-fd-ring"
+        onClick={() => setDismissed(true)}
+        type="button"
+      >
+        <X className="size-4" strokeWidth={2} />
+      </button>
+    </div>
+  );
+}

--- a/apps/fumadocs/src/lib/build-info.test.ts
+++ b/apps/fumadocs/src/lib/build-info.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+
+import { currentBuildInfo, isOutdatedBuild } from "./build-info";
+
+describe("build info", () => {
+  test("uses package metadata as a test-safe fallback", () => {
+    expect(currentBuildInfo.buildId).toMatch(/\S+/);
+    expect(currentBuildInfo.packageVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test("detects when the deployed build differs from the current client", () => {
+    expect(isOutdatedBuild("old-build", "new-build")).toBe(true);
+    expect(isOutdatedBuild("same-build", "same-build")).toBe(false);
+    expect(isOutdatedBuild("same-build", undefined)).toBe(false);
+  });
+});

--- a/apps/fumadocs/src/lib/build-info.ts
+++ b/apps/fumadocs/src/lib/build-info.ts
@@ -1,0 +1,15 @@
+import emailSdkPackage from "../../../../packages/email-sdk/package.json";
+
+const fallbackBuildId = emailSdkPackage.version;
+const buildEnv = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env;
+
+export const currentBuildInfo = {
+  buildId: buildEnv?.VITE_EMAIL_SDK_BUILD_ID || fallbackBuildId,
+  packageVersion: emailSdkPackage.version,
+} as const;
+
+export type BuildInfo = typeof currentBuildInfo;
+
+export function isOutdatedBuild(currentBuildId: string, deployedBuildId: string | null | undefined) {
+  return Boolean(deployedBuildId && deployedBuildId !== currentBuildId);
+}

--- a/apps/fumadocs/src/routeTree.gen.ts
+++ b/apps/fumadocs/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as DocsChar123Char125DotmdRouteImport } from './routes/docs/{$}[.
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
+import { Route as ApiBuildInfoRouteImport } from './routes/api/build-info'
 
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
@@ -88,6 +89,11 @@ const ApiSearchRoute = ApiSearchRouteImport.update({
   path: '/api/search',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiBuildInfoRoute = ApiBuildInfoRouteImport.update({
+  id: '/api/build-info',
+  path: '/api/build-info',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -98,6 +104,7 @@ export interface FileRoutesByFullPath {
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/terms': typeof TermsRoute
+  '/api/build-info': typeof ApiBuildInfoRoute
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
@@ -113,6 +120,7 @@ export interface FileRoutesByTo {
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/terms': typeof TermsRoute
+  '/api/build-info': typeof ApiBuildInfoRoute
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
@@ -129,6 +137,7 @@ export interface FileRoutesById {
   '/rss.xml': typeof RssDotxmlRoute
   '/sitemap.xml': typeof SitemapDotxmlRoute
   '/terms': typeof TermsRoute
+  '/api/build-info': typeof ApiBuildInfoRoute
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
@@ -146,6 +155,7 @@ export interface FileRouteTypes {
     | '/rss.xml'
     | '/sitemap.xml'
     | '/terms'
+    | '/api/build-info'
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
@@ -161,6 +171,7 @@ export interface FileRouteTypes {
     | '/rss.xml'
     | '/sitemap.xml'
     | '/terms'
+    | '/api/build-info'
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
@@ -176,6 +187,7 @@ export interface FileRouteTypes {
     | '/rss.xml'
     | '/sitemap.xml'
     | '/terms'
+    | '/api/build-info'
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
@@ -192,6 +204,7 @@ export interface RootRouteChildren {
   RssDotxmlRoute: typeof RssDotxmlRoute
   SitemapDotxmlRoute: typeof SitemapDotxmlRoute
   TermsRoute: typeof TermsRoute
+  ApiBuildInfoRoute: typeof ApiBuildInfoRoute
   ApiSearchRoute: typeof ApiSearchRoute
   BlogSlugRoute: typeof BlogSlugRoute
   DocsSplatRoute: typeof DocsSplatRoute
@@ -292,6 +305,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiSearchRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/build-info': {
+      id: '/api/build-info'
+      path: '/api/build-info'
+      fullPath: '/api/build-info'
+      preLoaderRoute: typeof ApiBuildInfoRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -304,6 +324,7 @@ const rootRouteChildren: RootRouteChildren = {
   RssDotxmlRoute: RssDotxmlRoute,
   SitemapDotxmlRoute: SitemapDotxmlRoute,
   TermsRoute: TermsRoute,
+  ApiBuildInfoRoute: ApiBuildInfoRoute,
   ApiSearchRoute: ApiSearchRoute,
   BlogSlugRoute: BlogSlugRoute,
   DocsSplatRoute: DocsSplatRoute,

--- a/apps/fumadocs/src/routes/__root.tsx
+++ b/apps/fumadocs/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { RootProvider } from "fumadocs-ui/provider/tanstack";
 import * as React from "react";
 
 import SearchDialog from "@/components/search";
+import { StaleBuildNotice } from "@/components/stale-build-notice";
 import { chunkLoadGuardScript } from "@/lib/chunk-load-guard";
 import { domMutationGuardScript } from "@/lib/dom-mutation-guard";
 import { siteMeta } from "@/lib/metadata";
@@ -53,6 +54,7 @@ function RootComponent() {
       <body className="flex flex-col min-h-screen">
         <RootProvider search={{ SearchDialog }}>
           <Outlet />
+          <StaleBuildNotice />
         </RootProvider>
         <Analytics />
         <Scripts />

--- a/apps/fumadocs/src/routes/api/build-info.ts
+++ b/apps/fumadocs/src/routes/api/build-info.ts
@@ -1,0 +1,16 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { currentBuildInfo } from "@/lib/build-info";
+
+export const Route = createFileRoute("/api/build-info")({
+  server: {
+    handlers: {
+      GET: () =>
+        Response.json(currentBuildInfo, {
+          headers: {
+            "Cache-Control": "no-store, max-age=0",
+          },
+        }),
+    },
+  },
+});

--- a/apps/fumadocs/vite.config.ts
+++ b/apps/fumadocs/vite.config.ts
@@ -58,6 +58,7 @@ export default defineConfig(({ mode }) => {
     env.VITE_OG_IMAGE_VERSION ||
     env.VERCEL_GIT_COMMIT_SHA?.slice(0, 12) ||
     new Date().toISOString().slice(0, 10).replaceAll("-", "");
+  const buildId = env.VITE_EMAIL_SDK_BUILD_ID || env.VERCEL_GIT_COMMIT_SHA || ogImageVersion;
 
   return {
     server: {
@@ -65,6 +66,7 @@ export default defineConfig(({ mode }) => {
     },
     define: {
       "import.meta.env.VITE_OG_IMAGE_VERSION": JSON.stringify(ogImageVersion),
+      "import.meta.env.VITE_EMAIL_SDK_BUILD_ID": JSON.stringify(buildId),
     },
     plugins: [
       mdx(),
@@ -97,6 +99,9 @@ export default defineConfig(({ mode }) => {
           ...versionedDocsPages,
           {
             path: "/api/search",
+          },
+          {
+            path: "/api/build-info",
           },
           {
             path: "sitemap.xml",


### PR DESCRIPTION
Adds a small docs refresh notice when an open tab is running an older build than the deployed site.\n\nAlso removes a duplicate Cloudflare entry from the archived v0.4.0 adapter nav.\n\nValidation run locally:\n- bun test apps/fumadocs/src/lib/build-info.test.ts apps/fumadocs/src/lib/chunk-load-guard.test.ts\n- bun run --filter fumadocs types:check\n- bun run --filter fumadocs test\n- VERCEL=1 bun run --filter fumadocs build\n- bun run docs:versions:check