### PR TITLE
Add AI agent support and improve SEO metadata

### DIFF
--- a/apps/fumadocs/public/.well-known/agent-skills
+++ b/apps/fumadocs/public/.well-known/agent-skills
@@ -1,0 +1,28 @@
+{
+  "name": "Email SDK",
+  "description": "TypeScript SDK that sends transactional email through 20+ providers (Resend, SMTP, Postmark, SendGrid, Mailgun, AWS SES, and more) behind one typed send() call, with retries and compatible fallbacks.",
+  "homepage": "https://email-sdk.dev",
+  "guide": "https://email-sdk.dev/agents.md",
+  "docs": "https://email-sdk.dev/docs",
+  "llmsTxt": "https://email-sdk.dev/llms.txt",
+  "repository": "https://github.com/opencoredev/email-sdk",
+  "package": "@opencoredev/email-sdk",
+  "skills": [
+    {
+      "name": "email-sdk",
+      "description": "Use when adding, reviewing, or documenting Email SDK integrations in TypeScript/Bun apps. Covers adapter selection, fallbacks, CLI smoke tests, hooks, and secret-safe observability.",
+      "install": "npx skills add opencoredev/email-sdk --skill email-sdk",
+      "source": "https://github.com/opencoredev/email-sdk/blob/main/skills/email-sdk/SKILL.md"
+    }
+  ],
+  "tools": [
+    {
+      "name": "send_email",
+      "description": "Send a transactional email through the app's configured Email SDK client. Requires from, to, and subject; optional html, text, adapter, and provider. Runs the full validate/retry/fallback pipeline.",
+      "package": "@opencoredev/email-sdk/agent-tools",
+      "factory": "createEmailAgentTools",
+      "docs": "https://email-sdk.dev/docs/agents/skill",
+      "requiresApproval": true
+    }
+  ]
+}

--- a/apps/fumadocs/public/agents.md
+++ b/apps/fumadocs/public/agents.md
@@ -1,0 +1,91 @@
+# Email SDK — Agent Guide
+
+Machine-facing guide for AI agents and coding assistants. Email SDK is an
+open-source **TypeScript SDK** (npm: `@opencoredev/email-sdk`) that sends
+transactional email through 20+ providers behind one typed `send()` call. It is
+a library you install into an app — not a hosted API or a service you sign up
+for. There are no API keys to obtain from us; you bring the provider credentials
+the app already has.
+
+- Docs: https://email-sdk.dev/docs
+- Machine index: https://email-sdk.dev/llms.txt and https://email-sdk.dev/llms-full.txt
+- Source: https://github.com/opencoredev/email-sdk
+- Package: https://www.npmjs.com/package/@opencoredev/email-sdk
+
+## When to use Email SDK
+
+Use it when a TypeScript/JavaScript (Node, Bun, or edge/Workers) app needs to:
+
+- Send transactional email (receipts, verifications, alerts, password resets).
+- Send through one provider but keep the option to switch or add providers later
+  without rewriting send sites.
+- Route across multiple providers with retries and compatible fallbacks.
+- Give an LLM agent a guarded `send_email` tool that goes through the same
+  validated pipeline as the rest of the app.
+
+## When NOT to use it
+
+- You need a marketing/campaign email builder or a CRM — this is transactional sending.
+- You are not in a TypeScript/JavaScript runtime.
+- You want a hosted email API with its own dashboard and billing — Email SDK wraps
+  providers you already pay (Resend, SES, Postmark, SMTP, …); it is not one itself.
+
+## Install and send
+
+```bash
+npm install @opencoredev/email-sdk
+```
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  retry: { retries: 1 },
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+```
+
+Adapters import from their own entry point (`@opencoredev/email-sdk/resend`,
+`/smtp`, `/ses`, …). Supported providers: Resend, SMTP, Postmark, SendGrid,
+Mailgun, Cloudflare Email Sending, Unosend, AWS SES, MailerSend, Brevo, Mailchimp
+Transactional, SparkPost, Iterable, Loops, Sequenzy, Plunk, Mailtrap, Scaleway,
+ZeptoMail, and MailPace.
+
+## Give an agent a send tool
+
+`createEmailAgentTools(client)` from `@opencoredev/email-sdk/agent-tools` returns a
+`send_email` tool (name, description, JSON-Schema parameters, `execute`) that maps
+onto any framework's tool format. `execute` runs the full client pipeline —
+validation, retries, fallbacks, plugins, hooks. See
+https://email-sdk.dev/docs/agents/skill.
+
+## The email-sdk skill
+
+A skill for coding agents lives at
+https://github.com/opencoredev/email-sdk/blob/main/skills/email-sdk/SKILL.md.
+Install it with:
+
+```bash
+npx skills add opencoredev/email-sdk --skill email-sdk
+```
+
+## Constraints for agents
+
+- Keep all provider credentials in environment variables. Never hardcode or log
+  API keys, SMTP passwords, raw tokens, full message bodies, or recipient lists.
+- Do not add Nodemailer — the SDK ships its own SMTP transport.
+- Only configure a fallback adapter that supports the same fields as the primary;
+  check https://email-sdk.dev/docs/adapters/field-support first.
+- Use idempotency keys for externally visible sends that may be retried.
+- Gate agent-initiated sends behind explicit human approval; the tool description
+  asks the model to confirm, but you must enforce it.
+- Run the CLI `email-sdk doctor` and `send --dry-run` before any live send, and do
+  not send real external mail without the user's approval.

--- a/apps/fumadocs/public/robots.txt
+++ b/apps/fumadocs/public/robots.txt
@@ -1,19 +1,54 @@
+# Email SDK — crawler policy
+# Default: every well-behaved crawler may index the whole site.
 User-agent: *
 Allow: /
 
+# AI assistants and answer engines that fetch on behalf of a user, drive traffic,
+# and cite sources are explicitly welcome.
 User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
 Allow: /
 
 User-agent: ChatGPT-User
 Allow: /
 
-User-agent: PerplexityBot
+User-agent: ClaudeBot
 Allow: /
 
-User-agent: ClaudeBot
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
 Allow: /
 
 User-agent: anthropic-ai
 Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+# Bulk training-data scrapers with no user-facing product and no attribution are disallowed.
+User-agent: CCBot
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
 
 Sitemap: https://email-sdk.dev/sitemap.xml

--- a/apps/fumadocs/src/lib/metadata.ts
+++ b/apps/fumadocs/src/lib/metadata.ts
@@ -93,6 +93,18 @@ export const homeStructuredData = {
       name: "OpenCore",
       url: "https://opencore.dev",
       logo: `${siteUrl}/logo.png`,
+      // sameAs links let agents disambiguate the brand against real, verifiable profiles.
+      sameAs: [
+        "https://github.com/opencoredev",
+        "https://github.com/opencoredev/email-sdk",
+        "https://www.npmjs.com/package/@opencoredev/email-sdk",
+      ],
+      contactPoint: {
+        "@type": "ContactPoint",
+        contactType: "technical support",
+        url: "https://github.com/opencoredev/email-sdk/issues",
+        availableLanguage: "English",
+      },
     },
     {
       "@type": "WebSite",
@@ -161,6 +173,39 @@ export const homeStructuredData = {
           },
         },
       ],
+    },
+    {
+      // Machine-readable enumeration of supported providers so agents can resolve
+      // "does Email SDK support <provider>?" without parsing prose.
+      "@type": "ItemList",
+      "@id": `${siteUrl}/#supported-providers`,
+      name: "Email providers supported by Email SDK",
+      itemListElement: [
+        "Resend",
+        "SMTP",
+        "Postmark",
+        "SendGrid",
+        "Mailgun",
+        "Cloudflare Email Sending",
+        "Unosend",
+        "AWS SES",
+        "MailerSend",
+        "Brevo",
+        "Mailchimp Transactional",
+        "SparkPost",
+        "Iterable",
+        "Loops",
+        "Sequenzy",
+        "Plunk",
+        "Mailtrap",
+        "Scaleway",
+        "ZeptoMail",
+        "MailPace",
+      ].map((name, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name,
+      })),
     },
   ],
 } as const;

--- a/apps/fumadocs/src/lib/shared.ts
+++ b/apps/fumadocs/src/lib/shared.ts
@@ -1,6 +1,21 @@
 export const appName = "Email SDK";
 export const appDescription =
   "A TypeScript email SDK for unified email sending with Resend, SMTP, Postmark, SendGrid, Mailgun, Unosend, AWS SES, fallbacks, plugins, and a local CLI.";
+
+// Shared description + agent constraints prepended to llms.txt / llms-full.txt so the
+// machine indexes lead with what the project is and the rules for using it safely.
+export const llmsOverview = `> ${appDescription}
+
+Email SDK is an open-source TypeScript SDK (npm: \`@opencoredev/email-sdk\`) for sending transactional email through 20+ providers — Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare Email Sending, Unosend, AWS SES, and more — behind one typed \`send()\` call with retries and compatible fallbacks. It is a library you install into a TypeScript/JavaScript app, not a hosted API or a service you sign up for.
+
+## Constraints
+
+- TypeScript/JavaScript runtimes only (Node, Bun, edge/Workers), for transactional email rather than marketing campaigns.
+- Bring your own provider credentials and keep them in environment variables. Never hardcode or log API keys, passwords, tokens, full message bodies, or recipient lists.
+- Import each adapter from its own entry point (\`@opencoredev/email-sdk/resend\`, \`/smtp\`, …); do not add Nodemailer — the SDK ships its own SMTP transport.
+- Configure a fallback only between adapters that support the same fields (see /docs/adapters/field-support). Use idempotency keys for externally visible sends that may retry.
+- Gate agent-initiated sends behind explicit human approval. Run the CLI \`doctor\` and \`send --dry-run\` before any live send.`;
+
 export const docsRoute = "/docs";
 export const siteUrl = (import.meta.env.VITE_SITE_URL ?? "https://email-sdk.dev").replace(
   /\/$/,

--- a/apps/fumadocs/src/routeTree.gen.ts
+++ b/apps/fumadocs/src/routeTree.gen.ts
@@ -16,6 +16,8 @@ import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
 import { Route as FeedDotjsonRouteImport } from './routes/feed[.]json'
+import { Route as ContactRouteImport } from './routes/contact'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as DocsChar123Char125DotmdRouteImport } from './routes/docs/{$}[.]md'
@@ -58,6 +60,16 @@ const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
 const FeedDotjsonRoute = FeedDotjsonRouteImport.update({
   id: '/feed.json',
   path: '/feed.json',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ContactRoute = ContactRouteImport.update({
+  id: '/contact',
+  path: '/contact',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
 const IndexRoute = IndexRouteImport.update({
@@ -103,6 +115,8 @@ const OgBlogSplatRoute = OgBlogSplatRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/contact': typeof ContactRoute
   '/feed.json': typeof FeedDotjsonRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
@@ -120,6 +134,8 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/contact': typeof ContactRoute
   '/feed.json': typeof FeedDotjsonRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
@@ -138,6 +154,8 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
+  '/contact': typeof ContactRoute
   '/feed.json': typeof FeedDotjsonRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
   '/llms.txt': typeof LlmsDottxtRoute
@@ -157,6 +175,8 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/about'
+    | '/contact'
     | '/feed.json'
     | '/llms-full.txt'
     | '/llms.txt'
@@ -174,6 +194,8 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/about'
+    | '/contact'
     | '/feed.json'
     | '/llms-full.txt'
     | '/llms.txt'
@@ -191,6 +213,8 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/about'
+    | '/contact'
     | '/feed.json'
     | '/llms-full.txt'
     | '/llms.txt'
@@ -209,6 +233,8 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AboutRoute: typeof AboutRoute
+  ContactRoute: typeof ContactRoute
   FeedDotjsonRoute: typeof FeedDotjsonRoute
   LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
@@ -276,6 +302,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof FeedDotjsonRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/contact': {
+      id: '/contact'
+      path: '/contact'
+      fullPath: '/contact'
+      preLoaderRoute: typeof ContactRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -337,6 +377,8 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AboutRoute: AboutRoute,
+  ContactRoute: ContactRoute,
   FeedDotjsonRoute: FeedDotjsonRoute,
   LlmsFullDottxtRoute: LlmsFullDottxtRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,

--- a/apps/fumadocs/src/routes/__root.tsx
+++ b/apps/fumadocs/src/routes/__root.tsx
@@ -39,7 +39,7 @@ export const Route = createRootRoute({
 
 function RootComponent() {
   return (
-    <html suppressHydrationWarning>
+    <html lang="en" suppressHydrationWarning>
       <head>
         <script
           // Browser translation/extensions can mutate React-owned DOM before hydration finishes.

--- a/apps/fumadocs/src/routes/about.tsx
+++ b/apps/fumadocs/src/routes/about.tsx
@@ -1,0 +1,123 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+import type { ReactNode } from "react";
+
+import { DocsVersionLink } from "@/components/docs-version-link";
+import { baseOptions } from "@/lib/layout.shared";
+import { appName, siteUrl } from "@/lib/shared";
+
+export const Route = createFileRoute("/about")({
+  head: () => ({
+    meta: [
+      { title: `About - ${appName}` },
+      {
+        name: "description",
+        content:
+          "About Email SDK — an open-source TypeScript SDK that sends transactional email through 20+ providers behind one typed API, maintained by OpenCore.",
+      },
+      { property: "og:title", content: `About - ${appName}` },
+      {
+        property: "og:description",
+        content:
+          "What Email SDK is, why it exists, and who maintains it — one typed email API across Resend, SMTP, Postmark, SendGrid, AWS SES, and more.",
+      },
+      { property: "og:url", content: `${siteUrl}/about` },
+    ],
+    links: [{ rel: "canonical", href: `${siteUrl}/about` }],
+  }),
+  component: About,
+});
+
+function About() {
+  return (
+    <HomeLayout {...baseOptions()}>
+      <main className="border-b border-fd-border bg-fd-background text-fd-foreground">
+        <article className="mx-auto max-w-3xl px-6 py-14 md:px-10 lg:px-14">
+          <p className="text-sm font-medium text-fd-muted-foreground">About</p>
+          <h1 className="mt-3 text-4xl font-medium leading-tight md:text-5xl">About Email SDK</h1>
+          <p className="mt-5 text-base leading-7 text-fd-muted-foreground md:text-lg">
+            Email SDK is an open-source TypeScript SDK for sending transactional email. It gives an
+            application one typed client and one message shape, then routes each send to providers
+            such as Resend, SMTP, Postmark, SendGrid, Mailgun, Unosend, AWS SES, and more.
+          </p>
+
+          <div className="mt-10 space-y-9 text-sm leading-7 text-fd-muted-foreground md:text-base">
+            <AboutSection title="What it is">
+              A single <code>send()</code> call with one normalized <code>EmailMessage</code> shape.
+              Provider-specific behavior lives in adapters imported from their own entry points, so
+              switching or adding a provider does not mean rewriting every place your app sends
+              mail. The core ships with zero dependencies and includes its own SMTP transport.
+            </AboutSection>
+
+            <AboutSection title="Why it exists">
+              Most applications start on one email provider and later need a second one for
+              deliverability, cost, or regional routing. Email SDK keeps provider differences behind
+              a consistent API with explicit routing, automatic retries on transient failures, and
+              fallback routes between adapters that support the same fields — so changing providers
+              is a configuration change, not a refactor.
+            </AboutSection>
+
+            <AboutSection title="Who maintains it">
+              Email SDK is built and maintained by{" "}
+              <a
+                className="text-fd-primary underline-offset-4 hover:underline"
+                href="https://opencore.dev"
+                rel="noreferrer"
+                target="_blank"
+              >
+                OpenCore
+              </a>{" "}
+              as an open-source project. The source, issues, and releases are public on{" "}
+              <a
+                className="text-fd-primary underline-offset-4 hover:underline"
+                href="https://github.com/opencoredev/email-sdk"
+                rel="noreferrer"
+                target="_blank"
+              >
+                GitHub
+              </a>
+              , and the package is published to{" "}
+              <a
+                className="text-fd-primary underline-offset-4 hover:underline"
+                href="https://www.npmjs.com/package/@opencoredev/email-sdk"
+                rel="noreferrer"
+                target="_blank"
+              >
+                npm
+              </a>
+              .
+            </AboutSection>
+
+            <AboutSection title="Where to go next">
+              Read the{" "}
+              <DocsVersionLink className="text-fd-primary underline-offset-4 hover:underline">
+                documentation
+              </DocsVersionLink>{" "}
+              to install the package and send your first email, browse the{" "}
+              <DocsVersionLink
+                className="text-fd-primary underline-offset-4 hover:underline"
+                docsPath="/docs/adapters"
+              >
+                adapters
+              </DocsVersionLink>{" "}
+              for each provider, or get in touch through the{" "}
+              <Link className="text-fd-primary underline-offset-4 hover:underline" to="/contact">
+                contact page
+              </Link>
+              .
+            </AboutSection>
+          </div>
+        </article>
+      </main>
+    </HomeLayout>
+  );
+}
+
+function AboutSection({ children, title }: { children: ReactNode; title: string }) {
+  return (
+    <section className="border-t border-fd-border pt-6">
+      <h2 className="text-xl font-medium text-fd-foreground">{title}</h2>
+      <p className="mt-3">{children}</p>
+    </section>
+  );
+}

--- a/apps/fumadocs/src/routes/contact.tsx
+++ b/apps/fumadocs/src/routes/contact.tsx
@@ -1,0 +1,128 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { HomeLayout } from "fumadocs-ui/layouts/home";
+import type { ReactNode } from "react";
+
+import { baseOptions } from "@/lib/layout.shared";
+import { appName, gitConfig, siteUrl } from "@/lib/shared";
+
+const repoUrl = `https://github.com/${gitConfig.user}/${gitConfig.repo}`;
+
+export const Route = createFileRoute("/contact")({
+  head: () => ({
+    meta: [
+      { title: `Contact - ${appName}` },
+      {
+        name: "description",
+        content:
+          "Contact the Email SDK project — report bugs, ask questions, disclose security issues, or sponsor development through GitHub.",
+      },
+      { property: "og:title", content: `Contact - ${appName}` },
+      {
+        property: "og:description",
+        content:
+          "How to reach the Email SDK project: GitHub issues for bugs, discussions for questions, private security reports, and sponsorship.",
+      },
+      { property: "og:url", content: `${siteUrl}/contact` },
+    ],
+    links: [{ rel: "canonical", href: `${siteUrl}/contact` }],
+  }),
+  component: Contact,
+});
+
+function Contact() {
+  return (
+    <HomeLayout {...baseOptions()}>
+      <main className="border-b border-fd-border bg-fd-background text-fd-foreground">
+        <article className="mx-auto max-w-3xl px-6 py-14 md:px-10 lg:px-14">
+          <p className="text-sm font-medium text-fd-muted-foreground">Contact</p>
+          <h1 className="mt-3 text-4xl font-medium leading-tight md:text-5xl">Contact</h1>
+          <p className="mt-5 text-base leading-7 text-fd-muted-foreground md:text-lg">
+            Email SDK is an open-source project maintained by OpenCore. The fastest way to reach the
+            maintainers is on GitHub — issues and discussions are public, so others benefit from the
+            answer too.
+          </p>
+
+          <div className="mt-10 space-y-9 text-sm leading-7 text-fd-muted-foreground md:text-base">
+            <ContactSection title="Bugs and feature requests">
+              Open an issue at{" "}
+              <a
+                className="text-fd-primary underline-offset-4 hover:underline"
+                href={`${repoUrl}/issues`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                github.com/{gitConfig.user}/{gitConfig.repo}/issues
+              </a>
+              . Include the package version, the adapter involved, and a minimal reproduction so the
+              problem can be confirmed quickly.
+            </ContactSection>
+
+            <ContactSection title="Questions and usage help">
+              Start a thread in{" "}
+              <a
+                className="text-fd-primary underline-offset-4 hover:underline"
+                href={`${repoUrl}/discussions`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                GitHub Discussions
+              </a>
+              . For integration patterns, check the{" "}
+              <a className="text-fd-primary underline-offset-4 hover:underline" href="/docs">
+                documentation
+              </a>{" "}
+              first — most setup and adapter questions are answered there.
+            </ContactSection>
+
+            <ContactSection title="Security reports">
+              Please do not file public issues for vulnerabilities. Report them privately through{" "}
+              <a
+                className="text-fd-primary underline-offset-4 hover:underline"
+                href={`${repoUrl}/security/advisories/new`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                GitHub security advisories
+              </a>{" "}
+              so a fix can ship before disclosure.
+            </ContactSection>
+
+            <ContactSection title="Sponsorship">
+              If Email SDK saves your team time, you can support ongoing maintenance through{" "}
+              <a
+                className="text-fd-primary underline-offset-4 hover:underline"
+                href={`https://github.com/sponsors/${gitConfig.user}`}
+                rel="noreferrer"
+                target="_blank"
+              >
+                GitHub Sponsors
+              </a>
+              .
+            </ContactSection>
+
+            <ContactSection title="More about the project">
+              Learn what Email SDK is and who maintains it on the{" "}
+              <Link className="text-fd-primary underline-offset-4 hover:underline" to="/about">
+                about page
+              </Link>
+              , and review how this site handles data in the{" "}
+              <Link className="text-fd-primary underline-offset-4 hover:underline" to="/privacy">
+                privacy policy
+              </Link>
+              .
+            </ContactSection>
+          </div>
+        </article>
+      </main>
+    </HomeLayout>
+  );
+}
+
+function ContactSection({ children, title }: { children: ReactNode; title: string }) {
+  return (
+    <section className="border-t border-fd-border pt-6">
+      <h2 className="text-xl font-medium text-fd-foreground">{title}</h2>
+      <p className="mt-3">{children}</p>
+    </section>
+  );
+}

--- a/apps/fumadocs/src/routes/llms-full[.]txt.ts
+++ b/apps/fumadocs/src/routes/llms-full[.]txt.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import { appName, llmsOverview } from "@/lib/shared";
 import { source, getLLMText } from "@/lib/source";
 
 export const Route = createFileRoute("/llms-full.txt")({
@@ -8,7 +9,11 @@ export const Route = createFileRoute("/llms-full.txt")({
       GET: async () => {
         const scan = source.getPages().map((page) => getLLMText(page));
         const scanned = await Promise.all(scan);
-        return new Response(scanned.join("\n\n"));
+        const body = `# ${appName}\n\n${llmsOverview}\n\n---\n\n${scanned.join("\n\n")}`;
+
+        return new Response(body, {
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
       },
     },
   },

--- a/apps/fumadocs/src/routes/llms[.]txt.ts
+++ b/apps/fumadocs/src/routes/llms[.]txt.ts
@@ -1,13 +1,23 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { llms } from "fumadocs-core/source";
 
+import { appName, llmsOverview } from "@/lib/shared";
 import { source } from "@/lib/source";
 
 export const Route = createFileRoute("/llms.txt")({
   server: {
     handlers: {
       GET() {
-        return new Response(llms(source).index());
+        // Replace the generated H1 with an enriched header: short description,
+        // overview, and agent constraints, then the documentation index.
+        const index = llms(source)
+          .index()
+          .replace(/^#[^\n]*\r?\n+/, "");
+        const body = `# ${appName}\n\n${llmsOverview}\n\n## Documentation\n\n${index}`;
+
+        return new Response(body, {
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
       },
     },
   },

--- a/apps/fumadocs/src/routes/sitemap[.]xml.ts
+++ b/apps/fumadocs/src/routes/sitemap[.]xml.ts
@@ -47,6 +47,18 @@ function getSitemapEntries() {
       priority: "0.8",
     },
     {
+      loc: `${siteUrl}/about`,
+      lastmod: "2026-06-01",
+      changefreq: "monthly",
+      priority: "0.5",
+    },
+    {
+      loc: `${siteUrl}/contact`,
+      lastmod: "2026-06-01",
+      changefreq: "monthly",
+      priority: "0.5",
+    },
+    {
       loc: `${siteUrl}/privacy`,
       lastmod: "2026-06-01",
       changefreq: "monthly",

--- a/apps/fumadocs/vite.config.ts
+++ b/apps/fumadocs/vite.config.ts
@@ -72,12 +72,14 @@ export default defineConfig(({ mode }) => {
       mdx(),
       tailwindcss(),
       tanstackStart({
-        spa: {
+        // Full static prerendering (SSG), not SPA mode. SPA mode reserves "/" for the
+        // pending-fallback shell and ships an empty <body> at the root — invisible to AI
+        // crawlers and search engines. Top-level prerender renders every route, including
+        // the homepage, to static HTML with real content; the client still hydrates for
+        // interactivity (provider switcher, search, theme toggle).
+        prerender: {
           enabled: true,
-          prerender: {
-            enabled: true,
-            crawlLinks: true,
-          },
+          crawlLinks: true,
         },
 
         pages: [
@@ -89,6 +91,12 @@ export default defineConfig(({ mode }) => {
           },
           {
             path: "/blog",
+          },
+          {
+            path: "/about",
+          },
+          {
+            path: "/contact",
           },
           {
             path: "/privacy",


### PR DESCRIPTION
## TL;DR

Add machine-readable support for AI agents and coding assistants by creating agent-skills configuration and guide, expand robots.txt to welcome AI crawlers while blocking bulk scrapers, and enhance structured data with organization details and provider support enumeration.

## What changed?

- **New agent integration files:**
  - Added `.well-known/agent-skills` JSON configuration exposing Email SDK skills and tools for AI agents, including the `send_email` tool with schema and approval requirements
  - Added `agents.md` guide with installation instructions, use cases, constraints, and provider list for machine-facing documentation

- **Enhanced robots.txt:**
  - Added descriptive comments explaining crawler policies
  - Expanded allowlist to explicitly welcome AI assistants and answer engines (GPTBot, OAI-SearchBot, ClaudeBot, Claude-User, Claude-SearchBot, PerplexityBot, Perplexity-User, Google-Extended)
  - Added disallowlist for bulk training-data scrapers without user-facing products (CCBot, Bytespider, Diffbot, Omgilibot, ImagesiftBot)

- **Improved structured data (metadata.ts):**
  - Added `sameAs` links to GitHub and npm package for brand disambiguation
  - Added `ContactPoint` structured data for technical support via GitHub issues
  - Added `ItemList` schema enumerating all 20+ supported email providers for agent resolution without parsing prose

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*