### PR TITLE
docs: add complete adapter examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Plugin entry points:
 Run the CLI without installing anything globally:
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk adapters
+bunx --bun --package @opencoredev/email-sdk email-sdk adapters
 ```
 
 After adding the package to a project, run the installed binary:

--- a/apps/fumadocs/content/docs/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs/adapters/brevo.mdx
@@ -6,6 +6,14 @@ icon: brevo
 
 <ProviderBadge adapter="brevo" />
 
+Brevo maps the transactional email API to the shared Email SDK message shape, including metadata as template `params`, tag values as Brevo tags, and attachments as Base64 content.
+
+## Before live sends
+
+Create a Brevo SMTP/API key that can send transactional email, verify the sender or domain you use in `from`, and confirm the account is allowed to send to your target recipients. A dry run checks SDK validation only; a live smoke send is still required for account readiness.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { brevo } from "@opencoredev/email-sdk/brevo";
@@ -14,6 +22,35 @@ const email = createEmailClient({
   adapters: [brevo({ apiKey: process.env.BREVO_API_KEY! })],
 });
 ```
+
+Use `baseUrl` only for test doubles or Brevo-compatible gateways.
+
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  subject: "Invoice ready",
+  html: "<p>Your invoice is ready.</p>",
+  metadata: {
+    invoiceId: "inv_123",
+  },
+  tags: [{ name: "type", value: "invoice" }],
+  attachments: [
+    {
+      filename: "invoice.txt",
+      content: "Invoice inv_123",
+      contentType: "text/plain",
+    },
+  ],
+});
+
+console.log(result.provider, result.id);
+```
+
+Brevo supports one `replyTo` address. The adapter rejects unsupported shapes before it calls Brevo, so fallback routes do not silently lose fields.
 
 ## Options
 
@@ -24,3 +61,18 @@ const email = createEmailClient({
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes. |
 
 See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.
+
+## Response
+
+The adapter maps Brevo `messageId` or `id` to the normalized `id` and `messageId` fields.
+
+## CLI smoke test
+
+```bash
+BREVO_API_KEY="xkeysib-..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter brevo \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Brevo test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs/adapters/brevo.mdx
@@ -69,7 +69,7 @@ The adapter maps Brevo `messageId` or `id` to the normalized `id` and `messageId
 ## CLI smoke test
 
 ```bash
-BREVO_API_KEY="xkeysib-..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+BREVO_API_KEY="xkeysib-..." npx email-sdk send \
   --adapter brevo \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/cloudflare.mdx
+++ b/apps/fumadocs/content/docs/adapters/cloudflare.mdx
@@ -6,6 +6,14 @@ icon: cloudflare
 
 <ProviderBadge adapter="cloudflare" />
 
+Cloudflare Email Sending uses Cloudflare's REST endpoint, not a Worker binding. It is useful when your sending domain already lives in Cloudflare and you want API-based delivery with CC, BCC, reply-to, headers, and attachments.
+
+## Before live sends
+
+Enable Cloudflare Email Sending for the account and DNS domain, create an API token with Email Sending permission, and verify whether the account is limited to approved recipients. The adapter can validate the message shape locally, but only Cloudflare can prove the domain and account are ready to deliver.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { cloudflare } from "@opencoredev/email-sdk/cloudflare";
@@ -20,6 +28,35 @@ const email = createEmailClient({
 });
 ```
 
+Use `baseUrl` only for tests or a Cloudflare-compatible proxy.
+
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  cc: "ops@example.com",
+  replyTo: "support@example.com",
+  subject: "Cloudflare Email Sending test",
+  text: "It works",
+  headers: {
+    "X-Order-ID": "ord_123",
+  },
+  attachments: [
+    {
+      filename: "receipt.txt",
+      content: "Thanks for your order.",
+      contentType: "text/plain",
+    },
+  ],
+});
+
+console.log(result.provider, result.accepted);
+```
+
+Cloudflare recipient fields support plain email addresses. `from` and `replyTo` may include display names, but `to`, `cc`, and `bcc` must not. The adapter also limits total recipients to 50 and `replyTo` to one address.
+
 ## Options
 
 | Option      | Type           | Required | Notes                                                     |
@@ -29,10 +66,14 @@ const email = createEmailClient({
 | `baseUrl`   | `string`       | No       | Defaults to `https://api.cloudflare.com/client/v4`.       |
 | `fetch`     | `typeof fetch` | No       | Useful for tests or custom runtimes.                      |
 
-## CLI
+## Response
+
+The adapter maps Cloudflare `delivered` and `queued` recipients to `accepted`, and `permanent_bounces` to `rejected`.
+
+## CLI smoke test
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk send \
+bunx --bun --package @opencoredev/email-sdk email-sdk send \
   --adapter cloudflare \
   --api-token "$CLOUDFLARE_API_TOKEN" \
   --account-id "$CLOUDFLARE_ACCOUNT_ID" \
@@ -41,9 +82,5 @@ npx --yes --package @opencoredev/email-sdk email-sdk send \
   --subject "Hello" \
   --text "It works"
 ```
-
-Cloudflare Email Sending requires a Cloudflare DNS domain onboarded to Email Service. New accounts may be limited to verified recipient addresses, and Email Sending is available on Workers Paid plans.
-
-Cloudflare's REST API accepts `to`, `cc`, and `bcc` as plain email-address strings. The adapter preserves display names for `from` and `replyTo`, and rejects named recipients before the request instead of silently dropping the names.
 
 See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs/adapters/cloudflare.mdx
+++ b/apps/fumadocs/content/docs/adapters/cloudflare.mdx
@@ -73,7 +73,7 @@ The adapter maps Cloudflare `delivered` and `queued` recipients to `accepted`, a
 ## CLI smoke test
 
 ```bash
-bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk send \
   --adapter cloudflare \
   --api-token "$CLOUDFLARE_API_TOKEN" \
   --account-id "$CLOUDFLARE_ACCOUNT_ID" \

--- a/apps/fumadocs/content/docs/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs/adapters/field-support.mdx
@@ -75,6 +75,7 @@ await email.send({
 Do not use SMTP as a fallback for a message that depends on provider-only fields. This fails before a provider request instead of dropping data.
 
 ```ts
+// This client has SMTP as a fallback, but SMTP cannot send metadata or tags.
 await email.send({
   from: "Acme <hello@acme.com>",
   to: "user@example.com",

--- a/apps/fumadocs/content/docs/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs/adapters/field-support.mdx
@@ -36,6 +36,57 @@ If you are unsure, start with Resend for the first send, then choose fallback ro
 - Does the backup support reply-to and headers if support workflows depend on them?
 - Has the backup provider account been live-verified in the target environment?
 
+## Fallback examples
+
+Use a narrow fallback only for a narrow message shape. This works because both Resend and SMTP can represent the fields used here.
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      host: process.env.SMTP_HOST!,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  defaultAdapter: "resend",
+  fallback: ["smtp"],
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  replyTo: "support@example.com",
+  subject: "Password reset",
+  text: "Use this link to reset your password.",
+  headers: {
+    "X-Template": "password-reset",
+  },
+});
+```
+
+Do not use SMTP as a fallback for a message that depends on provider-only fields. This fails before a provider request instead of dropping data.
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  html: "<p>Thanks for your order.</p>",
+  metadata: {
+    orderId: "ord_123",
+  },
+  tags: [{ name: "type", value: "receipt" }],
+});
+```
+
 ## API adapters
 
 These adapters cover most transactional email fields. They are the best fit when your app needs CC, BCC, reply-to, custom headers, tags, metadata, or attachments.

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -72,6 +72,8 @@ Email SDK can catch unsupported fields before a request. It cannot make a provid
 
 ## Import pattern
 
+Start with one adapter. Add a fallback only after the fallback supports the same message shape your app sends.
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { resend } from "@opencoredev/email-sdk/resend";
@@ -90,6 +92,37 @@ const email = createEmailClient({
   ],
   fallback: ["smtp"],
 });
+```
+
+Route a single send through another configured adapter when a message has a provider-specific job.
+
+```ts
+const response = await email.send(
+  {
+    from: "Acme <hello@acme.com>",
+    to: "user@example.com",
+    subject: "Password reset",
+    text: "Use this link to reset your password.",
+  },
+  {
+    adapter: "smtp",
+  },
+);
+
+console.log(response.provider);
+```
+
+Before adding the provider to production, run a dry run and then a live smoke test from the same environment that will send mail.
+
+```bash
+bunx --bun --package @opencoredev/email-sdk email-sdk adapters
+RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --dry-run \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Dry run" \
+  --text "Validate only"
 ```
 
 ## Adapter groups

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -115,8 +115,8 @@ console.log(response.provider);
 Before adding the provider to production, run a dry run and then a live smoke test from the same environment that will send mail.
 
 ```bash
-bunx --bun --package @opencoredev/email-sdk email-sdk adapters
-RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk adapters
+RESEND_API_KEY="re_..." npx email-sdk send \
   --dry-run \
   --adapter resend \
   --from "Acme <hello@acme.com>" \

--- a/apps/fumadocs/content/docs/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs/adapters/loops.mdx
@@ -6,7 +6,13 @@ icon: loops
 
 <ProviderBadge adapter="loops" />
 
-Loops transactional sends require a `transactionalId`.
+Loops sends through a published Loops transactional email. It is best for product-triggered lifecycle messages where the template lives in Loops and your app passes data variables.
+
+## Before live sends
+
+Create or publish the transactional email in Loops, copy its `transactionalId`, and create an API key with permission to send transactional email. Loops may require account-level enablement for attachments, so omit attachments until that capability is enabled.
+
+## Configure
 
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -22,6 +28,46 @@ const email = createEmailClient({
 });
 ```
 
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
+  metadata: {
+    firstName: "Ada",
+    workspaceName: "Acme",
+  },
+});
+
+console.log(result.provider, result.id);
+```
+
+Loops maps `metadata` into `dataVariables` together with `subject`, `html`, `text`, and `from`. It only supports one recipient per transactional send.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Export ready",
+  text: "Your export is attached.",
+  metadata: {
+    firstName: "Ada",
+  },
+  attachments: [
+    {
+      filename: "export.txt",
+      content: "name,total\nAda,42",
+      contentType: "text/plain",
+    },
+  ],
+});
+```
+
 ## Options
 
 | Option            | Type           | Required | Notes                                |
@@ -32,3 +78,20 @@ const email = createEmailClient({
 | `fetch`           | `typeof fetch` | No       | Useful for tests or custom runtimes. |
 
 Loops transactional sends support one recipient, metadata through `dataVariables`, and attachments through the transactional attachments payload. Loops documents that attachments require support enablement on the account, so accounts without that enablement should omit `attachments`. Unsupported fields throw before the API call.
+
+## Response
+
+The adapter maps Loops `id` or `transactionalId` to the normalized `id` field when the API returns one.
+
+## CLI smoke test
+
+```bash
+LOOPS_API_KEY="loops_..." \
+LOOPS_TRANSACTIONAL_ID="cm..." \
+bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter loops \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Loops test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs/adapters/loops.mdx
@@ -88,7 +88,7 @@ The adapter maps Loops `id` or `transactionalId` to the normalized `id` field wh
 ```bash
 LOOPS_API_KEY="loops_..." \
 LOOPS_TRANSACTIONAL_ID="cm..." \
-bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk send \
   --adapter loops \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailchimp.mdx
@@ -78,7 +78,7 @@ Mailchimp Transactional returns an array of recipient results. The adapter uses 
 ## CLI smoke test
 
 ```bash
-MAILCHIMP_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+MAILCHIMP_API_KEY="..." npx email-sdk send \
   --adapter mailchimp \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailchimp.mdx
@@ -8,12 +8,56 @@ icon: mailchimp
 
 Mailchimp Transactional is the API formerly known as Mandrill.
 
+## Before live sends
+
+Create a Mailchimp Transactional API key, verify the sending domain, and confirm the account can send to the target recipient class. Mailchimp returns per-recipient results, so check the provider `raw` response during live smoke tests if a message is accepted by the SDK but does not arrive.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { mailchimp } from "@opencoredev/email-sdk/mailchimp";
 
 const email = createEmailClient({
   adapters: [mailchimp({ apiKey: process.env.MAILCHIMP_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  subject: "Receipt",
+  html: "<p>Thanks for your order.</p>",
+  metadata: {
+    orderId: "ord_123",
+  },
+  tags: [{ name: "type", value: "receipt" }],
+});
+
+console.log(result.provider, result.messageId);
+```
+
+Mailchimp Transactional maps CC/BCC, headers, metadata, tags, and attachments. It does not support `replyTo` in this adapter, so set replies through your provider template or omit the field.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  text: "Thanks for your order.",
+  attachments: [
+    {
+      filename: "receipt.txt",
+      content: "Order ord_123",
+      contentType: "text/plain",
+    },
+  ],
 });
 ```
 
@@ -26,3 +70,18 @@ const email = createEmailClient({
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
 
 See <a href="/docs/adapters/field-support">field support</a> for supported message fields.
+
+## Response
+
+Mailchimp Transactional returns an array of recipient results. The adapter uses the first result's `_id` or `id` as the normalized `id` and `messageId`.
+
+## CLI smoke test
+
+```bash
+MAILCHIMP_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter mailchimp \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Mailchimp Transactional test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailersend.mdx
@@ -6,12 +6,57 @@ icon: mailersend
 
 <ProviderBadge adapter="mailersend" />
 
+MailerSend supports transactional sends with CC, BCC, one reply-to address, custom headers, tag values, and attachments.
+
+## Before live sends
+
+Create a MailerSend API token, verify the sending domain, and confirm the account plan supports any custom headers you send. MailerSend documents custom headers as Professional and Enterprise features, so lower-plan accounts should omit `headers`.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { mailersend } from "@opencoredev/email-sdk/mailersend";
 
 const email = createEmailClient({
   adapters: [mailersend({ apiKey: process.env.MAILERSEND_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
+  subject: "Invoice ready",
+  html: "<p>Your invoice is ready.</p>",
+  headers: [{ name: "X-Invoice-ID", value: "inv_123" }],
+  tags: [{ name: "type", value: "invoice" }],
+});
+
+console.log(result.provider, result.id);
+```
+
+MailerSend supports one `replyTo` address. The adapter rejects multiple reply-to addresses before it calls the API.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Invoice ready",
+  html: "<p>Your invoice is attached.</p>",
+  attachments: [
+    {
+      filename: "invoice.txt",
+      content: "Invoice inv_123",
+      contentType: "text/plain",
+    },
+  ],
 });
 ```
 
@@ -26,3 +71,18 @@ const email = createEmailClient({
 See <a href="/docs/adapters/field-support">field support</a> for supported message fields.
 
 MailerSend custom headers map to `headers`. MailerSend documents custom headers as available on Professional and Enterprise accounts, so lower-plan accounts may need to omit `headers`.
+
+## Response
+
+The adapter uses the `x-message-id` response header when available, then falls back to body `message_id` or `id`.
+
+## CLI smoke test
+
+```bash
+MAILERSEND_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter mailersend \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "MailerSend test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailersend.mdx
@@ -33,7 +33,9 @@ const result = await email.send({
   replyTo: "support@example.com",
   subject: "Invoice ready",
   html: "<p>Your invoice is ready.</p>",
-  headers: [{ name: "X-Invoice-ID", value: "inv_123" }],
+  headers: {
+    "X-Invoice-ID": "inv_123",
+  },
   tags: [{ name: "type", value: "invoice" }],
 });
 
@@ -79,7 +81,7 @@ The adapter uses the `x-message-id` response header when available, then falls b
 ## CLI smoke test
 
 ```bash
-MAILERSEND_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+MAILERSEND_API_KEY="..." npx email-sdk send \
   --adapter mailersend \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailgun.mdx
@@ -10,6 +10,8 @@ icon: mailgun
 
 Create a Mailgun API key for the sending domain and use the base URL for the domain region. EU domains need the EU API base URL; US domains use the default. Verify DNS and sender setup before treating a successful SDK call as production-ready delivery.
 
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { mailgun } from "@opencoredev/email-sdk/mailgun";
@@ -24,6 +26,47 @@ const email = createEmailClient({
 });
 ```
 
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@mg.example.com>",
+  to: "user@example.com",
+  replyTo: "support@example.com",
+  subject: "Receipt",
+  html: "<p>Thanks for your order.</p>",
+  metadata: {
+    orderId: "ord_123",
+  },
+  tags: [{ name: "type", value: "receipt" }],
+  attachments: [
+    {
+      filename: "receipt.txt",
+      content: "Thanks for your order.",
+      contentType: "text/plain",
+    },
+  ],
+});
+
+console.log(result.provider, result.messageId);
+```
+
+Mailgun maps metadata as `v:*` variables and tag values as `o:tag`. Use `baseUrl: "https://api.eu.mailgun.net"` for EU-region domains.
+
+## Send with headers
+
+```ts
+await email.send({
+  from: "Acme <hello@mg.example.com>",
+  to: "user@example.com",
+  subject: "Support update",
+  text: "We received your request.",
+  headers: {
+    "X-Ticket-ID": "ticket_123",
+  },
+});
+```
+
 ## Options
 
 | Option    | Type           | Required | Notes                                                                                              |
@@ -34,3 +77,20 @@ const email = createEmailClient({
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                                               |
 
 Mailgun sends attachments as multipart form data. See <a href="/docs/adapters/field-support">field support</a> for the full mapping.
+
+## Response
+
+The adapter maps Mailgun `id` to the normalized `id` and `messageId` fields.
+
+## CLI smoke test
+
+```bash
+MAILGUN_API_KEY="key-..." \
+MAILGUN_DOMAIN="mg.example.com" \
+bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter mailgun \
+  --from "Acme <hello@mg.example.com>" \
+  --to user@example.com \
+  --subject "Mailgun test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailgun.mdx
@@ -87,7 +87,7 @@ The adapter maps Mailgun `id` to the normalized `id` and `messageId` fields.
 ```bash
 MAILGUN_API_KEY="key-..." \
 MAILGUN_DOMAIN="mg.example.com" \
-bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk send \
   --adapter mailgun \
   --from "Acme <hello@mg.example.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailpace.mdx
@@ -68,7 +68,7 @@ The adapter maps MailPace `id` or `message_id` to the normalized `id` field.
 ## CLI smoke test
 
 ```bash
-MAILPACE_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+MAILPACE_API_KEY="..." npx email-sdk send \
   --adapter mailpace \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailpace.mdx
@@ -6,12 +6,48 @@ icon: mailpace
 
 <ProviderBadge adapter="mailpace" />
 
+MailPace is a narrow send API adapter for simple transactional email. Use it when your messages only need address fields, reply-to, text, or HTML.
+
+## Before live sends
+
+Create a MailPace server token and verify the sender or domain in MailPace. Because this adapter intentionally rejects headers, metadata, tags, and attachments, check your production message shape before using it as a fallback.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { mailpace } from "@opencoredev/email-sdk/mailpace";
 
 const email = createEmailClient({
   adapters: [mailpace({ apiKey: process.env.MAILPACE_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
+  subject: "Plain transactional update",
+  text: "Your account has been updated.",
+});
+
+console.log(result.provider, result.id);
+```
+
+MailPace is a narrow adapter for address fields plus text or HTML body content. It rejects headers, metadata, tags, and attachments before the API call.
+
+## Send HTML
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
 });
 ```
 
@@ -24,3 +60,18 @@ const email = createEmailClient({
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.           |
 
 MailPace supports CC, BCC, and reply-to. Unsupported fields throw before the API call.
+
+## Response
+
+The adapter maps MailPace `id` or `message_id` to the normalized `id` field.
+
+## CLI smoke test
+
+```bash
+MAILPACE_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter mailpace \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "MailPace test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailtrap.mdx
@@ -81,7 +81,7 @@ The adapter uses the first returned `message_ids` value, then falls back to `mes
 ## CLI smoke test
 
 ```bash
-MAILTRAP_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+MAILTRAP_API_KEY="..." npx email-sdk send \
   --adapter mailtrap \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailtrap.mdx
@@ -6,12 +6,59 @@ icon: mailtrap
 
 <ProviderBadge adapter="mailtrap" />
 
+Mailtrap sends through the Mailtrap Email Sending API. It supports broad API-style fields and is also useful for staging environments where you want provider-side message inspection.
+
+## Before live sends
+
+Create a Mailtrap API token for Email Sending and verify the sender or domain. If you use a Mailtrap sandbox or staging inbox, confirm the target environment is using the intended Mailtrap project before sending production mail.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { mailtrap } from "@opencoredev/email-sdk/mailtrap";
 
 const email = createEmailClient({
   adapters: [mailtrap({ apiKey: process.env.MAILTRAP_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  cc: "qa@example.com",
+  replyTo: "support@example.com",
+  subject: "Mailtrap smoke",
+  html: "<p>Message captured.</p>",
+  metadata: {
+    scenario: "staging-smoke",
+  },
+  tags: [{ name: "category", value: "staging" }],
+});
+
+console.log(result.provider, result.messageId);
+```
+
+Mailtrap accepts one Email SDK tag. The adapter maps that tag value to the provider `category` field and rejects additional tags.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Staging receipt",
+  text: "The receipt is attached.",
+  attachments: [
+    {
+      filename: "receipt.txt",
+      content: "Order ord_123",
+      contentType: "text/plain",
+    },
+  ],
 });
 ```
 
@@ -26,3 +73,18 @@ const email = createEmailClient({
 See <a href="/docs/adapters/field-support">field support</a> for supported message fields.
 
 Mailtrap maps `replyTo` to `reply_to`, metadata to `custom_variables`, and the first returned `message_ids` value to the SDK response ID.
+
+## Response
+
+The adapter uses the first returned `message_ids` value, then falls back to `message_id` or `id`, and exposes it as normalized `id` and `messageId`.
+
+## CLI smoke test
+
+```bash
+MAILTRAP_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter mailtrap \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Mailtrap test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs/adapters/plunk.mdx
@@ -6,12 +6,60 @@ icon: plunk
 
 <ProviderBadge adapter="plunk" />
 
+Plunk is a product-led email adapter for event-style sends. It supports reply-to, headers, metadata, and attachments, but not CC, BCC, or tags.
+
+## Before live sends
+
+Create a Plunk API key and verify the sender setup for your workspace. Check your message shape before using Plunk as a fallback because CC, BCC, and tags are rejected locally.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { plunk } from "@opencoredev/email-sdk/plunk";
 
 const email = createEmailClient({
   adapters: [plunk({ apiKey: process.env.PLUNK_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: { email: "hello@acme.com", name: "Acme" },
+  to: [{ email: "user@example.com", name: "Ada" }],
+  replyTo: "support@example.com",
+  subject: "Product event",
+  html: "<p>Your export is ready.</p>",
+  headers: {
+    "X-Export-ID": "exp_123",
+  },
+  metadata: {
+    exportId: "exp_123",
+  },
+});
+
+console.log(result.provider, result.id);
+```
+
+Plunk maps `metadata` to `data` and `replyTo` to `reply`. It rejects CC, BCC, and tags before the API call.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Export ready",
+  html: "<p>Your export is attached.</p>",
+  attachments: [
+    {
+      filename: "export.txt",
+      content: "name,total\nAda,42",
+      contentType: "text/plain",
+    },
+  ],
 });
 ```
 
@@ -24,3 +72,18 @@ const email = createEmailClient({
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.         |
 
 Plunk maps metadata to `data`, `replyTo` to `reply`, custom headers to `headers`, attachments to `attachments`, and the first returned `data.emails[].email` value to the SDK response ID. Unsupported fields throw before the API call.
+
+## Response
+
+The adapter first reads the first `data.emails[].email` value, then falls back to body `id` or `emailId`.
+
+## CLI smoke test
+
+```bash
+PLUNK_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter plunk \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Plunk test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs/adapters/plunk.mdx
@@ -80,7 +80,7 @@ The adapter first reads the first `data.emails[].email` value, then falls back t
 ## CLI smoke test
 
 ```bash
-PLUNK_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+PLUNK_API_KEY="..." npx email-sdk send \
   --adapter plunk \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs/adapters/postmark.mdx
@@ -12,6 +12,8 @@ The Postmark adapter calls the Postmark Email API directly. It does not add a ru
 
 Create a Postmark server token for the server and message stream you want to send through. Make sure the sender signature or domain is approved in Postmark before using a production `from` address.
 
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { postmark } from "@opencoredev/email-sdk/postmark";
@@ -29,16 +31,33 @@ const email = createEmailClient({
 ## Send
 
 ```ts
-await email.send({
+const result = await email.send({
   from: "Acme <hello@acme.com>",
-  to: "user@example.com",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
   subject: "Receipt",
   html: "<p>Thanks for your order.</p>",
+  headers: {
+    "X-Order-ID": "ord_123",
+  },
   metadata: {
     orderId: "ord_123",
   },
+  tags: [{ name: "type", value: "receipt" }],
+  attachments: [
+    {
+      filename: "receipt.txt",
+      content: "Order ord_123",
+      contentType: "text/plain",
+    },
+  ],
 });
+
+console.log(result.provider, result.messageId);
 ```
+
+Postmark supports one Email SDK tag. The adapter serializes the first tag as `name:value` and rejects additional tags before the API call.
 
 ## Options
 
@@ -52,12 +71,12 @@ await email.send({
 
 ## Response
 
-The adapter maps Postmark `MessageID` to `id` and `messageId`.
+The adapter maps Postmark `MessageID` to `id` and `messageId`, and maps returned `To` to `accepted`.
 
 ## CLI smoke test
 
 ```bash
-POSTMARK_SERVER_TOKEN="..." npx --yes --package @opencoredev/email-sdk email-sdk send \
+POSTMARK_SERVER_TOKEN="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
   --adapter postmark \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs/adapters/postmark.mdx
@@ -76,7 +76,7 @@ The adapter maps Postmark `MessageID` to `id` and `messageId`, and maps returned
 ## CLI smoke test
 
 ```bash
-POSTMARK_SERVER_TOKEN="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+POSTMARK_SERVER_TOKEN="..." npx email-sdk send \
   --adapter postmark \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs/adapters/resend.mdx
@@ -12,6 +12,8 @@ The Resend adapter calls the Resend Email API directly. It does not add a runtim
 
 Create a Resend API key and verify the sender domain or sender address you plan to use in `from`. A dry run can validate the Email SDK message shape, but only a live send from your target environment proves the Resend account, sender, and recipient policy are ready.
 
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { resend } from "@opencoredev/email-sdk/resend";
@@ -24,19 +26,35 @@ const email = createEmailClient({
 ## Send
 
 ```ts
-await email.send(
+const result = await email.send(
   {
     from: "Acme <hello@acme.com>",
-    to: "user@example.com",
+    to: [{ email: "user@example.com", name: "Ada" }],
+    cc: "billing@example.com",
+    replyTo: "support@example.com",
     subject: "Welcome",
     html: "<p>Your workspace is ready.</p>",
+    headers: {
+      "X-Template": "welcome",
+    },
     tags: [{ name: "type", value: "welcome" }],
+    attachments: [
+      {
+        filename: "welcome.txt",
+        content: "Welcome to Acme.",
+        contentType: "text/plain",
+      },
+    ],
   },
   {
     idempotencyKey: "welcome:user_123",
   },
 );
+
+console.log(result.provider, result.messageId);
 ```
+
+Resend supports attachments and tags, but it does not support Email SDK `metadata`. If metadata matters for routing or analytics, choose another fallback route.
 
 ## Options
 
@@ -54,7 +72,7 @@ The adapter returns the Resend `id` as `id` and `messageId`.
 ## CLI smoke test
 
 ```bash
-RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk send \
+RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs/adapters/resend.mdx
@@ -72,7 +72,7 @@ The adapter returns the Resend `id` as `id` and `messageId`.
 ## CLI smoke test
 
 ```bash
-RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+RESEND_API_KEY="re_..." npx email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs/adapters/scaleway.mdx
@@ -38,7 +38,9 @@ const result = await email.send({
   replyTo: "support@example.com",
   subject: "Scaleway Transactional Email test",
   html: "<p>It works.</p>",
-  headers: [{ name: "X-Trace-ID", value: "trace_123" }],
+  headers: {
+    "X-Trace-ID": "trace_123",
+  },
 });
 
 console.log(result.provider, result.id);
@@ -85,7 +87,7 @@ The adapter maps Scaleway `id` or `email_id` to the normalized `id` field.
 ```bash
 SCALEWAY_SECRET_KEY="..." \
 SCALEWAY_PROJECT_ID="..." \
-bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk send \
   --adapter scaleway \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs/adapters/scaleway.mdx
@@ -6,6 +6,14 @@ icon: scaleway
 
 <ProviderBadge adapter="scaleway" />
 
+Scaleway Transactional Email supports address fields, headers, reply-to, and attachments. The adapter defaults to the `fr-par` region unless you pass a different region.
+
+## Before live sends
+
+Create a Scaleway secret key, confirm the project ID and region, and verify the sending domain in Scaleway Transactional Email. If your project uses a region other than `fr-par`, pass `region` in code or `SCALEWAY_REGION` in the CLI environment.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { scaleway } from "@opencoredev/email-sdk/scaleway";
@@ -16,6 +24,42 @@ const email = createEmailClient({
       secretKey: process.env.SCALEWAY_SECRET_KEY!,
       projectId: process.env.SCALEWAY_PROJECT_ID!,
     }),
+  ],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
+  subject: "Scaleway Transactional Email test",
+  html: "<p>It works.</p>",
+  headers: [{ name: "X-Trace-ID", value: "trace_123" }],
+});
+
+console.log(result.provider, result.id);
+```
+
+Scaleway maps `replyTo` as a `Reply-To` additional header. If you already set a `Reply-To` header manually, omit `replyTo` to avoid a validation error.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Receipt",
+  text: "The receipt is attached.",
+  attachments: [
+    {
+      filename: "receipt.txt",
+      content: "Order ord_123",
+      contentType: "text/plain",
+    },
   ],
 });
 ```
@@ -31,3 +75,20 @@ const email = createEmailClient({
 | `fetch`     | `typeof fetch` | No       | Useful for tests or custom runtimes.    |
 
 Scaleway maps address objects, CC/BCC, attachments, custom headers, and `replyTo` through the Transactional Email REST API. Unsupported fields throw before the API call.
+
+## Response
+
+The adapter maps Scaleway `id` or `email_id` to the normalized `id` field.
+
+## CLI smoke test
+
+```bash
+SCALEWAY_SECRET_KEY="..." \
+SCALEWAY_PROJECT_ID="..." \
+bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter scaleway \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Scaleway test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -10,12 +10,53 @@ icon: sendgrid
 
 Create a SendGrid API key with Mail Send permission and verify the sender identity or domain used in `from`. SendGrid account review, sandbox mode, or sender verification can block delivery even when the SDK payload validates.
 
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { sendgrid } from "@opencoredev/email-sdk/sendgrid";
 
 const email = createEmailClient({
   adapters: [sendgrid({ apiKey: process.env.SENDGRID_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: { email: "hello@acme.com", name: "Acme" },
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
+  metadata: {
+    userId: "user_123",
+  },
+  tags: [{ name: "category", value: "welcome" }],
+});
+
+console.log(result.provider, result.id);
+```
+
+SendGrid maps Email SDK `metadata` to `custom_args` and tag values to `categories`.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Invoice ready",
+  html: "<p>Your invoice is attached.</p>",
+  attachments: [
+    {
+      filename: "invoice.txt",
+      content: "Invoice inv_123",
+      contentType: "text/plain",
+    },
+  ],
 });
 ```
 
@@ -29,8 +70,17 @@ const email = createEmailClient({
 
 See <a href="/docs/adapters/field-support">field support</a> for headers, tags, metadata, and attachments.
 
-## CLI
+## Response
+
+The adapter uses body `id` or `message_id` when present, then falls back to the `x-message-id` response header.
+
+## CLI smoke test
 
 ```bash
-SENDGRID_API_KEY="SG..." npx --yes --package @opencoredev/email-sdk email-sdk send --adapter sendgrid --from hello@example.com --to user@example.com --subject "Hello" --text "It works"
+SENDGRID_API_KEY="SG..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter sendgrid \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "SendGrid test" \
+  --text "It works"
 ```

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -77,7 +77,7 @@ The adapter uses body `id` or `message_id` when present, then falls back to the 
 ## CLI smoke test
 
 ```bash
-SENDGRID_API_KEY="SG..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+SENDGRID_API_KEY="SG..." npx email-sdk send \
   --adapter sendgrid \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs/adapters/ses.mdx
@@ -12,6 +12,8 @@ The AWS SES adapter calls the SES v2 SendEmail API directly with SigV4-signed fe
 
 Use credentials that can call SES v2 `SendEmail` in the selected region. Verify the sender identity in that same region, and confirm whether the AWS account is still in the SES sandbox before sending to arbitrary recipients.
 
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { ses } from "@opencoredev/email-sdk/ses";
@@ -31,14 +33,30 @@ const email = createEmailClient({
 ## Send
 
 ```ts
-await email.send({
+const result = await email.send({
   from: "Acme <hello@acme.com>",
-  to: "user@example.com",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
   subject: "Welcome",
   html: "<p>Your workspace is ready.</p>",
+  headers: {
+    "X-Template": "welcome",
+  },
   tags: [{ name: "type", value: "welcome" }],
+  attachments: [
+    {
+      filename: "welcome.txt",
+      content: "Welcome to Acme.",
+      contentType: "text/plain",
+    },
+  ],
 });
+
+console.log(result.provider, result.messageId);
 ```
+
+SES maps Email SDK tags to SES `EmailTags`, headers to `Simple.Headers`, and attachments to SES v2 `Simple.Attachments`. It does not map Email SDK `metadata`.
 
 ## Options
 
@@ -53,19 +71,19 @@ await email.send({
 | `charset`              | `string`       | No       | Defaults to `UTF-8`.                                  |
 | `configurationSetName` | `string`       | No       | SES configuration set for sends through this adapter. |
 
-## CLI
+## Response
+
+The adapter returns the SES `MessageId` as `id` and `messageId`.
+
+## CLI smoke test
 
 ```bash
 AWS_ACCESS_KEY_ID=... \
 AWS_SECRET_ACCESS_KEY=... \
 AWS_REGION=us-east-1 \
-npx --yes --package @opencoredev/email-sdk email-sdk send --adapter ses \
+bunx --bun --package @opencoredev/email-sdk email-sdk send --adapter ses \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \
   --subject "Welcome" \
   --html "<p>Your workspace is ready.</p>"
 ```
-
-## Response
-
-The adapter returns the SES `MessageId` as `id` and `messageId`.

--- a/apps/fumadocs/content/docs/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs/adapters/ses.mdx
@@ -81,7 +81,7 @@ The adapter returns the SES `MessageId` as `id` and `messageId`.
 AWS_ACCESS_KEY_ID=... \
 AWS_SECRET_ACCESS_KEY=... \
 AWS_REGION=us-east-1 \
-bunx --bun --package @opencoredev/email-sdk email-sdk send --adapter ses \
+npx email-sdk send --adapter ses \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \
   --subject "Welcome" \

--- a/apps/fumadocs/content/docs/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs/adapters/smtp.mdx
@@ -107,7 +107,7 @@ The adapter returns the SMTP server message ID when it can parse one. It also re
 ## CLI smoke test
 
 ```bash
-bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk send \
   --adapter smtp \
   --host smtp.purelymail.com \
   --user hello@example.com \

--- a/apps/fumadocs/content/docs/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs/adapters/smtp.mdx
@@ -35,6 +35,26 @@ const email = createEmailClient({
 });
 ```
 
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@example.com>",
+  to: "user@example.com",
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
+  subject: "SMTP delivery test",
+  text: "It works",
+  headers: {
+    "X-Trace-ID": "trace_123",
+  },
+});
+
+console.log(result.provider, result.accepted);
+```
+
+SMTP supports address fields and headers. It rejects attachments, tags, and metadata because those provider-specific fields cannot be represented in this built-in transport.
+
 ## Options
 
 | Option              | Type                             | Required | Notes                                     |
@@ -58,18 +78,36 @@ Rename adapters when you have multiple SMTP routes.
 ```ts
 const email = createEmailClient({
   adapters: [
-    smtp({ name: "purelymail", host: "smtp.purelymail.com" }),
-    smtp({ name: "backup-smtp", host: "smtp.backup.example" }),
+    smtp({
+      name: "purelymail",
+      host: "smtp.purelymail.com",
+      auth: {
+        user: process.env.PURELYMAIL_USER!,
+        pass: process.env.PURELYMAIL_PASS!,
+      },
+    }),
+    smtp({
+      name: "backup-smtp",
+      host: "smtp.backup.example",
+      auth: {
+        user: process.env.BACKUP_SMTP_USER!,
+        pass: process.env.BACKUP_SMTP_PASS!,
+      },
+    }),
   ],
   defaultAdapter: "purelymail",
   fallback: ["backup-smtp"],
 });
 ```
 
-## CLI
+## Response
+
+The adapter returns the SMTP server message ID when it can parse one. It also returns accepted recipients and an empty `rejected` array because failed recipients throw during the SMTP conversation.
+
+## CLI smoke test
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk send \
+bunx --bun --package @opencoredev/email-sdk email-sdk send \
   --adapter smtp \
   --host smtp.purelymail.com \
   --user hello@example.com \

--- a/apps/fumadocs/content/docs/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs/adapters/sparkpost.mdx
@@ -82,7 +82,7 @@ The adapter maps SparkPost `results.id` or `results.transmission_id` to the norm
 ## CLI smoke test
 
 ```bash
-SPARKPOST_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+SPARKPOST_API_KEY="..." npx email-sdk send \
   --adapter sparkpost \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs/adapters/sparkpost.mdx
@@ -6,12 +6,61 @@ icon: sparkpost
 
 <ProviderBadge adapter="sparkpost" />
 
+SparkPost sends transmissions with one normalized recipient list, reply-to, headers, metadata, tag-derived substitution data, and attachments. It does not support normalized CC or BCC through this adapter.
+
+## Before live sends
+
+Create a SparkPost API key with Transmissions permission, verify the sending domain, and choose whether to use SparkPost sandbox mode. Set `sandbox: true` for provider-side sandbox validation without normal delivery.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { sparkpost } from "@opencoredev/email-sdk/sparkpost";
 
 const email = createEmailClient({
   adapters: [sparkpost({ apiKey: process.env.SPARKPOST_API_KEY! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: { email: "hello@acme.com", name: "Acme" },
+  to: "user@example.com",
+  replyTo: "support@example.com",
+  subject: "SparkPost transmission",
+  html: "<p>Your report is ready.</p>",
+  headers: {
+    "X-Report-ID": "rep_123",
+  },
+  metadata: {
+    reportId: "rep_123",
+  },
+  tags: [{ name: "type", value: "report" }],
+});
+
+console.log(result.provider, result.id);
+```
+
+SparkPost does not expose normalized CC/BCC in this adapter. It maps metadata to `metadata` and tags to `substitution_data`.
+
+## Send with an attachment
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Report ready",
+  html: "<p>Your report is attached.</p>",
+  attachments: [
+    {
+      filename: "report.txt",
+      content: "Report rep_123",
+      contentType: "text/plain",
+    },
+  ],
 });
 ```
 
@@ -25,3 +74,18 @@ const email = createEmailClient({
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.            |
 
 SparkPost does not expose normalized CC/BCC in this adapter. See <a href="/docs/adapters/field-support">field support</a>.
+
+## Response
+
+The adapter maps SparkPost `results.id` or `results.transmission_id` to the normalized `id` field.
+
+## CLI smoke test
+
+```bash
+SPARKPOST_API_KEY="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter sparkpost \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "SparkPost test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/adapters/unosend.mdx
+++ b/apps/fumadocs/content/docs/adapters/unosend.mdx
@@ -6,6 +6,14 @@ icon: unosend
 
 <ProviderBadge adapter="unosend" />
 
+The Unosend adapter calls the Unosend REST API directly. It is a good fit when you want API-based transactional delivery with CC, BCC, headers, tags, and attachments, but do not need Email SDK `metadata`.
+
+## Before live sends
+
+Create a server-side Unosend API key, verify the sending domain you use in `from`, and keep the key in `UNOSEND_API_KEY`. A dry run can validate the Email SDK message shape, but only a live send from your target environment proves the Unosend account and domain are ready.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { unosend } from "@opencoredev/email-sdk/unosend";
@@ -15,6 +23,35 @@ const email = createEmailClient({
 });
 ```
 
+## Send
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  bcc: "audit@example.com",
+  replyTo: "support@example.com",
+  subject: "Welcome",
+  html: "<p>Your workspace is ready.</p>",
+  headers: {
+    "X-Template": "welcome",
+  },
+  tags: [{ name: "type", value: "welcome" }],
+  attachments: [
+    {
+      filename: "welcome.txt",
+      content: "Welcome to Acme.",
+      contentType: "text/plain",
+    },
+  ],
+});
+
+console.log(result.provider, result.messageId);
+```
+
+Unosend supports one `replyTo` address. The adapter rejects multiple reply-to addresses before it calls the API.
+
 ## Options
 
 | Option    | Type           | Required | Notes                                 |
@@ -23,20 +60,19 @@ const email = createEmailClient({
 | `baseUrl` | `string`       | No       | Defaults to `https://api.unosend.co`. |
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.  |
 
-## CLI
+Unosend maps CC, BCC, one reply-to address, headers, tags, and Base64 attachments. `metadata` is not part of Unosend's send endpoint, so the adapter rejects metadata before the request instead of silently dropping it.
+
+## Response
+
+The adapter maps the Unosend email ID to `id` and `messageId`, and keeps the provider response in `raw`.
+
+## CLI smoke test
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk send \
+UNOSEND_API_KEY="un_..." npx email-sdk send \
   --adapter unosend \
-  --api-key "$UNOSEND_API_KEY" \
-  --from "hello@example.com" \
+  --from "Acme <hello@acme.com>" \
   --to "user@example.com" \
   --subject "Hello" \
   --text "It works"
 ```
-
-Unosend requires a server-side Bearer API key and a verified sending domain. API keys start with `un_` and should be stored in `UNOSEND_API_KEY`.
-
-The adapter calls `POST https://api.unosend.co/emails`, maps CC, BCC, one reply-to address, headers, tags, and Base64 attachments, and returns the Unosend email ID as `id` and `messageId`. `metadata` is not part of Unosend's send endpoint, so the adapter rejects metadata before the request instead of silently dropping it.
-
-See <a href="/docs/adapters/field-support">field support</a> for supported message fields.

--- a/apps/fumadocs/content/docs/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs/adapters/zeptomail.mdx
@@ -75,7 +75,7 @@ The adapter maps ZeptoMail `request_id`, `messageId`, or `id` to the normalized 
 ## CLI smoke test
 
 ```bash
-ZEPTOMAIL_TOKEN="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+ZEPTOMAIL_TOKEN="..." npx email-sdk send \
   --adapter zeptomail \
   --from "Acme <hello@acme.com>" \
   --to user@example.com \

--- a/apps/fumadocs/content/docs/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs/adapters/zeptomail.mdx
@@ -6,12 +6,55 @@ icon: zeptomail
 
 <ProviderBadge adapter="zeptomail" />
 
+ZeptoMail supports recipient objects, CC, BCC, reply-to, and attachments. It intentionally rejects headers, metadata, and tags because the adapter does not map them to the ZeptoMail API.
+
+## Before live sends
+
+Create a ZeptoMail API token and verify the sending domain in Zoho ZeptoMail. The adapter accepts tokens with or without the `Zoho-enczapikey` prefix.
+
+## Configure
+
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
 import { zeptomail } from "@opencoredev/email-sdk/zeptomail";
 
 const email = createEmailClient({
   adapters: [zeptomail({ token: process.env.ZEPTOMAIL_TOKEN! })],
+});
+```
+
+## Send
+
+```ts
+const result = await email.send({
+  from: { email: "hello@acme.com", name: "Acme" },
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "billing@example.com",
+  replyTo: "support@example.com",
+  subject: "ZeptoMail test",
+  html: "<p>It works.</p>",
+  attachments: [
+    {
+      filename: "receipt.txt",
+      content: "Thanks for your order.",
+      contentType: "text/plain",
+    },
+  ],
+});
+
+console.log(result.provider, result.id);
+```
+
+ZeptoMail supports recipients, reply-to, and attachments. It rejects headers, metadata, and tags before the API call.
+
+## Send text only
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Plain update",
+  text: "Your account has been updated.",
 });
 ```
 
@@ -24,3 +67,18 @@ const email = createEmailClient({
 | `fetch`   | `typeof fetch` | No       | Useful for tests or custom runtimes.                                          |
 
 ZeptoMail supports recipients, reply-to, and attachments. Unsupported fields throw before the API call.
+
+## Response
+
+The adapter maps ZeptoMail `request_id`, `messageId`, or `id` to the normalized `id` field.
+
+## CLI smoke test
+
+```bash
+ZEPTOMAIL_TOKEN="..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
+  --adapter zeptomail \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "ZeptoMail test" \
+  --text "It works"
+```

--- a/apps/fumadocs/content/docs/getting-started/install.mdx
+++ b/apps/fumadocs/content/docs/getting-started/install.mdx
@@ -45,6 +45,8 @@ Check a provider configuration:
 RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk doctor --adapter resend
 ```
 
+If you are using npm without Bun, install `@opencoredev/email-sdk` in the project first, then run the installed `email-sdk` binary with `npx`.
+
 ## Run the CLI from an installed project
 
 After installing `@opencoredev/email-sdk`, run the installed binary:
@@ -53,7 +55,7 @@ After installing `@opencoredev/email-sdk`, run the installed binary:
 npx email-sdk adapters
 ```
 
-The command is still `email-sdk`; the package you installed is still `@opencoredev/email-sdk`. Avoid `npx email-sdk` outside an installed project because the unscoped npm package is unrelated. For one-off checks, use the `bunx --bun --package @opencoredev/email-sdk email-sdk ...` form shown above.
+The command is still `email-sdk`; the package you installed is still `@opencoredev/email-sdk`. Avoid `npx email-sdk` outside an installed project because the unscoped npm package is unrelated. For no-install checks, use the `bunx --bun --package @opencoredev/email-sdk email-sdk ...` form shown above.
 
 ## Prerequisites
 

--- a/apps/fumadocs/content/docs/getting-started/install.mdx
+++ b/apps/fumadocs/content/docs/getting-started/install.mdx
@@ -12,7 +12,7 @@ The command-line binary is named `email-sdk`. That means the package name and th
 | ------------------------------ | ------------------------------------------------------------ |
 | Install the package            | `npm install @opencoredev/email-sdk` or your package manager's install command |
 | Run the installed CLI          | `npx email-sdk ...`                                          |
-| Run the CLI without installing | `npx --yes --package @opencoredev/email-sdk email-sdk ...`   |
+| Run the CLI without installing | `bunx --bun --package @opencoredev/email-sdk email-sdk ...`  |
 
 Do not install the unscoped `email-sdk` package from npm. It is a different package.
 
@@ -36,13 +36,13 @@ The SDK and CLI run in server-side Node 20+ and Bun runtimes.
 Use the scoped package name when you want a quick adapter check without adding the package to a project.
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk adapters
+bunx --bun --package @opencoredev/email-sdk email-sdk adapters
 ```
 
 Check a provider configuration:
 
 ```bash
-RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk doctor --adapter resend
+RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk doctor --adapter resend
 ```
 
 ## Run the CLI from an installed project
@@ -53,9 +53,7 @@ After installing `@opencoredev/email-sdk`, run the installed binary:
 npx email-sdk adapters
 ```
 
-The command is still `email-sdk`; the package you installed is still `@opencoredev/email-sdk`. Avoid `npx email-sdk` outside an installed project because the unscoped npm package is unrelated.
-
-Bun users can use the same package and binary. If you want Bun to execute the one-off CLI command, use `bunx --bun --package @opencoredev/email-sdk email-sdk adapters`.
+The command is still `email-sdk`; the package you installed is still `@opencoredev/email-sdk`. Avoid `npx email-sdk` outside an installed project because the unscoped npm package is unrelated. For one-off checks, use the `bunx --bun --package @opencoredev/email-sdk email-sdk ...` form shown above.
 
 ## Prerequisites
 
@@ -66,14 +64,14 @@ Bun users can use the same package and binary. If you want Bun to execute the on
 
 ## Verify the install
 
-Check the published package and CLI version:
+Check the installed package and CLI version:
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk version
+npx email-sdk version
 ```
 
 List supported adapters:
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk adapters
+npx email-sdk adapters
 ```

--- a/apps/fumadocs/content/docs/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs/getting-started/quickstart.mdx
@@ -8,7 +8,7 @@ Install the scoped package with the package manager your app already uses:
 
 <PackageInstallTabs />
 
-The SDK and CLI work in server-side Node 20+ and Bun runtimes. The installed CLI command is named `email-sdk`. If you only need the CLI for a quick check, run `bunx --bun --package @opencoredev/email-sdk email-sdk ...` instead. See <a href="/docs/getting-started/install">Install</a> for the package and CLI distinction.
+The SDK and CLI work in server-side Node 20+ and Bun runtimes. The installed CLI command is named `email-sdk`. If you only need the CLI for a no-install check, run `bunx --bun --package @opencoredev/email-sdk email-sdk ...`. npm-only projects should install `@opencoredev/email-sdk` first, then run `npx email-sdk ...`. See <a href="/docs/getting-started/install">Install</a> for the package and CLI distinction.
 
 ## Choose a first adapter
 
@@ -57,13 +57,13 @@ responses are still available through `raw` when an adapter includes them.
 Use `doctor` to check that the selected adapter has the required environment variables.
 
 ```bash
-RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk doctor --adapter resend
+RESEND_API_KEY="re_..." npx email-sdk doctor --adapter resend
 ```
 
 Use `--dry-run` to validate the message shape and adapter field support without sending email.
 
 ```bash
-bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to "user@example.com" \

--- a/apps/fumadocs/content/docs/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs/getting-started/quickstart.mdx
@@ -8,7 +8,7 @@ Install the scoped package with the package manager your app already uses:
 
 <PackageInstallTabs />
 
-The SDK and CLI work in server-side Node 20+ and Bun runtimes. The installed CLI command is named `email-sdk`. If you only need the CLI for a quick check, run `npx --yes --package @opencoredev/email-sdk email-sdk ...` instead. See <a href="/docs/getting-started/install">Install</a> for the package and CLI distinction.
+The SDK and CLI work in server-side Node 20+ and Bun runtimes. The installed CLI command is named `email-sdk`. If you only need the CLI for a quick check, run `bunx --bun --package @opencoredev/email-sdk email-sdk ...` instead. See <a href="/docs/getting-started/install">Install</a> for the package and CLI distinction.
 
 ## Choose a first adapter
 
@@ -57,13 +57,13 @@ responses are still available through `raw` when an adapter includes them.
 Use `doctor` to check that the selected adapter has the required environment variables.
 
 ```bash
-RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk doctor --adapter resend
+RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk doctor --adapter resend
 ```
 
 Use `--dry-run` to validate the message shape and adapter field support without sending email.
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk send \
+bunx --bun --package @opencoredev/email-sdk email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to "user@example.com" \

--- a/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
+++ b/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
@@ -287,19 +287,19 @@ Test fallback routes with the same message fields your production route uses.
 List supported adapters:
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk adapters
+bunx --bun --package @opencoredev/email-sdk email-sdk adapters
 ```
 
 Check required configuration for one adapter:
 
 ```bash
-RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk doctor --adapter resend
+RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk doctor --adapter resend
 ```
 
 Validate message shape and adapter field support without sending:
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk send \
+bunx --bun --package @opencoredev/email-sdk email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to "user@example.com" \

--- a/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
+++ b/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
@@ -287,19 +287,19 @@ Test fallback routes with the same message fields your production route uses.
 List supported adapters:
 
 ```bash
-bunx --bun --package @opencoredev/email-sdk email-sdk adapters
+npx email-sdk adapters
 ```
 
 Check required configuration for one adapter:
 
 ```bash
-RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk doctor --adapter resend
+RESEND_API_KEY="re_..." npx email-sdk doctor --adapter resend
 ```
 
 Validate message shape and adapter field support without sending:
 
 ```bash
-bunx --bun --package @opencoredev/email-sdk email-sdk send \
+npx email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to "user@example.com" \

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -13,7 +13,7 @@ The npm package is `@opencoredev/email-sdk`; the CLI command it installs is `ema
 Run the CLI once with the scoped package:
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk adapters
+bunx --bun --package @opencoredev/email-sdk email-sdk adapters
 ```
 
 Install the SDK in a project:
@@ -32,12 +32,12 @@ Check the installed version before comparing behavior against the docs:
 npx email-sdk version
 ```
 
-The CLI supports Node 20+ and Bun 1.1+. The examples use `npx` because it is the broadest copy-paste path; Bun users can run the one-off CLI with `bunx --bun --package @opencoredev/email-sdk email-sdk adapters`.
+The CLI supports Node 20+ and Bun 1.1+. One-off examples use `bunx --bun --package @opencoredev/email-sdk email-sdk ...` because it executes the scoped package binary without installing anything globally. After installing `@opencoredev/email-sdk` in a project, use `npx email-sdk ...` from that project.
 
 ## Send
 
 ```bash
-RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk send \
+RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk send \
   --adapter resend \
   --from "Acme <hello@acme.com>" \
   --to "user@example.com" \
@@ -48,7 +48,7 @@ RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk sen
 ## Adapters
 
 ```bash
-npx --yes --package @opencoredev/email-sdk email-sdk adapters
+bunx --bun --package @opencoredev/email-sdk email-sdk adapters
 ```
 
 | Adapter      | Required environment                                       |
@@ -77,7 +77,7 @@ If `--adapter` is omitted, the CLI selects the first adapter with all required e
 ## Doctor
 
 ```bash
-RESEND_API_KEY="re_..." npx --yes --package @opencoredev/email-sdk email-sdk doctor --adapter resend
+RESEND_API_KEY="re_..." bunx --bun --package @opencoredev/email-sdk email-sdk doctor --adapter resend
 ```
 
 `doctor` checks whether the selected adapter has the required environment variables or matching CLI credential flags.

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -32,7 +32,7 @@ Check the installed version before comparing behavior against the docs:
 npx email-sdk version
 ```
 
-The CLI supports Node 20+ and Bun 1.1+. One-off examples use `bunx --bun --package @opencoredev/email-sdk email-sdk ...` because it executes the scoped package binary without installing anything globally. After installing `@opencoredev/email-sdk` in a project, use `npx email-sdk ...` from that project.
+The CLI supports Node 20+ and Bun 1.1+. No-install examples use `bunx --bun --package @opencoredev/email-sdk email-sdk ...` because that verified path executes the scoped package binary directly. For npm-only projects, install `@opencoredev/email-sdk` first, then use `npx email-sdk ...` from that project.
 
 ## Send
 

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -318,7 +318,7 @@ The package includes a small CLI:
 
 ```bash
 # one-off: no install needed
-npx --yes --package @opencoredev/email-sdk email-sdk adapters
+bunx --bun --package @opencoredev/email-sdk email-sdk adapters
 
 # after installing @opencoredev/email-sdk
 npx email-sdk adapters
@@ -327,7 +327,7 @@ RESEND_API_KEY="re_..." npx email-sdk send --adapter resend --from hello@example
 npx email-sdk send --dry-run --adapter resend --from hello@example.com --to user@example.com --subject "Hello" --text "It works"
 ```
 
-The CLI can read provider credentials from environment variables or matching credential flags. Run `npx email-sdk adapters` to see the variables each adapter expects after the package is installed. `--dry-run` validates the message and selected adapter field support without sending email.
+The CLI can read provider credentials from environment variables or matching credential flags. Run `bunx --bun --package @opencoredev/email-sdk email-sdk adapters` for a one-off adapter list, or `npx email-sdk adapters` after installing the scoped package in a project. `--dry-run` validates the message and selected adapter field support without sending email.
 
 ## Provider Reality
 


### PR DESCRIPTION
## Summary
- expand every adapter page with setup, send, options, response, and CLI smoke examples
- add fallback examples to the field-support page and routing/dry-run examples to the adapter index
- correct one-off CLI docs to the verified bunx scoped-package command while keeping installed-project npx examples

## Verification
- python3 /Users/leo/.agents/skills/docs-writer/scripts/docs_quality_gate.py
- git diff --check
- adapter docs section coverage check for all 17 adapter pages
- bunx --bun --package @opencoredev/email-sdk email-sdk version
- bunx --bun --package @opencoredev/email-sdk email-sdk adapters
- RESEND_API_KEY=dummy bunx --bun --package @opencoredev/email-sdk email-sdk send --dry-run --adapter resend --from 'Acme <hello@acme.com>' --to user@example.com --subject 'Docs one-off' --text 'It works'
- bun run release:ci