### PR TITLE
docs: schedule SEO blog cadence

### DIFF
--- a/.github/workflows/blog-schedule.yml
+++ b/.github/workflows/blog-schedule.yml
@@ -1,0 +1,30 @@
+name: Refresh scheduled blog posts
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Rebuild every Wednesday after the scheduled post date rolls over in UTC.
+    - cron: "30 13 * * 3"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: scheduled-blog-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Trigger Vercel rebuild
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deploy hook
+        env:
+          VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
+        run: |
+          if [ -z "$VERCEL_DEPLOY_HOOK_URL" ]; then
+            echo "::notice::Set VERCEL_DEPLOY_HOOK_URL to refresh static blog, sitemap, RSS, and JSON feed every week."
+            exit 0
+          fi
+
+          curl --fail --show-error --silent --request POST "$VERCEL_DEPLOY_HOOK_URL"

--- a/apps/fumadocs/src/lib/blog.test.ts
+++ b/apps/fumadocs/src/lib/blog.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { getAllBlogPosts, getBlogPostMetaTitle, getPublishedBlogPosts } from "./blog";
+
+describe("blog schedule", () => {
+  test("keeps twenty weekly posts scheduled after the June launch posts", () => {
+    const scheduled = getAllBlogPosts().filter((post) => post.publishedAt >= "2026-06-17");
+
+    expect(scheduled).toHaveLength(20);
+
+    for (let index = 1; index < scheduled.length; index++) {
+      const previous = new Date(`${scheduled[index - 1]?.publishedAt}T00:00:00Z`);
+      const current = new Date(`${scheduled[index]?.publishedAt}T00:00:00Z`);
+      const days = (current.getTime() - previous.getTime()) / 86_400_000;
+
+      expect(days).toBe(7);
+    }
+  });
+
+  test("hides future posts from public feeds until their publish date", () => {
+    const posts = getPublishedBlogPosts(new Date("2026-06-09T12:00:00Z"));
+
+    expect(posts.map((post) => post.slug)).toEqual([
+      "email-provider-fallbacks",
+      "introducing-email-sdk",
+    ]);
+  });
+
+  test("uses a distinct image URL for every blog post", () => {
+    const images = getAllBlogPosts().map((post) => post.image);
+
+    expect(new Set(images).size).toBe(images.length);
+    expect(images.every((image) => image.startsWith("/og/blog/"))).toBe(true);
+  });
+
+  test("keeps post title tags short enough for search results", () => {
+    const titles = getAllBlogPosts().map((post) => getBlogPostMetaTitle(post.title));
+
+    expect(titles.every((title) => title.length <= 68)).toBe(true);
+    expect(titles.every((title) => title.endsWith(" - Email SDK"))).toBe(true);
+  });
+});

--- a/apps/fumadocs/src/lib/blog.ts
+++ b/apps/fumadocs/src/lib/blog.ts
@@ -10,6 +10,9 @@ export type BlogPost = {
   tags: string[];
 };
 
+const blogMetaTitleSuffix = " - Email SDK";
+const maxBlogMetaTitleLength = 68;
+
 export const blogPosts = [
   {
     slug: "introducing-email-sdk",
@@ -19,7 +22,7 @@ export const blogPosts = [
     publishedAt: "2026-06-01",
     updatedAt: "2026-06-01",
     readTime: "6 min read",
-    image: "/og/email-sdk.png",
+    image: getBlogPostImageUrl("introducing-email-sdk"),
     imageAlt: "Email SDK unified email sending preview",
     tags: ["Launch", "TypeScript", "Transactional email"],
   },
@@ -31,7 +34,7 @@ export const blogPosts = [
     publishedAt: "2026-06-05",
     updatedAt: "2026-06-05",
     readTime: "7 min read",
-    image: "/og/email-sdk.png",
+    image: getBlogPostImageUrl("email-provider-fallbacks"),
     imageAlt: "Email SDK adapter and fallback routing preview",
     tags: ["Reliability", "Adapters", "Email APIs"],
   },
@@ -43,9 +46,249 @@ export const blogPosts = [
     publishedAt: "2026-06-10",
     updatedAt: "2026-06-10",
     readTime: "6 min read",
-    image: "/og/email-sdk.png",
+    image: getBlogPostImageUrl("nodemailer-alternative-typescript"),
     imageAlt: "Email SDK TypeScript email provider comparison preview",
     tags: ["Nodemailer", "TypeScript", "SMTP"],
+  },
+  {
+    slug: "transactional-email-provider-checklist",
+    title: "A Transactional Email Provider Checklist That Starts With the App",
+    description:
+      "A practical way to choose Resend, Postmark, SendGrid, Mailgun, SES, SMTP, or a mixed provider setup without turning every email into vendor glue.",
+    publishedAt: "2026-06-17",
+    updatedAt: "2026-06-17",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("transactional-email-provider-checklist"),
+    imageAlt: "Checklist for choosing transactional email providers",
+    tags: ["Provider selection", "Transactional email", "Architecture"],
+  },
+  {
+    slug: "resend-postmark-sendgrid-comparison",
+    title: "Resend, Postmark, and SendGrid Are Different Tools",
+    description:
+      "A developer-focused comparison of three common transactional email providers, with the tradeoffs that matter once the first welcome email works.",
+    publishedAt: "2026-06-24",
+    updatedAt: "2026-06-24",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("resend-postmark-sendgrid-comparison"),
+    imageAlt: "Resend Postmark and SendGrid comparison map",
+    tags: ["Resend", "Postmark", "SendGrid"],
+  },
+  {
+    slug: "sendgrid-alternative-typescript",
+    title: "Looking for a SendGrid Alternative in a TypeScript App?",
+    description:
+      "How to move SendGrid-specific code behind a typed email layer so the next provider change does not become a product rewrite.",
+    publishedAt: "2026-07-01",
+    updatedAt: "2026-07-01",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("sendgrid-alternative-typescript"),
+    imageAlt: "SendGrid alternative TypeScript adapter route",
+    tags: ["SendGrid", "Migration", "TypeScript"],
+  },
+  {
+    slug: "postmark-alternative-typescript",
+    title: "A Postmark Alternative Is Usually a Routing Problem",
+    description:
+      "Postmark is good at transactional email. The hard part is deciding where provider-specific templates, streams, tags, and fallbacks belong.",
+    publishedAt: "2026-07-08",
+    updatedAt: "2026-07-08",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("postmark-alternative-typescript"),
+    imageAlt: "Postmark alternative routing diagram",
+    tags: ["Postmark", "Routing", "Email APIs"],
+  },
+  {
+    slug: "aws-ses-typescript-production",
+    title: "Using AWS SES From TypeScript Without Letting AWS Own the Email Layer",
+    description:
+      "SES is cheap and serious, but most product teams still need a cleaner app-facing API, safer fallbacks, and sharper provider boundaries.",
+    publishedAt: "2026-07-15",
+    updatedAt: "2026-07-15",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("aws-ses-typescript-production"),
+    imageAlt: "AWS SES TypeScript production email architecture",
+    tags: ["AWS SES", "TypeScript", "Production"],
+  },
+  {
+    slug: "multi-tenant-email-provider-routing",
+    title: "Multi-Tenant Email Routing Needs More Than an ENV Var",
+    description:
+      "What changes when each tenant can bring a sender domain, provider account, region, or fallback policy into the same TypeScript app.",
+    publishedAt: "2026-07-22",
+    updatedAt: "2026-07-22",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("multi-tenant-email-provider-routing"),
+    imageAlt: "Multi-tenant email provider routing lanes",
+    tags: ["Multi-tenant", "Routing", "SaaS"],
+  },
+  {
+    slug: "email-fallbacks-without-data-loss",
+    title: "Email Fallbacks Without Data Loss",
+    description:
+      "Fallback email routes can save a login flow or quietly drop metadata. Here is the line between a safe backup and a false sense of safety.",
+    publishedAt: "2026-07-29",
+    updatedAt: "2026-07-29",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("email-fallbacks-without-data-loss"),
+    imageAlt: "Transactional email fallback field compatibility",
+    tags: ["Fallbacks", "Reliability", "Field support"],
+  },
+  {
+    slug: "smtp-fallback-modern-apps",
+    title: "SMTP Is Still a Useful Fallback for Modern Apps",
+    description:
+      "SMTP should not define your whole email architecture, but it can be a practical backup route when you keep the contract narrow.",
+    publishedAt: "2026-08-05",
+    updatedAt: "2026-08-05",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("smtp-fallback-modern-apps"),
+    imageAlt: "SMTP fallback for modern TypeScript apps",
+    tags: ["SMTP", "Fallbacks", "Nodemailer"],
+  },
+  {
+    slug: "testing-transactional-email-typescript",
+    title: "Testing Transactional Email in TypeScript Without Sending Real Mail",
+    description:
+      "A straightforward testing strategy for message shape, provider limits, fallback order, and CLI smoke checks.",
+    publishedAt: "2026-08-12",
+    updatedAt: "2026-08-12",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("testing-transactional-email-typescript"),
+    imageAlt: "TypeScript transactional email testing workflow",
+    tags: ["Testing", "TypeScript", "CLI"],
+  },
+  {
+    slug: "email-observability-provider-adapters",
+    title: "Email Observability Starts Before the Provider Dashboard",
+    description:
+      "Provider dashboards help after the fact. App-level email logs explain which adapter ran, which fields were sent, and why a fallback happened.",
+    publishedAt: "2026-08-19",
+    updatedAt: "2026-08-19",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("email-observability-provider-adapters"),
+    imageAlt: "Email adapter observability timeline",
+    tags: ["Observability", "Adapters", "Logs"],
+  },
+  {
+    slug: "idempotent-email-retries",
+    title: "Email Retries Need an Idempotency Story",
+    description:
+      "Retries are useful until they send the same receipt twice. The fix starts with message IDs, provider responses, and route-specific failure policy.",
+    publishedAt: "2026-08-26",
+    updatedAt: "2026-08-26",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("idempotent-email-retries"),
+    imageAlt: "Idempotent email retry path with message IDs",
+    tags: ["Retries", "Reliability", "Idempotency"],
+  },
+  {
+    slug: "adapter-pattern-email-apis",
+    title: "The Adapter Pattern Fits Email APIs Better Than a Giant Switch Statement",
+    description:
+      "A small adapter contract keeps provider quirks local while giving the app one place to send email and one place to check limits.",
+    publishedAt: "2026-09-02",
+    updatedAt: "2026-09-02",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("adapter-pattern-email-apis"),
+    imageAlt: "Email API adapter pattern interface",
+    tags: ["Adapters", "Architecture", "TypeScript"],
+  },
+  {
+    slug: "migrate-from-provider-sdk",
+    title: "How to Migrate Away From Provider-Specific Email SDKs",
+    description:
+      "A low-drama migration plan for moving Resend, SendGrid, Postmark, Mailgun, or SES calls behind one app-owned email boundary.",
+    publishedAt: "2026-09-09",
+    updatedAt: "2026-09-09",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("migrate-from-provider-sdk"),
+    imageAlt: "Provider-specific email SDK migration plan",
+    tags: ["Migration", "Email APIs", "Refactoring"],
+  },
+  {
+    slug: "email-attachments-provider-limits",
+    title: "Email Attachments Are Where Provider Abstractions Get Honest",
+    description:
+      "Attachments look simple in a message object, but providers disagree on size limits, encoding, filenames, and request shape.",
+    publishedAt: "2026-09-16",
+    updatedAt: "2026-09-16",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("email-attachments-provider-limits"),
+    imageAlt: "Email attachment provider limits comparison",
+    tags: ["Attachments", "Provider limits", "Message shape"],
+  },
+  {
+    slug: "email-metadata-tags-headers",
+    title: "Metadata, Tags, and Headers Are Not Interchangeable",
+    description:
+      "How to decide which data belongs in email metadata, provider tags, custom headers, or your own app database.",
+    publishedAt: "2026-09-23",
+    updatedAt: "2026-09-23",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("email-metadata-tags-headers"),
+    imageAlt: "Email metadata tags and headers layers",
+    tags: ["Metadata", "Headers", "Tracking"],
+  },
+  {
+    slug: "email-queue-vs-sdk-boundary",
+    title: "Your Email Queue and Email SDK Should Do Different Jobs",
+    description:
+      "Queues decide when work runs. Email SDKs decide how a message becomes a provider request. Mixing those jobs makes outages harder to reason about.",
+    publishedAt: "2026-09-30",
+    updatedAt: "2026-09-30",
+    readTime: "7 min read",
+    image: getBlogPostImageUrl("email-queue-vs-sdk-boundary"),
+    imageAlt: "Email queue and SDK boundary diagram",
+    tags: ["Queues", "Architecture", "Reliability"],
+  },
+  {
+    slug: "deliverability-code-can-control",
+    title: "The Deliverability Work Your Code Can Actually Control",
+    description:
+      "SPF, DKIM, and reputation matter, but code still controls message shape, sender choice, fallback policy, logging, and duplicate sends.",
+    publishedAt: "2026-10-07",
+    updatedAt: "2026-10-07",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("deliverability-code-can-control"),
+    imageAlt: "Email deliverability controls inside application code",
+    tags: ["Deliverability", "Reliability", "Production"],
+  },
+  {
+    slug: "self-hosted-smtp-vs-email-api",
+    title: "Self-Hosted SMTP vs Email APIs: Pick the Pain You Want to Own",
+    description:
+      "Self-hosted SMTP gives control. Email APIs give product speed. Most teams need a clear boundary more than a dramatic winner.",
+    publishedAt: "2026-10-14",
+    updatedAt: "2026-10-14",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("self-hosted-smtp-vs-email-api"),
+    imageAlt: "Self-hosted SMTP and email API tradeoff map",
+    tags: ["SMTP", "Email APIs", "Infrastructure"],
+  },
+  {
+    slug: "customer-byo-email-provider",
+    title: "Letting Customers Bring Their Own Email Provider",
+    description:
+      "BYO email provider support sounds simple until customers bring domains, API keys, regions, compliance rules, and their own failure modes.",
+    publishedAt: "2026-10-21",
+    updatedAt: "2026-10-21",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("customer-byo-email-provider"),
+    imageAlt: "Customer bring your own email provider setup",
+    tags: ["BYO provider", "SaaS", "Multi-tenant"],
+  },
+  {
+    slug: "agents-sending-email-safely",
+    title: "Agents Sending Email Need Guardrails, Not Just API Keys",
+    description:
+      "AI agents can draft, queue, or trigger email, but production apps still need typed boundaries, approvals, capture, and provider-aware validation.",
+    publishedAt: "2026-10-28",
+    updatedAt: "2026-10-28",
+    readTime: "8 min read",
+    image: getBlogPostImageUrl("agents-sending-email-safely"),
+    imageAlt: "AI agent email sending guardrails",
+    tags: ["Agents", "Guardrails", "Email SDK"],
   },
 ] as const satisfies BlogPost[];
 
@@ -58,8 +301,12 @@ export function getBlogPost(slug: string, options: { includeFuture?: boolean } =
   return undefined;
 }
 
+export function getAllBlogPosts(): BlogPost[] {
+  return [...blogPosts] as BlogPost[];
+}
+
 export function getPublishedBlogPosts(date = new Date()): BlogPost[] {
-  return (blogPosts as BlogPost[])
+  return getAllBlogPosts()
     .filter((post) => isBlogPostPublished(post, date))
     .sort((a, b) => b.publishedAt.localeCompare(a.publishedAt));
 }
@@ -70,6 +317,29 @@ export function isBlogPostPublished(post: BlogPost, date = new Date()) {
 
 export function getBlogPostUrl(slug: string) {
   return `/blog/${slug}`;
+}
+
+export function getBlogPostImageUrl(slug: string) {
+  return `/og/blog/${slug}.svg`;
+}
+
+export function getBlogPostMetaTitle(title: string) {
+  const maxTitleLength = maxBlogMetaTitleLength - blogMetaTitleSuffix.length;
+
+  return `${truncateTitle(title, maxTitleLength)}${blogMetaTitleSuffix}`;
+}
+
+function truncateTitle(title: string, maxLength: number) {
+  if (title.length <= maxLength) return title;
+
+  const stemLimit = Math.max(1, maxLength - 3);
+  const wordBoundaryStem = title
+    .slice(0, stemLimit)
+    .replace(/\s+\S*$/, "")
+    .replace(/[.,;:\s]+$/, "");
+  const stem = wordBoundaryStem || title.slice(0, stemLimit).trimEnd();
+
+  return `${stem}...`;
 }
 
 export function formatBlogDate(value: string) {

--- a/apps/fumadocs/src/routeTree.gen.ts
+++ b/apps/fumadocs/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as ApiBuildInfoRouteImport } from './routes/api/build-info'
+import { Route as OgBlogSplatRouteImport } from './routes/og/blog/$'
 
 const TermsRoute = TermsRouteImport.update({
   id: '/terms',
@@ -94,6 +95,11 @@ const ApiBuildInfoRoute = ApiBuildInfoRouteImport.update({
   path: '/api/build-info',
   getParentRoute: () => rootRouteImport,
 } as any)
+const OgBlogSplatRoute = OgBlogSplatRouteImport.update({
+  id: '/og/blog/$',
+  path: '/og/blog/$',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -110,6 +116,7 @@ export interface FileRoutesByFullPath {
   '/docs/$': typeof DocsSplatRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
   '/blog/': typeof BlogIndexRoute
+  '/og/blog/$': typeof OgBlogSplatRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -126,6 +133,7 @@ export interface FileRoutesByTo {
   '/docs/$': typeof DocsSplatRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
   '/blog': typeof BlogIndexRoute
+  '/og/blog/$': typeof OgBlogSplatRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -143,6 +151,7 @@ export interface FileRoutesById {
   '/docs/$': typeof DocsSplatRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
   '/blog/': typeof BlogIndexRoute
+  '/og/blog/$': typeof OgBlogSplatRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -161,6 +170,7 @@ export interface FileRouteTypes {
     | '/docs/$'
     | '/docs/{$}.md'
     | '/blog/'
+    | '/og/blog/$'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -177,6 +187,7 @@ export interface FileRouteTypes {
     | '/docs/$'
     | '/docs/{$}.md'
     | '/blog'
+    | '/og/blog/$'
   id:
     | '__root__'
     | '/'
@@ -193,6 +204,7 @@ export interface FileRouteTypes {
     | '/docs/$'
     | '/docs/{$}.md'
     | '/blog/'
+    | '/og/blog/$'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -210,6 +222,7 @@ export interface RootRouteChildren {
   DocsSplatRoute: typeof DocsSplatRoute
   DocsChar123Char125DotmdRoute: typeof DocsChar123Char125DotmdRoute
   BlogIndexRoute: typeof BlogIndexRoute
+  OgBlogSplatRoute: typeof OgBlogSplatRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -312,6 +325,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiBuildInfoRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/og/blog/$': {
+      id: '/og/blog/$'
+      path: '/og/blog/$'
+      fullPath: '/og/blog/$'
+      preLoaderRoute: typeof OgBlogSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -330,6 +350,7 @@ const rootRouteChildren: RootRouteChildren = {
   DocsSplatRoute: DocsSplatRoute,
   DocsChar123Char125DotmdRoute: DocsChar123Char125DotmdRoute,
   BlogIndexRoute: BlogIndexRoute,
+  OgBlogSplatRoute: OgBlogSplatRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/fumadocs/src/routes/blog/$slug.tsx
+++ b/apps/fumadocs/src/routes/blog/$slug.tsx
@@ -16,9 +16,15 @@ import githubDarkTheme from "shiki/themes/github-dark.mjs";
 import githubLightTheme from "shiki/themes/github-light.mjs";
 
 import { DocsVersionLink } from "@/components/docs-version-link";
-import { formatBlogDate, getBlogPost, getBlogPostUrl, type BlogPost } from "@/lib/blog";
+import {
+  formatBlogDate,
+  getBlogPost,
+  getBlogPostMetaTitle,
+  getBlogPostUrl,
+  type BlogPost,
+} from "@/lib/blog";
 import { baseOptions } from "@/lib/layout.shared";
-import { siteOgImageUrl, siteUrl } from "@/lib/shared";
+import { siteUrl } from "@/lib/shared";
 
 type BlogPostLoaderData = {
   fallbackPost: BlogPost | null;
@@ -33,10 +39,11 @@ const blogCodeHighlighter = createHighlighterCoreSync({
 
 export const Route = createFileRoute("/blog/$slug")({
   head: ({ params }) => {
-    const post = getBlogPost(params.slug);
-    const title = post ? `${post.title} - Email SDK` : "Email SDK Blog";
+    const post = getBlogPost(params.slug, { includeFuture: true });
+    const title = post ? getBlogPostMetaTitle(post.title) : "Email SDK Blog";
     const description = post?.description ?? "Email SDK blog post.";
     const canonicalUrl = `${siteUrl}${getBlogPostUrl(params.slug)}`;
+    const imageUrl = post ? `${siteUrl}${post.image}` : `${siteUrl}/og/email-sdk.png`;
 
     const meta = [
       { title },
@@ -45,13 +52,20 @@ export const Route = createFileRoute("/blog/$slug")({
       { property: "og:title", content: title },
       { property: "og:description", content: description },
       { property: "og:url", content: canonicalUrl },
-      { property: "og:image", content: `${siteUrl}${post?.image ?? "/og/email-sdk.png"}` },
+      { property: "og:image", content: imageUrl },
+      { property: "og:image:alt", content: post?.imageAlt ?? "Email SDK blog post preview" },
+      { property: "og:image:width", content: "1200" },
+      { property: "og:image:height", content: "630" },
       { name: "twitter:card", content: "summary_large_image" },
       { name: "twitter:title", content: title },
       { name: "twitter:description", content: description },
-      { name: "twitter:image", content: siteOgImageUrl },
+      { name: "twitter:image", content: imageUrl },
+      { name: "twitter:image:alt", content: post?.imageAlt ?? "Email SDK blog post preview" },
       ...(post
         ? [
+            { property: "article:published_time", content: `${post.publishedAt}T00:00:00.000Z` },
+            { property: "article:modified_time", content: `${post.updatedAt}T00:00:00.000Z` },
+            ...post.tags.map((tag) => ({ property: "article:tag", content: tag })),
             {
               "script:ld+json": {
                 "@context": "https://schema.org",
@@ -116,7 +130,7 @@ export const Route = createFileRoute("/blog/$slug")({
   },
   component: BlogPostPage,
   loader: ({ params }) => {
-    const post = getBlogPost(params.slug);
+    const post = getBlogPost(params.slug, { includeFuture: true });
     if (!post) throw notFound();
 
     return {
@@ -180,6 +194,7 @@ function BlogPostContent({ fallbackPost, slug }: { fallbackPost: BlogPost | null
   if (slug === "introducing-email-sdk") return <IntroducingPost fallbackPost={fallbackPost} />;
   if (slug === "email-provider-fallbacks") return <FallbacksPost />;
   if (slug === "nodemailer-alternative-typescript") return <NodemailerAlternativePost />;
+  if (slug in plannedPosts) return <PlannedPostContent content={plannedPosts[slug]} />;
 
   throw new Error(`Missing blog post content for slug: ${slug}`);
 }
@@ -588,6 +603,862 @@ await email.send({
         >
           Read SMTP docs
         </DocsVersionLink>
+      </div>
+    </BlogBody>
+  );
+}
+
+type PlannedPostSection = {
+  title: string;
+  paragraphs?: string[];
+  checklist?: string[];
+  table?: {
+    headers: [string, string, string];
+    rows: [string, string, string][];
+  };
+  code?: string;
+};
+
+type PlannedPost = {
+  paragraphs: string[];
+  sections: PlannedPostSection[];
+  callout: string;
+  primaryCta: {
+    label: string;
+    docsPath: string;
+  };
+  secondaryCta?: {
+    label: string;
+    docsPath: string;
+  };
+};
+
+const plannedPosts: Record<string, PlannedPost> = {
+  "transactional-email-provider-checklist": {
+    paragraphs: [
+      "Most provider comparisons start in the wrong place. They rank dashboards, templates, prices, and brand names before asking what the app actually needs to send.",
+      "Start with the product email, not the vendor. A login code, invoice receipt, export-ready notification, and customer-hosted sender domain do not have the same risk profile. One provider can be perfect for one and awkward for another.",
+    ],
+    sections: [
+      {
+        title: "Sort by message shape",
+        paragraphs: [
+          "Write down the fields each class of email needs before choosing a provider. Include attachments, custom headers, reply-to addresses, metadata, tags, and tenant-specific sender domains. Those details are where provider APIs stop feeling interchangeable.",
+        ],
+        table: {
+          headers: ["Email", "Likely requirement", "Provider question"],
+          rows: [
+            [
+              "Login code",
+              "Plain text or simple HTML",
+              "Can the backup send it from the same trusted domain?",
+            ],
+            [
+              "Receipt",
+              "Metadata, headers, maybe PDF attachments",
+              "Does the fallback support every field?",
+            ],
+            [
+              "Product digest",
+              "Tags, unsubscribe behavior, template data",
+              "Does this belong in a campaign tool instead?",
+            ],
+            ["Audit notice", "Stable IDs and traceability", "Can logs prove which route sent it?"],
+          ],
+        },
+      },
+      {
+        title: "Pick a default and a boring backup",
+        paragraphs: [
+          "The default provider should match your normal product path. The backup provider should match the smallest safe version of the same message. If the backup cannot carry the fields your support or billing team relies on, it is not a backup. It is a different email.",
+        ],
+        checklist: [
+          "Confirm the sender domain works on both routes.",
+          "Check field support before enabling a fallback.",
+          "Log the adapter name and provider response ID.",
+          "Keep retry count low for emails a user might notice twice.",
+        ],
+      },
+      {
+        title: "Keep provider details at the boundary",
+        paragraphs: [
+          "Provider SDKs are fine inside an adapter. They get painful when their payload shape leaks into product code. A clean app boundary lets you replace, add, or split providers without hunting through every password reset and invoice path.",
+        ],
+        code: `const email = createEmailClient({
+  adapters: [resendAdapter, postmarkAdapter, smtpAdapter],
+  defaultAdapter: "resend",
+  fallback: ["postmark"],
+});`,
+      },
+    ],
+    callout:
+      "Provider choice is less about finding one winner and more about protecting the app from making provider-specific promises everywhere.",
+    primaryCta: { label: "Read the adapter model", docsPath: "/docs/concepts/adapter-model" },
+    secondaryCta: { label: "Check field support", docsPath: "/docs/adapters/field-support" },
+  },
+  "resend-postmark-sendgrid-comparison": {
+    paragraphs: [
+      "Resend, Postmark, and SendGrid all send transactional email, but they do not feel the same in a real product. The right choice depends on the shape of your team as much as the shape of your payload.",
+      "Resend is clean for modern developer workflows. Postmark is steady and transactional-first. SendGrid is widely adopted and often already sitting in the company account. That does not make any of them a universal default.",
+    ],
+    sections: [
+      {
+        title: "Compare the job, not the logo",
+        table: {
+          headers: ["Provider", "Good fit", "Watch for"],
+          rows: [
+            [
+              "Resend",
+              "New product teams that want a sharp API and fast setup.",
+              "You may still need a backup route for customer policy or region needs.",
+            ],
+            [
+              "Postmark",
+              "Receipt, login, and lifecycle email where transactional behavior matters.",
+              "Streams and templates can become app assumptions if you are casual.",
+            ],
+            [
+              "SendGrid",
+              "Teams with existing accounts, enterprise procurement, or mixed email programs.",
+              "The API surface is broad enough to invite one-off payload code.",
+            ],
+          ],
+        },
+      },
+      {
+        title: "What the app should own",
+        paragraphs: [
+          "The app should own the message contract, fallback order, and logging shape. The provider should own delivery infrastructure. When those responsibilities blur, a provider migration becomes a product migration.",
+        ],
+        checklist: [
+          "Keep the product-level message shape independent from provider payloads.",
+          "Keep template IDs, stream names, and tags close to the adapter or route config.",
+          "Record provider response IDs under your own send attempt ID.",
+        ],
+      },
+      {
+        title: "A mixed setup is normal",
+        paragraphs: [
+          "Many teams end up with one provider for the primary path and another for backup, legacy, or customer-owned sending. That is fine. What matters is making the split explicit instead of letting provider calls spread through the codebase.",
+        ],
+      },
+    ],
+    callout:
+      "The safest comparison is the one you can encode. If the decision cannot be represented in routing and validation, it will drift.",
+    primaryCta: { label: "Browse adapters", docsPath: "/docs/adapters" },
+    secondaryCta: { label: "Read fallback docs", docsPath: "/docs/concepts/fallbacks-and-retries" },
+  },
+  "sendgrid-alternative-typescript": {
+    paragraphs: [
+      "A SendGrid alternative is rarely just a different install command. The hidden work is removing SendGrid-shaped assumptions from your app without breaking every email that already works.",
+      "The good news: you do not have to migrate everything at once. Start by wrapping SendGrid behind a small TypeScript boundary, then move one route at a time.",
+    ],
+    sections: [
+      {
+        title: "Find the SendGrid-shaped code",
+        checklist: [
+          "Search for direct SendGrid imports outside infrastructure code.",
+          "List template IDs, categories, custom args, and attachment usage.",
+          "Mark which emails are customer-visible if they duplicate or fail.",
+          "Identify send paths that already have tests or CLI smoke coverage.",
+        ],
+      },
+      {
+        title: "Move to an app-owned message shape",
+        paragraphs: [
+          "The first migration step is not picking the replacement provider. It is making the app call one email function that you own. After that, SendGrid becomes one adapter instead of the object every feature has to understand.",
+        ],
+        code: `await email.send({
+  from: "Acme <billing@acme.com>",
+  to: customer.email,
+  subject: "Your receipt",
+  html: receiptHtml,
+  metadata: { invoiceId: invoice.id },
+});`,
+      },
+      {
+        title: "Run providers side by side",
+        paragraphs: [
+          "Keep SendGrid as the known route while you test another provider on low-risk emails. Once the new adapter has field support, logging, and failure handling you trust, move the important paths.",
+        ],
+      },
+    ],
+    callout:
+      "A clean migration lets SendGrid keep working while the app stops depending on SendGrid everywhere.",
+    primaryCta: { label: "Read SendGrid docs", docsPath: "/docs/adapters/sendgrid" },
+    secondaryCta: { label: "Create an adapter", docsPath: "/docs/guides/authoring/create-adapter" },
+  },
+  "postmark-alternative-typescript": {
+    paragraphs: [
+      "Postmark is good software. If it is working for your product, there is no prize for replacing it. The usual reason to add an alternative is routing: backup delivery, tenant-specific providers, region rules, or a customer who refuses to use your default.",
+      "That means the migration question is not whether Postmark should go away. It is which Postmark assumptions should stay out of product code.",
+    ],
+    sections: [
+      {
+        title: "Separate templates from transport",
+        paragraphs: [
+          "Postmark templates and message streams can be useful, but they are provider concepts. Keep them in route config or adapter code so a reset-password flow does not need to know which provider is underneath.",
+        ],
+      },
+      {
+        title: "Keep the receipt path conservative",
+        table: {
+          headers: ["Path", "Risk", "Safer move"],
+          rows: [
+            [
+              "Password reset",
+              "Duplicate sends annoy users.",
+              "Low retry count and clear logging.",
+            ],
+            ["Receipt", "Dropped metadata hurts support.", "Require equivalent field support."],
+            [
+              "Notification",
+              "Template drift creates weird copy.",
+              "Move one template family at a time.",
+            ],
+          ],
+        },
+      },
+      {
+        title: "Use Postmark as one adapter",
+        paragraphs: [
+          "A provider layer lets Postmark stay in the system without owning the app shape. That is the sweet spot: the provider can remain excellent at delivery, and your code can remain honest about what it sends.",
+        ],
+      },
+    ],
+    callout:
+      "The best Postmark alternative plan may keep Postmark. It just stops letting Postmark define every product email.",
+    primaryCta: { label: "Read Postmark docs", docsPath: "/docs/adapters/postmark" },
+    secondaryCta: { label: "Read adapter model", docsPath: "/docs/concepts/adapter-model" },
+  },
+  "aws-ses-typescript-production": {
+    paragraphs: [
+      "AWS SES is attractive because it is cheap, serious, and already inside the AWS account many teams use for the rest of the stack. It also brings AWS-shaped setup into a part of the product that designers, support, and growth teams notice quickly when it breaks.",
+      "A TypeScript app should be able to use SES without letting SES become the whole email architecture.",
+    ],
+    sections: [
+      {
+        title: "Treat SES as infrastructure",
+        paragraphs: [
+          "Keep regions, credentials, identities, and IAM concerns near the adapter. Product code should send a receipt or login email. It should not care whether the route signs an AWS request, calls a JSON API, or uses SMTP.",
+        ],
+      },
+      {
+        title: "Know where SES is strict",
+        checklist: [
+          "Sender identity and region have to match your production setup.",
+          "Sandbox mode changes what you can test.",
+          "Raw email and attachment behavior deserve their own smoke tests.",
+          "Fallbacks should use the same verified domain posture where possible.",
+        ],
+      },
+      {
+        title: "Keep a second route",
+        paragraphs: [
+          "SES can be the low-cost primary route, but it is still a provider. If the product cannot tolerate a blocked send path, configure a backup route and test it before an incident.",
+        ],
+      },
+    ],
+    callout:
+      "SES is a strong provider when the app boundary is clean. It gets messy when AWS details show up in every feature.",
+    primaryCta: { label: "Read SES docs", docsPath: "/docs/adapters/ses" },
+    secondaryCta: {
+      label: "Read production guide",
+      docsPath: "/docs/guides/production-send-pipeline",
+    },
+  },
+  "multi-tenant-email-provider-routing": {
+    paragraphs: [
+      "A single ENV var is fine for a single product email route. Multi-tenant sending is different. One tenant wants Postmark, another needs SES in a specific region, and a third brings a domain that your default provider cannot send from.",
+      "The hard part is not storing more API keys. It is making routing decisions explicit enough that support can explain what happened.",
+    ],
+    sections: [
+      {
+        title: "Store policy, not just credentials",
+        paragraphs: [
+          "Each tenant needs a provider choice, sender identity, allowed message classes, and fallback policy. If you store only the API key, every send path has to rediscover the rest.",
+        ],
+      },
+      {
+        title: "Separate route selection from sending",
+        code: `const route = await selectTenantEmailRoute({
+  tenantId,
+  messageType: "receipt",
+});
+
+await email.send(message, { adapter: route.primary, fallback: route.fallback });`,
+      },
+      {
+        title: "Make support possible",
+        checklist: [
+          "Log tenant ID, adapter ID, and sender domain.",
+          "Keep provider response IDs attached to your own send attempt.",
+          "Reject sends when tenant config cannot support the message fields.",
+          "Use a safe default only for low-risk emails.",
+        ],
+      },
+    ],
+    callout:
+      "Multi-tenant email fails quietly when route policy lives in scattered conditionals. Pull it into one place.",
+    primaryCta: { label: "Read client reference", docsPath: "/docs/reference/client" },
+    secondaryCta: { label: "Check field support", docsPath: "/docs/adapters/field-support" },
+  },
+  "email-fallbacks-without-data-loss": {
+    paragraphs: [
+      "Fallbacks are comforting. They also hide mistakes. If your backup provider cannot send the same fields as the primary route, you may trade a visible failure for a quiet data loss bug.",
+      "The fix is simple but not glamorous: validate the message before it leaves the app, and make fallback eligibility part of the route design.",
+    ],
+    sections: [
+      {
+        title: "Fields are part of reliability",
+        paragraphs: [
+          "A receipt without metadata may still arrive in the inbox, but support loses the invoice ID it needed. A notification without tags may still send, but downstream reporting changes. That is not the same result.",
+        ],
+      },
+      {
+        title: "Choose fallback classes",
+        table: {
+          headers: ["Message class", "Fallback posture", "Reason"],
+          rows: [
+            ["Login code", "Broad fallback", "Small message, time-sensitive."],
+            ["Receipt", "Strict fallback", "Metadata and attachments often matter."],
+            ["Digest", "Maybe no fallback", "Template and unsubscribe behavior can drift."],
+          ],
+        },
+      },
+      {
+        title: "Fail before the provider call",
+        paragraphs: [
+          "If a fallback route cannot represent the payload, the SDK should stop. That error is annoying in development. In production, it is much better than pretending the email was equivalent.",
+        ],
+      },
+    ],
+    callout:
+      "A fallback is only safe when it can send the same kind of message, not merely any message.",
+    primaryCta: { label: "Read fallback docs", docsPath: "/docs/concepts/fallbacks-and-retries" },
+    secondaryCta: { label: "Check field support", docsPath: "/docs/adapters/field-support" },
+  },
+  "smtp-fallback-modern-apps": {
+    paragraphs: [
+      "SMTP has survived because it is boring in the useful way. It is not always the nicest primary interface for a new TypeScript app, but it can be a practical backup route when the message contract stays narrow.",
+      "The trap is treating SMTP as if it can mirror every provider API feature. It cannot, and that is fine. Use it where it fits.",
+    ],
+    sections: [
+      {
+        title: "Use SMTP for simple critical mail",
+        checklist: [
+          "Login codes and password resets are usually good candidates.",
+          "Receipts need more care if attachments or metadata matter.",
+          "Campaign-like messages should probably stay out of the fallback route.",
+          "Sender identity and bounce handling still need real setup.",
+        ],
+      },
+      {
+        title: "Keep the adapter honest",
+        paragraphs: [
+          "SMTP routes should reject fields they cannot safely carry instead of dropping them. That is the difference between a backup path and a silent downgrade.",
+        ],
+      },
+      {
+        title: "Do not confuse SMTP with Nodemailer",
+        paragraphs: [
+          "Nodemailer is a mature Node package for SMTP and related transports. SMTP itself is the protocol. A provider layer can include SMTP without making Nodemailer or SMTP the center of the product API.",
+        ],
+      },
+    ],
+    callout:
+      "SMTP works best as a narrow, explicit route. It gets risky when it pretends to be every provider.",
+    primaryCta: { label: "Read SMTP docs", docsPath: "/docs/adapters/smtp" },
+    secondaryCta: {
+      label: "Read Nodemailer comparison",
+      docsPath: "/docs/getting-started/install",
+    },
+  },
+  "testing-transactional-email-typescript": {
+    paragraphs: [
+      "The worst email test is the one that only proves an API key works. Production bugs usually come from message shape, unsupported fields, fallback order, duplicate sends, or a provider response your code did not expect.",
+      "Good tests keep real sending rare. Most confidence should come from local adapters, dry runs, and small payload checks.",
+    ],
+    sections: [
+      {
+        title: "Test the contract first",
+        checklist: [
+          "Assert the message shape your app creates.",
+          "Assert unsupported fields throw for limited adapters.",
+          "Assert fallback order for transient failures.",
+          "Assert provider response IDs are captured in logs.",
+        ],
+      },
+      {
+        title: "Use dry-run smoke checks",
+        paragraphs: [
+          "A CLI dry run is useful because it exercises configuration and payload normalization without sending mail. Keep one command for the primary route and one for a fallback route.",
+        ],
+        code: `email-sdk send --dry-run --adapter resend \\
+  --from "Acme <hello@acme.com>" \\
+  --to "user@example.com" \\
+  --subject "Smoke test" \\
+  --text "No mail should leave the app."`,
+      },
+      {
+        title: "Send live mail sparingly",
+        paragraphs: [
+          "Live sends still matter, especially after changing provider credentials, domains, or attachment behavior. They should be deliberate checks, not the only test suite you have.",
+        ],
+      },
+    ],
+    callout:
+      "A healthy email test suite proves the app knows what it is sending before any provider receives it.",
+    primaryCta: { label: "Read testing guide", docsPath: "/docs/guides/test-email-behavior" },
+    secondaryCta: { label: "Read CLI reference", docsPath: "/docs/reference/cli" },
+  },
+  "email-observability-provider-adapters": {
+    paragraphs: [
+      "Provider dashboards are useful, but they start too late. They can tell you what the provider saw. They usually cannot tell you why your app picked that adapter, why it retried, or which fields were rejected before the request.",
+      "Email observability should start at the app boundary.",
+    ],
+    sections: [
+      {
+        title: "Log the send attempt",
+        checklist: [
+          "Your internal send attempt ID.",
+          "Adapter name and fallback step.",
+          "Message class, tenant, and route policy.",
+          "Provider response ID or normalized error code.",
+          "Duration and retry count.",
+        ],
+      },
+      {
+        title: "Keep sensitive data out",
+        paragraphs: [
+          "Useful logs do not need raw API keys, full recipient lists, message bodies, or private attachment contents. Keep identifiers and route decisions. Leave secrets and unnecessary personal data out.",
+        ],
+      },
+      {
+        title: "Make fallbacks visible",
+        paragraphs: [
+          "A fallback that succeeds should still be visible. Otherwise the first sign of trouble is a provider bill, a support ticket, or a weird dip in engagement numbers.",
+        ],
+      },
+    ],
+    callout: "The provider dashboard is one witness. Your app logs should be the timeline.",
+    primaryCta: {
+      label: "Read observability plugin docs",
+      docsPath: "/docs/plugins/built-in/observability",
+    },
+    secondaryCta: { label: "Read plugin API", docsPath: "/docs/plugins/api" },
+  },
+  "idempotent-email-retries": {
+    paragraphs: [
+      "Retries sound harmless until the same receipt lands twice. Email is user-visible, and a retry policy that would be normal for a database write can feel sloppy in an inbox.",
+      "The question is not whether to retry. It is which failures deserve another attempt and how you know a previous attempt did not already send.",
+    ],
+    sections: [
+      {
+        title: "Name the message before sending",
+        paragraphs: [
+          "Generate an app-level send attempt ID before calling a provider. Keep it with the message class, adapter, tenant, and provider response. That gives support one thing to search when a customer forwards a duplicate.",
+        ],
+      },
+      {
+        title: "Retry the right failures",
+        table: {
+          headers: ["Failure", "Retry?", "Reason"],
+          rows: [
+            ["Network timeout", "Maybe", "The provider may or may not have received it."],
+            ["Rate limit", "Maybe", "Backoff can help if the email is still useful later."],
+            ["Invalid sender", "No", "Configuration is broken; retrying repeats the mistake."],
+            ["Unsupported field", "No", "The payload must change or the route must change."],
+          ],
+        },
+      },
+      {
+        title: "Avoid duplicate-prone paths",
+        paragraphs: [
+          "Receipts, account security messages, and legal notices deserve conservative retry counts. A product digest can often wait. A password reset may need a fresh token instead of a blind retry.",
+        ],
+      },
+    ],
+    callout:
+      "Retries are a product behavior. Treat them that way, especially when money or security is involved.",
+    primaryCta: { label: "Read fallback docs", docsPath: "/docs/concepts/fallbacks-and-retries" },
+    secondaryCta: { label: "Read errors reference", docsPath: "/docs/reference/errors" },
+  },
+  "adapter-pattern-email-apis": {
+    paragraphs: [
+      "The simplest email abstraction usually starts as a switch statement. If provider is Resend, call Resend. If provider is SendGrid, call SendGrid. It works until every branch grows its own validation, error shape, and fallback behavior.",
+      "An adapter contract gives the mess a place to live.",
+    ],
+    sections: [
+      {
+        title: "Keep quirks local",
+        paragraphs: [
+          "Every provider has quirks. That is not a failure. The failure is spreading those quirks across product code. An adapter can translate one app-owned message into one provider-owned request and report what happened.",
+        ],
+      },
+      {
+        title: "Make capability explicit",
+        checklist: [
+          "Name which fields the adapter supports.",
+          "Reject unsupported fields before sending.",
+          "Normalize provider errors enough for routing decisions.",
+          "Return provider IDs without forcing provider types into the app.",
+        ],
+      },
+      {
+        title: "Use the contract for community adapters",
+        paragraphs: [
+          "A clear adapter shape also makes third-party providers possible. Community packages can implement the same boundary, and the app does not need to learn a new send API for each one.",
+        ],
+      },
+    ],
+    callout:
+      "An adapter is not fancy architecture here. It is a small fence around provider-specific behavior.",
+    primaryCta: { label: "Read adapter contract", docsPath: "/docs/reference/adapter-contract" },
+    secondaryCta: { label: "Create an adapter", docsPath: "/docs/guides/authoring/create-adapter" },
+  },
+  "migrate-from-provider-sdk": {
+    paragraphs: [
+      "Provider-specific SDKs are fine at the start. They are direct, documented, and usually the fastest way to send the first email. The bill comes later, when every product path knows about that provider.",
+      "A calmer migration moves provider code behind a boundary before replacing the provider.",
+    ],
+    sections: [
+      {
+        title: "Do the inventory",
+        checklist: [
+          "List every direct provider import.",
+          "Group sends by message type and risk.",
+          "Find provider-only fields such as template IDs, streams, tags, and custom args.",
+          "Mark paths with tests, live smoke checks, or no coverage at all.",
+        ],
+      },
+      {
+        title: "Wrap first, replace second",
+        paragraphs: [
+          "Move the existing provider into an adapter and keep behavior the same. Once product code calls your own email boundary, you can add another adapter without turning the migration into a rewrite.",
+        ],
+      },
+      {
+        title: "Move low-risk routes first",
+        paragraphs: [
+          "Start with a simple notification or internal email. Receipts, login codes, and compliance notices should wait until logging, retries, and field support are proven.",
+        ],
+      },
+    ],
+    callout:
+      "The first milestone is not a new provider. It is fewer places in the app that care which provider is underneath.",
+    primaryCta: { label: "Read quickstart", docsPath: "/docs/getting-started/quickstart" },
+    secondaryCta: { label: "Read adapter model", docsPath: "/docs/concepts/adapter-model" },
+  },
+  "email-attachments-provider-limits": {
+    paragraphs: [
+      "Attachments are where email abstractions stop being cute. A filename, content type, base64 string, stream, size limit, and provider request shape all have to line up.",
+      "If your product sends invoices, exports, contracts, or reports, attachment support is not a footnote. It is part of the route contract.",
+    ],
+    sections: [
+      {
+        title: "Check limits before launch",
+        checklist: [
+          "Maximum total message size.",
+          "Accepted attachment encoding.",
+          "Filename and content type handling.",
+          "Whether the provider supports inline attachments.",
+          "How failed attachment sends appear in logs.",
+        ],
+      },
+      {
+        title: "Do not fallback blindly",
+        paragraphs: [
+          "A fallback provider that cannot carry the attachment should reject the send. A receipt without its PDF might look successful from the outside while creating support work later.",
+        ],
+      },
+      {
+        title: "Test with real-ish files",
+        paragraphs: [
+          "A one-line text attachment does not prove much. Test a PDF near your expected production size, a weird filename, and a missing content type. Those cases catch adapter mistakes early.",
+        ],
+      },
+    ],
+    callout:
+      "Attachment support should be verified for each route. It is too visible to leave to hope.",
+    primaryCta: { label: "Check field support", docsPath: "/docs/adapters/field-support" },
+    secondaryCta: { label: "Read message reference", docsPath: "/docs/reference/message" },
+  },
+  "email-metadata-tags-headers": {
+    paragraphs: [
+      "Metadata, tags, and headers all look like places to stash extra information. They are not the same thing, and mixing them casually makes debugging harder.",
+      "Use each layer for the job it is good at, then keep your own app database as the source of truth for anything critical.",
+    ],
+    sections: [
+      {
+        title: "Use the right layer",
+        table: {
+          headers: ["Layer", "Good for", "Be careful with"],
+          rows: [
+            [
+              "Metadata",
+              "Provider-side lookup and webhook correlation.",
+              "Provider support varies.",
+            ],
+            ["Tags", "Grouping sends in provider dashboards.", "Names and limits differ."],
+            [
+              "Headers",
+              "Protocol-level behavior and downstream systems.",
+              "Some providers restrict custom headers.",
+            ],
+          ],
+        },
+      },
+      {
+        title: "Keep critical IDs at home",
+        paragraphs: [
+          "Put invoice IDs, tenant IDs, and support-facing references in your app database first. Sending them through a provider can help with correlation, but it should not be the only place they exist.",
+        ],
+      },
+      {
+        title: "Validate by adapter",
+        paragraphs: [
+          "If a route needs metadata, use an adapter that supports metadata. If a backup route cannot send it, make that a configuration error instead of discovering it from a missing support trace.",
+        ],
+      },
+    ],
+    callout:
+      "Extra fields are useful, but they are not portable by default. Treat them as provider capabilities.",
+    primaryCta: { label: "Read message reference", docsPath: "/docs/reference/message" },
+    secondaryCta: { label: "Check field support", docsPath: "/docs/adapters/field-support" },
+  },
+  "email-queue-vs-sdk-boundary": {
+    paragraphs: [
+      "Queues and email SDKs solve different problems. A queue decides when work runs and how it is retried. An email SDK decides how a message becomes a provider request.",
+      "When those jobs blur, incidents get muddy. Nobody can tell whether the queue retried too much, the adapter rejected the payload, or the provider accepted a duplicate.",
+    ],
+    sections: [
+      {
+        title: "Let the queue own scheduling",
+        paragraphs: [
+          "Use the queue for delayed sends, background work, backoff, concurrency, and job history. It should pass a clear message request into the email boundary, not build provider payloads itself.",
+        ],
+      },
+      {
+        title: "Let the SDK own provider behavior",
+        checklist: [
+          "Normalize the message shape.",
+          "Validate adapter field support.",
+          "Choose provider and fallback routes.",
+          "Return normalized results and errors.",
+        ],
+      },
+      {
+        title: "Put IDs across both systems",
+        paragraphs: [
+          "The queue job ID and email send attempt ID should be linked. That gives you a straight line from product event to background job to provider response.",
+        ],
+      },
+    ],
+    callout:
+      "A queue can retry work. It should not be the only place your app understands email provider behavior.",
+    primaryCta: {
+      label: "Read production guide",
+      docsPath: "/docs/guides/production-send-pipeline",
+    },
+    secondaryCta: { label: "Read client reference", docsPath: "/docs/reference/client" },
+  },
+  "deliverability-code-can-control": {
+    paragraphs: [
+      "Deliverability is bigger than code. Domains, DNS, reputation, content, and sending practices all matter. Still, code controls more than teams admit.",
+      "Your app decides which sender to use, whether a retry can duplicate a receipt, whether metadata survives a fallback, and whether anyone can debug a failed route.",
+    ],
+    sections: [
+      {
+        title: "Control the message shape",
+        checklist: [
+          "Use stable from and reply-to addresses.",
+          "Keep plain text available for important transactional email.",
+          "Avoid provider fallbacks that remove headers or metadata you depend on.",
+          "Log provider IDs and normalized errors.",
+        ],
+      },
+      {
+        title: "Control the send policy",
+        paragraphs: [
+          "Backoff, retries, and fallback order affect what users see. If a provider is rate limiting, retrying aggressively can make the problem worse. If a provider rejects sender identity, fallback may be safer than retry.",
+        ],
+      },
+      {
+        title: "Know what code cannot solve",
+        paragraphs: [
+          "Code cannot rescue a bad domain reputation or missing DNS records. It can make those problems visible early and stop the app from pretending every provider route is equivalent.",
+        ],
+      },
+    ],
+    callout:
+      "Treat deliverability as a shared job. DNS and reputation matter, but app code still makes the send path safer or messier.",
+    primaryCta: {
+      label: "Read production guide",
+      docsPath: "/docs/guides/production-send-pipeline",
+    },
+    secondaryCta: { label: "Browse adapters", docsPath: "/docs/adapters" },
+  },
+  "self-hosted-smtp-vs-email-api": {
+    paragraphs: [
+      "Self-hosted SMTP and email APIs are two different kinds of pain. SMTP gives control and responsibility. Email APIs give speed and a provider contract. Neither choice is morally superior.",
+      "Pick based on what your team is willing to own when something fails at 2am.",
+    ],
+    sections: [
+      {
+        title: "The self-hosted trade",
+        paragraphs: [
+          "Running SMTP can make sense for infrastructure-heavy teams with strong operational reasons. It also means owning deliverability posture, monitoring, abuse handling, and mail server maintenance.",
+        ],
+      },
+      {
+        title: "The API provider trade",
+        paragraphs: [
+          "Provider APIs move a lot of operational work out of your app, but they add vendor limits, pricing, and product-specific payloads. A typed adapter boundary keeps that trade manageable.",
+        ],
+      },
+      {
+        title: "Keep both possible",
+        table: {
+          headers: ["Need", "Likely route", "Boundary"],
+          rows: [
+            ["Fast product launch", "Email API", "Adapter hides provider payload."],
+            ["Internal infrastructure control", "SMTP", "Strict message subset."],
+            ["Tenant choice", "Mixed", "Route policy selects adapter."],
+          ],
+        },
+      },
+    ],
+    callout:
+      "The winner is the setup your team can operate honestly, with failures you can see and explain.",
+    primaryCta: { label: "Read SMTP docs", docsPath: "/docs/adapters/smtp" },
+    secondaryCta: { label: "Browse provider APIs", docsPath: "/docs/adapters" },
+  },
+  "customer-byo-email-provider": {
+    paragraphs: [
+      "Bring-your-own email provider support sounds like a settings page with an API key input. In practice, customers bring sender domains, regions, provider limits, compliance preferences, and their own broken credentials.",
+      "If the app lets customers own the route, the app also needs to own validation and supportability.",
+    ],
+    sections: [
+      {
+        title: "Collect enough configuration",
+        checklist: [
+          "Provider type and credentials.",
+          "Verified sender domain or address.",
+          "Allowed message classes.",
+          "Region or compliance constraints.",
+          "Fallback policy and support owner.",
+        ],
+      },
+      {
+        title: "Test before enabling",
+        paragraphs: [
+          "A save button should not be the moment you discover credentials are wrong. Run a dry check, show the provider identity state, and keep the route disabled until a smoke test passes.",
+        ],
+      },
+      {
+        title: "Protect the shared app",
+        paragraphs: [
+          "One tenant's provider outage should not make every tenant's email path unclear. Keep route policy tenant-scoped, log tenant IDs, and avoid global fallback behavior that crosses customer boundaries.",
+        ],
+      },
+    ],
+    callout:
+      "BYO provider support is powerful, but it needs product-grade guardrails. API keys alone are not a routing model.",
+    primaryCta: { label: "Read adapter docs", docsPath: "/docs/adapters" },
+    secondaryCta: { label: "Read testing guide", docsPath: "/docs/guides/test-email-behavior" },
+  },
+  "agents-sending-email-safely": {
+    paragraphs: [
+      "Agents can draft email, collect context, and trigger workflows. That does not mean they should get a raw provider API key and a blank check. Email is too visible, too easy to duplicate, and too easy to make weird.",
+      "The safer pattern is to let agents work inside a typed boundary with capture, approval, and provider-aware validation.",
+    ],
+    sections: [
+      {
+        title: "Separate draft from send",
+        paragraphs: [
+          "An agent can prepare the message body and metadata. The app should still decide whether the message is allowed, which route can send it, and whether a human approval step is required.",
+        ],
+      },
+      {
+        title: "Capture before delivery",
+        checklist: [
+          "Record the generated message before sending.",
+          "Validate recipients and sender identity.",
+          "Block unsupported fields by adapter.",
+          "Require approval for high-risk message classes.",
+          "Keep an audit trail of who or what triggered the send.",
+        ],
+      },
+      {
+        title: "Use tools with narrow permissions",
+        paragraphs: [
+          "A send tool should not expose every provider option. Give the agent the smallest useful interface: message type, approved recipients, and route policy chosen by the app.",
+        ],
+      },
+    ],
+    callout:
+      "Agents should not bypass your email architecture. They should use the safest version of it.",
+    primaryCta: { label: "Read agent tools", docsPath: "/docs/agents/skill" },
+    secondaryCta: { label: "Read capture plugin", docsPath: "/docs/plugins/built-in/capture" },
+  },
+};
+
+function PlannedPostContent({ content }: { content: PlannedPost }) {
+  return (
+    <BlogBody>
+      {content.paragraphs.map((paragraph) => (
+        <p key={paragraph}>{paragraph}</p>
+      ))}
+
+      {content.sections.map((section) => (
+        <Section key={section.title} title={section.title}>
+          {section.paragraphs?.map((paragraph) => (
+            <p key={paragraph}>{paragraph}</p>
+          ))}
+          {section.table ? (
+            <Table>
+              <thead>
+                <tr>
+                  {section.table.headers.map((header) => (
+                    <th key={header}>{header}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {section.table.rows.map((row) => (
+                  <tr key={row.join(":")}>
+                    {row.map((cell) => (
+                      <td key={cell}>{cell}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </Table>
+          ) : null}
+          {section.checklist ? <Checklist items={section.checklist} /> : null}
+          {section.code ? <CodeBlock>{section.code}</CodeBlock> : null}
+        </Section>
+      ))}
+
+      <Callout>{content.callout}</Callout>
+
+      <div className="not-prose mt-10 flex flex-col gap-3 sm:flex-row">
+        <DocsVersionLink
+          className="inline-flex h-11 items-center justify-center gap-2 rounded-md bg-fd-primary px-4 text-sm font-medium text-fd-primary-foreground transition hover:opacity-90"
+          docsPath={content.primaryCta.docsPath}
+        >
+          {content.primaryCta.label}
+          <ArrowRight className="size-4" />
+        </DocsVersionLink>
+        {content.secondaryCta ? (
+          <DocsVersionLink
+            className="inline-flex h-11 items-center justify-center rounded-md border border-fd-border px-4 text-sm font-medium transition hover:bg-fd-accent"
+            docsPath={content.secondaryCta.docsPath}
+          >
+            {content.secondaryCta.label}
+          </DocsVersionLink>
+        ) : null}
       </div>
     </BlogBody>
   );

--- a/apps/fumadocs/src/routes/blog/index.tsx
+++ b/apps/fumadocs/src/routes/blog/index.tsx
@@ -4,27 +4,77 @@ import { ArrowRight } from "lucide-react";
 
 import { formatBlogDate, getPublishedBlogPosts, type BlogPost } from "@/lib/blog";
 import { baseOptions } from "@/lib/layout.shared";
-import { siteUrl } from "@/lib/shared";
+import { appName, siteOgImageUrl, siteUrl } from "@/lib/shared";
 
 export const Route = createFileRoute("/blog/")({
-  head: () => ({
-    meta: [
-      { title: "Email SDK Blog - TypeScript email, adapters, and launch notes" },
-      {
-        name: "description",
-        content:
-          "Notes from the Email SDK team on TypeScript transactional email, provider adapters, fallbacks, and launch work.",
-      },
-      { property: "og:title", content: "Email SDK Blog" },
-      {
-        property: "og:description",
-        content:
-          "TypeScript email notes for developers who care about provider choice, fallbacks, and boring production behavior.",
-      },
-      { property: "og:url", content: `${siteUrl}/blog` },
-    ],
-    links: [{ rel: "canonical", href: `${siteUrl}/blog` }],
-  }),
+  head: ({ loaderData }) => {
+    const posts = (loaderData as BlogPost[] | undefined) ?? [];
+    const description =
+      "TypeScript email notes for developers who care about provider choice, fallbacks, testing, and boring production behavior.";
+
+    return {
+      meta: [
+        { title: "Email SDK Blog - TypeScript email, adapters, and launch notes" },
+        {
+          name: "description",
+          content: description,
+        },
+        { property: "og:type", content: "website" },
+        { property: "og:title", content: "Email SDK Blog" },
+        {
+          property: "og:description",
+          content: description,
+        },
+        { property: "og:url", content: `${siteUrl}/blog` },
+        { property: "og:image", content: siteOgImageUrl },
+        { property: "og:image:alt", content: "Email SDK blog preview" },
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: "Email SDK Blog" },
+        { name: "twitter:description", content: description },
+        { name: "twitter:image", content: siteOgImageUrl },
+        { name: "twitter:image:alt", content: "Email SDK blog preview" },
+        {
+          "script:ld+json": {
+            "@context": "https://schema.org",
+            "@type": "Blog",
+            name: `${appName} Blog`,
+            url: `${siteUrl}/blog`,
+            description,
+            publisher: {
+              "@type": "Organization",
+              name: "OpenCore",
+              url: "https://opencore.dev",
+            },
+            blogPost: posts.map((post) => ({
+              "@type": "BlogPosting",
+              headline: post.title,
+              description: post.description,
+              datePublished: post.publishedAt,
+              dateModified: post.updatedAt,
+              url: `${siteUrl}/blog/${post.slug}`,
+              image: `${siteUrl}${post.image}`,
+            })),
+          },
+        },
+        {
+          "script:ld+json": {
+            "@context": "https://schema.org",
+            "@type": "ItemList",
+            name: `${appName} Blog posts`,
+            itemListElement: posts.map((post, index) => ({
+              "@type": "ListItem",
+              position: index + 1,
+              name: post.title,
+              url: `${siteUrl}/blog/${post.slug}`,
+            })),
+          },
+        },
+      ],
+      links: [{ rel: "canonical", href: `${siteUrl}/blog` }],
+    };
+  },
   loader: () => getPublishedBlogPosts(),
   component: BlogIndex,
 });

--- a/apps/fumadocs/src/routes/og/blog/$.ts
+++ b/apps/fumadocs/src/routes/og/blog/$.ts
@@ -1,0 +1,158 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { getBlogPost } from "@/lib/blog";
+import { appName, siteUrl } from "@/lib/shared";
+
+export const Route = createFileRoute("/og/blog/$")({
+  server: {
+    handlers: {
+      GET({ params }) {
+        const slug = params._splat?.replace(/\.svg$/, "");
+        const post = slug ? getBlogPost(slug, { includeFuture: true }) : undefined;
+
+        if (!post || params._splat === slug) {
+          return new Response("Not found", { status: 404 });
+        }
+
+        return new Response(renderBlogOgImage(post), {
+          headers: {
+            "cache-control": "public, max-age=86400, stale-while-revalidate=604800",
+            "content-type": "image/svg+xml; charset=utf-8",
+          },
+        });
+      },
+    },
+  },
+});
+
+type OgPost = NonNullable<ReturnType<typeof getBlogPost>>;
+
+const palettes = [
+  ["#121214", "#f2d492", "#6ee7b7", "#8aa8ff"],
+  ["#111318", "#f7b267", "#89ddff", "#f78fb3"],
+  ["#101414", "#a7f3d0", "#f6bd60", "#83c5be"],
+  ["#151218", "#f4a261", "#a8dadc", "#e9c46a"],
+  ["#101217", "#cdb4db", "#ffd166", "#06d6a0"],
+] as const;
+
+function renderBlogOgImage(post: OgPost) {
+  const palette = palettes[hashSlug(post.slug) % palettes.length] ?? palettes[0];
+  const [background, primary, secondary, accent] = palette;
+  const titleLines = limitLines(wrapText(post.title, 28), 3);
+  const descriptionLines = limitLines(wrapText(post.description, 54), 2);
+  const tag = post.tags[0] ?? "Email SDK";
+  const seed = hashSlug(post.slug);
+  const xOffset = seed % 160;
+  const yOffset = (seed >> 3) % 90;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="1200" height="630" viewBox="0 0 1200 630" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">${escapeXml(post.title)}</title>
+  <desc id="desc">${escapeXml(post.imageAlt)}</desc>
+  <rect width="1200" height="630" fill="${background}"/>
+  <rect x="44" y="44" width="1112" height="542" rx="28" fill="#ffffff" fill-opacity="0.035" stroke="#ffffff" stroke-opacity="0.11"/>
+  <ellipse cx="${960 - xOffset / 2}" cy="${250 + yOffset / 2}" rx="220" ry="110" fill="${primary}" fill-opacity="0.17"/>
+  <ellipse cx="${930 - xOffset / 3}" cy="${360 - yOffset / 4}" rx="220" ry="125" fill="${secondary}" fill-opacity="0.15"/>
+  <g opacity="0.9">
+    <rect x="${770 - xOffset}" y="132" width="236" height="58" rx="14" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.13"/>
+    <rect x="${835 - xOffset}" y="251" width="266" height="58" rx="14" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.13"/>
+    <rect x="${740 - xOffset}" y="370" width="206" height="58" rx="14" fill="#ffffff" fill-opacity="0.08" stroke="#ffffff" stroke-opacity="0.13"/>
+    <circle cx="${770 - xOffset}" cy="161" r="9" fill="${primary}"/>
+    <circle cx="${835 - xOffset}" cy="280" r="9" fill="${accent}"/>
+    <circle cx="${740 - xOffset}" cy="399" r="9" fill="${secondary}"/>
+  </g>
+  <text x="96" y="112" fill="${primary}" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="24" font-weight="700" letter-spacing="0.04em">${escapeXml(appName.toUpperCase())}</text>
+  <text x="96" y="151" fill="#ffffff" fill-opacity="0.58" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22">${escapeXml(formatDate(post.publishedAt))} / ${escapeXml(tag)}</text>
+  ${titleLines
+    .map(
+      (line, index) =>
+        `<text x="96" y="${247 + index * 70}" fill="#ffffff" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="60" font-weight="700">${escapeXml(line)}</text>`,
+    )
+    .join("\n  ")}
+  ${descriptionLines
+    .map(
+      (line, index) =>
+        `<text x="98" y="${492 + index * 34}" fill="#ffffff" fill-opacity="0.68" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="26">${escapeXml(line)}</text>`,
+    )
+    .join("\n  ")}
+  <text x="96" y="560" fill="${secondary}" font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="22" font-weight="700">${escapeXml(siteUrl.replace(/^https?:\/\//, ""))}</text>
+</svg>`;
+}
+
+function hashSlug(value: string) {
+  let hash = 0;
+  for (let index = 0; index < value.length; index++) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+  return hash;
+}
+
+function wrapText(value: string, maxLength: number) {
+  const words = value.split(/\s+/);
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    if (word.length > maxLength) {
+      if (current) {
+        lines.push(current);
+        current = "";
+      }
+      lines.push(...splitLongWord(word, maxLength));
+      continue;
+    }
+
+    const candidate = current ? `${current} ${word}` : word;
+    if (candidate.length > maxLength && current) {
+      lines.push(current);
+      current = word;
+      continue;
+    }
+    current = candidate;
+  }
+
+  if (current) lines.push(current);
+  return lines;
+}
+
+function splitLongWord(word: string, maxLength: number) {
+  const chunkSize = Math.max(1, maxLength - 1);
+  const chunks: string[] = [];
+
+  for (let index = 0; index < word.length; index += chunkSize) {
+    const chunk = word.slice(index, index + chunkSize);
+    chunks.push(index + chunkSize < word.length ? `${chunk}-` : chunk);
+  }
+
+  return chunks;
+}
+
+function limitLines(lines: string[], maxLines: number) {
+  if (lines.length <= maxLines) return lines;
+
+  const visible = lines.slice(0, maxLines);
+  const last = visible.at(-1);
+  if (last) {
+    visible[visible.length - 1] = `${last.replace(/[.,;:\s]+$/, "")}...`;
+  }
+
+  return visible;
+}
+
+function formatDate(value: string) {
+  return new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(new Date(`${value}T00:00:00Z`));
+}
+
+function escapeXml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+}

--- a/apps/fumadocs/src/routes/rss[.]xml.ts
+++ b/apps/fumadocs/src/routes/rss[.]xml.ts
@@ -28,22 +28,27 @@ function renderRssFeed() {
       <link>${escapedUrl}</link>
       <guid>${escapedUrl}</guid>
       <description>${escapeXml(post.description)}</description>
+      <media:content url="${escapeXml(`${siteUrl}${post.image}`)}" medium="image" type="image/svg+xml"/>
+      <media:thumbnail url="${escapeXml(`${siteUrl}${post.image}`)}"/>
       <pubDate>${new Date(`${post.publishedAt}T00:00:00Z`).toUTCString()}</pubDate>
     </item>`;
   });
 
-  const latestPost = posts.reduce((latest, post) =>
-    post.updatedAt > latest.updatedAt ? post : latest,
+  const latestPost = posts.reduce<(typeof posts)[number] | undefined>(
+    (latest, post) => (!latest || post.updatedAt > latest.updatedAt ? post : latest),
+    undefined,
   );
+  const latestUpdatedAt = latestPost?.updatedAt ?? "2026-06-01";
 
   return `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/">
   <channel>
     <title>${escapeXml(`${appName} Blog`)}</title>
     <link>${escapeXml(`${siteUrl}/blog`)}</link>
+    <atom:link href="${escapeXml(`${siteUrl}/rss.xml`)}" rel="self" type="application/rss+xml"/>
     <description>${escapeXml(appDescription)}</description>
     <language>en</language>
-    <lastBuildDate>${new Date(`${latestPost.updatedAt}T00:00:00Z`).toUTCString()}</lastBuildDate>
+    <lastBuildDate>${new Date(`${latestUpdatedAt}T00:00:00Z`).toUTCString()}</lastBuildDate>
 ${items.join("\n")}
   </channel>
 </rss>`;

--- a/apps/fumadocs/src/routes/sitemap[.]xml.ts
+++ b/apps/fumadocs/src/routes/sitemap[.]xml.ts
@@ -27,6 +27,12 @@ export const Route = createFileRoute("/sitemap.xml")({
 });
 
 function getSitemapEntries() {
+  const publishedBlogPosts = getPublishedBlogPosts();
+  const latestBlogUpdate =
+    publishedBlogPosts.reduce(
+      (latest, post) => (post.updatedAt > latest ? post.updatedAt : latest),
+      "2026-06-01",
+    ) || "2026-06-01";
   const entries: SitemapEntry[] = [
     {
       loc: `${siteUrl}/`,
@@ -36,7 +42,7 @@ function getSitemapEntries() {
     },
     {
       loc: `${siteUrl}/blog`,
-      lastmod: "2026-06-01",
+      lastmod: latestBlogUpdate,
       changefreq: "weekly",
       priority: "0.8",
     },
@@ -52,7 +58,7 @@ function getSitemapEntries() {
       changefreq: "monthly",
       priority: "0.3",
     },
-    ...getPublishedBlogPosts().map((post) => ({
+    ...publishedBlogPosts.map((post) => ({
       loc: `${siteUrl}${getBlogPostUrl(post.slug)}`,
       lastmod: post.updatedAt,
       changefreq: "monthly" as const,

--- a/apps/fumadocs/vite.config.ts
+++ b/apps/fumadocs/vite.config.ts
@@ -8,7 +8,7 @@ import mdx from "fumadocs-mdx/vite";
 import { nitro } from "nitro/vite";
 import { defineConfig, loadEnv } from "vite";
 
-import { getBlogPostUrl, getPublishedBlogPosts } from "./src/lib/blog";
+import { getAllBlogPosts, getBlogPostImageUrl, getBlogPostUrl } from "./src/lib/blog";
 import { docsVersions, getDocsVersionHref } from "./src/lib/versions";
 
 function collectContentPages(dir: string) {
@@ -96,8 +96,11 @@ export default defineConfig(({ mode }) => {
           {
             path: "/terms",
           },
-          ...getPublishedBlogPosts().map((post) => ({
+          ...getAllBlogPosts().map((post) => ({
             path: getBlogPostUrl(post.slug),
+          })),
+          ...getAllBlogPosts().map((post) => ({
+            path: getBlogPostImageUrl(post.slug),
           })),
           ...versionedDocsPages,
           {


### PR DESCRIPTION
## Summary
- Adds 20 weekly scheduled SEO blog posts from June 17 through October 28, 2026.
- Gives each blog post a distinct generated SVG OG image route and richer article/blog structured metadata.
- Keeps future posts out of the blog index, sitemap, RSS, and JSON feed until their publish date, while pre-rendering pages/assets for static deploys.
- Adds a weekly Vercel deploy-hook workflow so static sitemap/feed/blog surfaces can refresh on schedule.

## Validation
- bun test apps/fumadocs/src/lib/blog.test.ts apps/fumadocs/src/lib/metadata.test.ts
- bun run --cwd apps/fumadocs types:check
- bun run --cwd apps/fumadocs build
- bun run release:ci
- Greptile review against origin/main: fixed scoped review findings for OG cache, title truncation, RSS image metadata, and blog index social image. Final follow-up review job stayed stuck in Reviewing files, so local Greptile clients were stopped after fixes and green release:ci.