### PR TITLE
Add SMTP2GO community registry entry

### DIFF
--- a/apps/fumadocs/content/community/plugins.json
+++ b/apps/fumadocs/content/community/plugins.json
@@ -1,1 +1,15 @@
-[]
+[
+  {
+    "name": "SMTP2GO",
+    "package": "email-sdk-smtp2go",
+    "kind": "adapter",
+    "status": "community",
+    "description": "Adds an SMTP2GO provider adapter for Email SDK.",
+    "href": "https://www.npmjs.com/package/email-sdk-smtp2go",
+    "repo": "https://github.com/stefandevo/email-sdk-smtp2go",
+    "maintainer": "stefandevo",
+    "pluginId": "smtp2go",
+    "adapter": "smtp2go",
+    "importName": "smtp2goPlugin"
+  }
+]


### PR DESCRIPTION
## Purpose

Add the published SMTP2GO adapter package to the Email SDK community plugin registry.

## Key Changes

- Adds `email-sdk-smtp2go` as a `community` adapter entry in `apps/fumadocs/content/community/plugins.json`.
- Points users to the published npm package and the community-maintained adapter repository.
- Leaves out verified/official metadata for the initial community listing.

## Checks

- `npm view email-sdk-smtp2go version` -> `0.1.1`
- `npm view email-sdk-smtp2go repository.url peerDependencies --json`
- Fresh install/import smoke check with `email-sdk-smtp2go` and `@opencoredev/email-sdk`
- `bun run community:check`