### PR TITLE
chore(docs): track Sequenzy sponsor referrals with ?ref=emailsdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Email SDK is supported by companies that help keep provider integrations practic
 
 <!-- Sequenzy sponsors outside GitHub Sponsors, so it can't appear in the auto grid above and is listed manually here. -->
 <p align="center">
-  <a href="https://www.sequenzy.com/"><img src="./apps/fumadocs/public/og/provider-logos/sequenzy.jpeg" width="56" height="56" alt="Sequenzy logo"></a><br>
-  <sub>Also sponsored by <a href="https://www.sequenzy.com/"><b>Sequenzy</b></a> · <a href="https://email-sdk.dev/docs/adapters/sequenzy">adapter docs</a></sub>
+  <a href="https://www.sequenzy.com/?ref=emailsdk"><img src="./apps/fumadocs/public/og/provider-logos/sequenzy.jpeg" width="56" height="56" alt="Sequenzy logo"></a><br>
+  <sub>Also sponsored by <a href="https://www.sequenzy.com/?ref=emailsdk"><b>Sequenzy</b></a> · <a href="https://email-sdk.dev/docs/adapters/sequenzy">adapter docs</a></sub>
 </p>
 
 ## Star History

--- a/apps/fumadocs/src/components/sponsors.tsx
+++ b/apps/fumadocs/src/components/sponsors.tsx
@@ -12,7 +12,7 @@ const sponsors = [
   },
   {
     name: "Sequenzy",
-    href: "https://www.sequenzy.com/",
+    href: "https://www.sequenzy.com/?ref=emailsdk",
     logo: "/og/provider-logos/sequenzy.jpeg",
   },
   {


### PR DESCRIPTION
## What

Adds the `?ref=emailsdk` referral marker to Sequenzy's outbound sponsor links so Sequenzy can attribute clickthroughs coming from Email SDK.

## Where

| Surface | File | Link |
| --- | --- | --- |
| Docs homepage sponsor spotlight | `apps/fumadocs/src/components/sponsors.tsx` | `https://www.sequenzy.com/?ref=emailsdk` |
| README sponsor block (logo + name) | `README.md` | `https://www.sequenzy.com/?ref=emailsdk` |

## Left untouched (intentional)

- `apps/fumadocs/src/lib/providers.ts` adapters-catalog `website` link — kept plain, matching the Resend precedent (Resend's tracked link lives only in the spotlight; its catalog website stays plain `resend.com`).
- The internal `email-sdk.dev/docs/adapters/sequenzy` docs link and the `api.sequenzy.com/api/v1` API endpoints.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
