### PR TITLE
ci: skip release workflow for docs-only pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
   push:
     branches:
       - main
+    paths:
+      - ".changeset/**"
+      - "package.json"
+      - "packages/**"
+      - "scripts/**"
+      - "turbo.json"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- restrict the release workflow push trigger to package/release-relevant paths
- keep manual workflow dispatch available
- avoid running changesets publish after docs-only merges

## Validation
- bun run release:ci
- greptile review -b origin/main --agent --no-color (addressed Formula/** and bun.lock feedback)