### PR TITLE
chore(docs): mark JetEmail as a sponsor on the adapters page

### DIFF
--- a/apps/fumadocs/src/lib/providers.ts
+++ b/apps/fumadocs/src/lib/providers.ts
@@ -234,6 +234,7 @@ export const providers = [
     status: "Official",
     testStatus: "Request tested",
     apiStatus: "API tested",
+    sponsorship: "Sponsor",
     currentOnly: true,
   },
   {


### PR DESCRIPTION
## Summary

JetEmail sponsors the project, so flag its provider entry with `sponsorship: "Sponsor"` (like Resend and Sequenzy). This ranks it alongside the other sponsors in the provider grid and marks it as a sponsor on the adapters page.

The website `SponsorSpotlight` stays manually curated (it has its own list and does not read this flag), so the website sponsor showcase is unchanged.

Follow-up to #94. JetEmail's `apiStatus` is **API tested**, now backed by real delivery from the verified `jetemail.email-sdk.dev` domain — confirmed via both the transactional API adapter and the SMTP relay.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*