### PR TITLE
fix(docs): release 0.6.3 (patch) and make "latest" docs follow new releases

### DIFF
--- a/.changeset/jetemail-adapter.md
+++ b/.changeset/jetemail-adapter.md
@@ -1,5 +1,5 @@
 ---
-"@opencoredev/email-sdk": minor
+"@opencoredev/email-sdk": patch
 ---
 
 Add the JetEmail adapter (`@opencoredev/email-sdk/jetemail`) for the JetEmail transactional email API. It maps CC, BCC, reply-to, custom headers, and base64 attachments, forwards `idempotencyKey` as JetEmail's `Idempotency-Key` header, and fails fast with a clear error when `from` is missing a display name (JetEmail requires the `"Name <email>"` form). Tags and metadata are rejected before the request, consistent with the SDK's fail-fast field support.

--- a/apps/fumadocs/src/lib/docs-version-state.ts
+++ b/apps/fumadocs/src/lib/docs-version-state.ts
@@ -6,7 +6,7 @@ import {
   docsVersionStorageKey,
   getDocsVersionByStoredValue,
   getDocsVersionFromPathname,
-  getDocsVersionSlug,
+  getDocsVersionStorageValue,
   latestDocsVersion,
 } from "./versions";
 
@@ -27,7 +27,7 @@ function readStoredDocsVersion() {
 export function rememberDocsVersion(version: DocsVersion) {
   if (typeof window === "undefined") return;
 
-  window.localStorage.setItem(docsVersionStorageKey, getDocsVersionSlug(version));
+  window.localStorage.setItem(docsVersionStorageKey, getDocsVersionStorageValue(version));
   window.dispatchEvent(new CustomEvent(docsVersionChangeEvent));
 }
 

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -102,11 +102,21 @@ export function getDocsVersionBySlug(slug: string) {
 export function getDocsVersionByStoredValue(value: string | null | undefined) {
   if (!value) return undefined;
 
+  // "latest" tracks whichever version is current, so readers on latest move
+  // forward when a new version ships; a specific slug stays pinned.
+  if (value === "latest") return latestDocsVersion;
+
   return getDocsVersionBySlug(value.replace(/^v/, ""));
 }
 
 export function getDocsVersionSlug(version: DocsVersion) {
   return version.version.replace(/^v/, "");
+}
+
+export function getDocsVersionStorageValue(version: DocsVersion) {
+  // Persist the current version as "latest" so a reader on latest tracks future
+  // releases instead of pinning to today's version number.
+  return version.current ? "latest" : getDocsVersionSlug(version);
 }
 
 export function getDocsVersionBase(version: DocsVersion) {


### PR DESCRIPTION
## Summary

Two release-prep changes:

1. **Version 0.6.3, not 0.7.0.** Flips the JetEmail changeset to a `patch` bump so the next release is `0.6.2 → 0.6.3`.
2. **"Latest" docs follow new releases.** The docs version switcher now persists a `"latest"` sentinel when the current version is selected (instead of today's version number), and resolves `"latest"` to whatever version is current. Result:
   - A reader on **latest** automatically moves to the new version when one ships.
   - A reader **pinned** to a specific version (e.g. `0.6.2`) stays on it.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*