### PR TITLE
Update Homebrew formula for 0.6.2

### DIFF
--- a/Formula/email-sdk.rb
+++ b/Formula/email-sdk.rb
@@ -1,8 +1,8 @@
 class EmailSdk < Formula
   desc "Lightweight TypeScript SDK and CLI for unified email sending"
   homepage "https://github.com/opencoredev/email-sdk"
-  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.6.1.tgz"
-  sha256 "6504a3446ddaf9b7e75c200f1a515f04c68d2c2a52015ddea61dbf2046fc5eb5"
+  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.6.2.tgz"
+  sha256 "a87e9442ea314959eacea04b9301cd894c217c4553116919e8b876cd01cf2438"
   license "MIT"
 
   depends_on "bun"


### PR DESCRIPTION
Updates the Homebrew formula to the published `@opencoredev/email-sdk@0.6.2` npm tarball (URL + sha256). Auto-pushed by the release workflow; opening the PR here since the CI token can't create PRs directly.

Generated-By: PostHog Code
Task-Id: 2fce2016-dc39-453b-ab4d-9edb97bcfc9d

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*