### PR TITLE
Update Homebrew formula for 0.6.3

### DIFF
--- a/Formula/email-sdk.rb
+++ b/Formula/email-sdk.rb
@@ -1,8 +1,8 @@
 class EmailSdk < Formula
   desc "Lightweight TypeScript SDK and CLI for unified email sending"
   homepage "https://github.com/opencoredev/email-sdk"
-  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.6.2.tgz"
-  sha256 "a87e9442ea314959eacea04b9301cd894c217c4553116919e8b876cd01cf2438"
+  url "https://registry.npmjs.org/@opencoredev/email-sdk/-/email-sdk-0.6.3.tgz"
+  sha256 "c005331a4d896f0f6327c529eaa740ab207d5e8a77cbd0995e978567cb0c4e0f"
   license "AGPL-3.0-only"
 
   depends_on "bun"


### PR DESCRIPTION
Updates the Homebrew formula checksum to the published `@opencoredev/email-sdk@0.6.3` npm tarball (opened automatically by the release pipeline).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*