### PR TITLE
feat(docs): agent-readiness discovery surface for email-sdk.dev

### DIFF
--- a/apps/fumadocs/content/docs/authentication.mdx
+++ b/apps/fumadocs/content/docs/authentication.mdx
@@ -1,0 +1,137 @@
+---
+title: Authentication
+description: How Email SDK authenticates to every provider — there is no platform account, you supply each provider's own credential from an environment variable.
+icon: KeyRound
+---
+
+Email SDK is a library, not a hosted service. **There is no Email SDK account, API
+key, or OAuth flow.** You authenticate to each email provider with *that provider's*
+own credential, which you read from an environment variable and pass to the
+adapter. The adapter sets the provider's required auth header (or signs the request)
+for you.
+
+<Callout type="info">
+  One typed client, many providers: the only thing that changes between providers
+  is the factory you import and the credential you give it. For an agent-facing
+  summary of this model see [/auth.md](https://email-sdk.dev/auth.md).
+</Callout>
+
+## How credentials flow
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+export const email = createEmailClient({
+  // The credential comes from your environment, never from email-sdk.dev.
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+Each adapter is imported from its own entry point (`@opencoredev/email-sdk/<name>`)
+and takes the fields that provider needs. Most providers use a single API key; a
+few add a routing id, use a key pair, or sign requests.
+
+## Credential by provider
+
+| Provider | Import | Credential model | Required config → environment variable |
+| --- | --- | --- | --- |
+| Resend | `@opencoredev/email-sdk/resend` | API key | `apiKey` → `RESEND_API_KEY` |
+| Postmark | `@opencoredev/email-sdk/postmark` | Server token | `serverToken` → `POSTMARK_SERVER_TOKEN` |
+| SendGrid | `@opencoredev/email-sdk/sendgrid` | API key | `apiKey` → `SENDGRID_API_KEY` |
+| Cloudflare | `@opencoredev/email-sdk/cloudflare` | API token + account | `apiToken` → `CLOUDFLARE_API_TOKEN`, `accountId` → `CLOUDFLARE_ACCOUNT_ID` |
+| Unosend | `@opencoredev/email-sdk/unosend` | API key | `apiKey` → `UNOSEND_API_KEY` |
+| AWS SES | `@opencoredev/email-sdk/ses` | Access key pair (SigV4) | `accessKeyId` → `AWS_ACCESS_KEY_ID`, `secretAccessKey` → `AWS_SECRET_ACCESS_KEY`, `region` → `AWS_REGION` (optional `sessionToken` → `AWS_SESSION_TOKEN`) |
+| Mailgun | `@opencoredev/email-sdk/mailgun` | API key + domain | `apiKey` → `MAILGUN_API_KEY`, `domain` → `MAILGUN_DOMAIN` |
+| MailerSend | `@opencoredev/email-sdk/mailersend` | API key | `apiKey` → `MAILERSEND_API_KEY` |
+| Brevo | `@opencoredev/email-sdk/brevo` | API key | `apiKey` → `BREVO_API_KEY` |
+| Mailchimp Transactional | `@opencoredev/email-sdk/mailchimp` | API key | `apiKey` → `MAILCHIMP_API_KEY` |
+| SparkPost | `@opencoredev/email-sdk/sparkpost` | API key | `apiKey` → `SPARKPOST_API_KEY` |
+| Iterable | `@opencoredev/email-sdk/iterable` | API key + campaign | `apiKey` → `ITERABLE_API_KEY`, `campaignId` → `ITERABLE_CAMPAIGN_ID` |
+| Loops | `@opencoredev/email-sdk/loops` | API key + transactional id | `apiKey` → `LOOPS_API_KEY`, `transactionalId` → `LOOPS_TRANSACTIONAL_ID` |
+| Sequenzy | `@opencoredev/email-sdk/sequenzy` | API key | `apiKey` → `SEQUENZY_API_KEY` |
+| JetEmail | `@opencoredev/email-sdk/jetemail` | API key | `apiKey` → `JETEMAIL_API_KEY` |
+| Lettermint | `@opencoredev/email-sdk/lettermint` | API token | `apiToken` → `LETTERMINT_API_TOKEN` |
+| Primitive | `@opencoredev/email-sdk/primitive` | API key | `apiKey` → `PRIMITIVE_API_KEY` |
+| Plunk | `@opencoredev/email-sdk/plunk` | API key | `apiKey` → `PLUNK_API_KEY` |
+| Mailtrap | `@opencoredev/email-sdk/mailtrap` | API key | `apiKey` → `MAILTRAP_API_KEY` |
+| Scaleway | `@opencoredev/email-sdk/scaleway` | Project id + secret key | `projectId` → `SCALEWAY_PROJECT_ID`, `secretKey` → `SCALEWAY_SECRET_KEY`, `region` |
+| ZeptoMail | `@opencoredev/email-sdk/zeptomail` | Send-mail token | `token` → `ZEPTOMAIL_TOKEN` |
+| MailPace | `@opencoredev/email-sdk/mailpace` | API key | `apiKey` → `MAILPACE_API_KEY` |
+| SMTP | `@opencoredev/email-sdk/smtp` | SMTP username + password | `host`, `port`, `secure`, `auth: { user, pass }` → `SMTP_USER`, `SMTP_PASS` |
+
+Each provider page under [Adapters](/docs/adapters) links to where that credential
+is issued and lists every configuration field.
+
+## SMTP
+
+SMTP is the one adapter that does not take an API key. It connects to a mail server
+with a host, port, and username/password — the SDK ships its own SMTP transport, so
+you do **not** add Nodemailer.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+export const email = createEmailClient({
+  adapters: [
+    smtp({
+      host: "smtp.example.com",
+      port: 587,
+      secure: false,
+      auth: { user: process.env.SMTP_USER!, pass: process.env.SMTP_PASS! },
+    }),
+  ],
+});
+```
+
+## Optional configuration
+
+Beyond credentials, every adapter accepts the same optional fields:
+
+- `baseUrl` — override the provider's API origin (for a proxy or region endpoint).
+- `headers` — extra HTTP headers sent with every request.
+- `fetch` — a custom `fetch` implementation for tests or special runtimes.
+
+## Multiple providers and fallbacks
+
+Pass several configured adapters to route across them. Only configure a fallback
+between adapters that support the same fields — see
+[Field support](/docs/adapters/field-support).
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { ses } from "@opencoredev/email-sdk/ses";
+
+export const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    ses({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      region: process.env.AWS_REGION!,
+    }),
+  ],
+  retry: { retries: 1 },
+});
+```
+
+## Keeping credentials safe
+
+<Callout type="warn">
+  Keep every credential in environment variables or a secret manager. Never
+  hardcode or log API keys, SMTP passwords, raw tokens, full message bodies, or
+  recipient lists. When an agent drives sends, gate them behind explicit human
+  approval and run `email-sdk doctor` and `send --dry-run` first.
+</Callout>
+
+- Scope each provider key to sending only, where the provider supports it.
+- Rotate or revoke credentials in the provider's own dashboard, then update the
+  environment variable — Email SDK holds no session or token state of its own.
+- Use [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys)
+  for externally visible sends that may be retried.
+
+## Per-provider setup
+
+<ProviderGrid />

--- a/apps/fumadocs/content/docs/authentication.mdx
+++ b/apps/fumadocs/content/docs/authentication.mdx
@@ -55,7 +55,7 @@ few add a routing id, use a key pair, or sign requests.
 | Primitive | `@opencoredev/email-sdk/primitive` | API key | `apiKey` → `PRIMITIVE_API_KEY` |
 | Plunk | `@opencoredev/email-sdk/plunk` | API key | `apiKey` → `PLUNK_API_KEY` |
 | Mailtrap | `@opencoredev/email-sdk/mailtrap` | API key | `apiKey` → `MAILTRAP_API_KEY` |
-| Scaleway | `@opencoredev/email-sdk/scaleway` | Project id + secret key | `projectId` → `SCALEWAY_PROJECT_ID`, `secretKey` → `SCALEWAY_SECRET_KEY`, `region` |
+| Scaleway | `@opencoredev/email-sdk/scaleway` | Project id + secret key | `projectId` → `SCALEWAY_PROJECT_ID`, `secretKey` → `SCALEWAY_SECRET_KEY` (optional `region`, defaults to `fr-par`) |
 | ZeptoMail | `@opencoredev/email-sdk/zeptomail` | Send-mail token | `token` → `ZEPTOMAIL_TOKEN` |
 | MailPace | `@opencoredev/email-sdk/mailpace` | API key | `apiKey` → `MAILPACE_API_KEY` |
 | SMTP | `@opencoredev/email-sdk/smtp` | SMTP username + password | `host`, `port`, `secure`, `auth: { user, pass }` → `SMTP_USER`, `SMTP_PASS` |

--- a/apps/fumadocs/content/docs/meta.json
+++ b/apps/fumadocs/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "getting-started",
+    "authentication",
     "concepts",
     "adapters",
     "plugins",

--- a/apps/fumadocs/public/.well-known/agent.json
+++ b/apps/fumadocs/public/.well-known/agent.json
@@ -1,0 +1,55 @@
+{
+  "schemaVersion": "1.0",
+  "name": "Email SDK",
+  "description": "Open-source TypeScript SDK that sends transactional email through 20+ providers (Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare Email Sending, Unosend, AWS SES, and more) behind one typed send() call, with retries and compatible fallbacks. It is a library you install into an app, not a hosted API.",
+  "productType": "sdk",
+  "homepage": "https://email-sdk.dev",
+  "documentation": "https://email-sdk.dev/docs",
+  "guide": "https://email-sdk.dev/agents.md",
+  "instructions": "Email SDK is a TypeScript/JavaScript library, not a hosted service. There is no API to call and no credentials to obtain from us — install the npm package and bring the provider keys the app already has. Use it to send transactional email behind one typed client. Read /agents.md for when-to-use guidance and /auth.md for the authentication model. Gate any agent-initiated send behind explicit human approval and run `email-sdk doctor` and `send --dry-run` before live sends.",
+  "machineResources": {
+    "llmsTxt": "https://email-sdk.dev/llms.txt",
+    "llmsFullTxt": "https://email-sdk.dev/llms-full.txt",
+    "markdownHome": "https://email-sdk.dev/index.md",
+    "authModel": "https://email-sdk.dev/auth.md",
+    "apiCatalog": "https://email-sdk.dev/.well-known/api-catalog",
+    "schemaFeed": "https://email-sdk.dev/feeds/docs.jsonl"
+  },
+  "authentication": {
+    "type": "none",
+    "description": "Email SDK exposes no hosted API and issues no credentials. You provide each email provider's API key (or SMTP credentials) through environment variables in your own application."
+  },
+  "distribution": {
+    "npm": "@opencoredev/email-sdk",
+    "repository": "https://github.com/opencoredev/email-sdk",
+    "cli": "email-sdk"
+  },
+  "capabilities": [
+    "Send transactional email through one typed client across 20+ providers",
+    "Retry transient failures and fall back across compatible adapters",
+    "Expose a guarded send_email tool to LLM agents",
+    "Run local configuration checks and dry-run sends via the email-sdk CLI"
+  ],
+  "skills": [
+    {
+      "name": "email-sdk",
+      "description": "Use when adding, reviewing, or documenting Email SDK integrations in TypeScript/Bun apps. Covers adapter selection, fallbacks, CLI smoke tests, hooks, and secret-safe observability.",
+      "install": "npx skills add opencoredev/email-sdk --skill email-sdk",
+      "source": "https://github.com/opencoredev/email-sdk/blob/main/skills/email-sdk/SKILL.md"
+    }
+  ],
+  "tools": [
+    {
+      "name": "send_email",
+      "description": "Send a transactional email through the app's configured Email SDK client. Requires from, to, and subject; optional html, text, adapter, and provider. Runs the full validate/retry/fallback pipeline.",
+      "package": "@opencoredev/email-sdk/agent-tools",
+      "factory": "createEmailAgentTools",
+      "documentation": "https://email-sdk.dev/docs/agents/skill",
+      "requiresApproval": true
+    }
+  ],
+  "contact": {
+    "type": "technical support",
+    "url": "https://github.com/opencoredev/email-sdk/issues"
+  }
+}

--- a/apps/fumadocs/public/.well-known/api-catalog
+++ b/apps/fumadocs/public/.well-known/api-catalog
@@ -1,0 +1,22 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://email-sdk.dev/",
+      "service-desc": [
+        { "href": "https://email-sdk.dev/llms.txt", "type": "text/plain" },
+        { "href": "https://email-sdk.dev/llms-full.txt", "type": "text/plain" }
+      ],
+      "service-doc": [
+        { "href": "https://email-sdk.dev/docs", "type": "text/html" },
+        { "href": "https://email-sdk.dev/docs/llms.txt", "type": "text/plain" },
+        { "href": "https://email-sdk.dev/agents.md", "type": "text/markdown" }
+      ],
+      "service-meta": [
+        { "href": "https://email-sdk.dev/.well-known/agent.json", "type": "application/json" },
+        { "href": "https://email-sdk.dev/.well-known/agent-skills", "type": "application/json" },
+        { "href": "https://email-sdk.dev/auth.md", "type": "text/markdown" },
+        { "href": "https://email-sdk.dev/feeds/docs.jsonl", "type": "application/x-ndjson" }
+      ]
+    }
+  ]
+}

--- a/apps/fumadocs/public/agents.md
+++ b/apps/fumadocs/public/agents.md
@@ -56,8 +56,8 @@ await email.send({
 Adapters import from their own entry point (`@opencoredev/email-sdk/resend`,
 `/smtp`, `/ses`, …). Supported providers: Resend, SMTP, Postmark, SendGrid,
 Mailgun, Cloudflare Email Sending, Unosend, AWS SES, MailerSend, Brevo, Mailchimp
-Transactional, SparkPost, Iterable, Loops, Sequenzy, Plunk, Mailtrap, Scaleway,
-ZeptoMail, and MailPace.
+Transactional, SparkPost, Iterable, Loops, Sequenzy, JetEmail, Primitive,
+Lettermint, Plunk, Mailtrap, Scaleway, ZeptoMail, and MailPace.
 
 ## Give an agent a send tool
 
@@ -76,6 +76,22 @@ Install it with:
 ```bash
 npx skills add opencoredev/email-sdk --skill email-sdk
 ```
+
+## Machine-readable endpoints
+
+Predictable URLs for programmatic discovery:
+
+- Agent discovery: https://email-sdk.dev/.well-known/agent.json
+- Authentication model: https://email-sdk.dev/auth.md (there is no hosted API or platform credential to obtain)
+- Per-provider credentials: https://email-sdk.dev/docs/authentication (every adapter's config field + env var in one table)
+- Markdown homepage: https://email-sdk.dev/index.md
+- Docs-scoped index: https://email-sdk.dev/docs/llms.txt
+- API catalog (RFC 9727): https://email-sdk.dev/.well-known/api-catalog
+- Schema feed (NLWeb): https://email-sdk.dev/schemamap.xml → https://email-sdk.dev/feeds/docs.jsonl
+- Skill descriptor: https://email-sdk.dev/.well-known/agent-skills
+
+Append `.md` to any documentation URL (for example `/docs/quickstart.md`) to fetch
+its raw markdown, or pass `?mode=agent` to the homepage for this guide.
 
 ## Constraints for agents
 

--- a/apps/fumadocs/public/auth.md
+++ b/apps/fumadocs/public/auth.md
@@ -1,0 +1,73 @@
+# Email SDK — Authentication for Agents
+
+This document tells an AI agent how authentication works for Email SDK. The short
+version: **there is nothing to authenticate against here.**
+
+Email SDK is an open-source TypeScript library (npm: `@opencoredev/email-sdk`)
+that you install into an application. It is **not** a hosted API and not a service
+you sign up for, so `email-sdk.dev` issues no API keys, tokens, or OAuth
+credentials. Do not probe this origin for `WWW-Authenticate`, `agent_auth`,
+`register_uri`, an authorization server, or an `id-jag` / `identity_assertion`
+handshake — none exist, by design.
+
+## Discover
+
+The credentials Email SDK uses are **the email provider's own credentials**
+(Resend, Postmark, SendGrid, Mailgun, AWS SES, SMTP, …), which the host
+application already holds. The SDK is a typed client in front of those providers.
+
+## Pick a method
+
+There is one method: configure each adapter with the provider key the app owns.
+
+- Read the provider key from an environment variable.
+- Pass it to the adapter at construction time.
+- The SDK never asks `email-sdk.dev` for anything at runtime.
+
+## Use the credential
+
+```ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+// RESEND_API_KEY is the provider's credential, supplied by the app — not by us.
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+To obtain a provider key, follow that provider's own dashboard and docs (for
+example, create a Resend API key in the Resend dashboard). Email SDK plays no part
+in issuing or exchanging it.
+
+## Errors
+
+Authentication failures surface as the **provider's** error (for example an
+invalid-API-key response from Resend or SES), normalized by the SDK and thrown
+from `send()`. There is no Email SDK auth endpoint to return `401` or a
+`resource_metadata` hint, because there is no Email SDK server in the request
+path.
+
+## Revocation
+
+Rotate or revoke credentials in the provider's dashboard, then update the
+environment variable the app reads. Email SDK holds no session or token state to
+revoke.
+
+## Safety for agents
+
+- Keep all provider keys in environment variables. Never hardcode or log API
+  keys, SMTP passwords, raw tokens, full message bodies, or recipient lists.
+- Gate any agent-initiated send behind explicit human approval.
+- Run `email-sdk doctor` and `send --dry-run` before any live send.
+
+## Per-provider credentials
+
+Each provider's required credential and environment variable is listed in one
+place at https://email-sdk.dev/docs/authentication (append `.md` for markdown:
+https://email-sdk.dev/docs/authentication.md). For example: Resend uses
+`apiKey` from `RESEND_API_KEY`, AWS SES uses `accessKeyId` / `secretAccessKey` /
+`region`, and SMTP uses `host` / `port` / `auth.user` / `auth.pass`.
+
+See also: the agent guide at https://email-sdk.dev/agents.md and the machine
+index at https://email-sdk.dev/llms.txt.

--- a/apps/fumadocs/public/robots.txt
+++ b/apps/fumadocs/public/robots.txt
@@ -2,6 +2,9 @@
 # Default: every well-behaved crawler may index the whole site.
 User-agent: *
 Allow: /
+# Content Signals (Cloudflare spec): allow search indexing and AI answer-engine
+# input/citation; disallow use of this content for AI model training.
+Content-Signal: search=yes, ai-input=yes, ai-train=no
 
 # AI assistants and answer engines that fetch on behalf of a user, drive traffic,
 # and cite sources are explicitly welcome.
@@ -52,3 +55,6 @@ User-agent: ImagesiftBot
 Disallow: /
 
 Sitemap: https://email-sdk.dev/sitemap.xml
+
+# NLWeb Schema Feeds: structured-data feeds for natural-language retrieval.
+Schemamap: https://email-sdk.dev/schemamap.xml

--- a/apps/fumadocs/public/schemamap.xml
+++ b/apps/fumadocs/public/schemamap.xml
@@ -14,11 +14,11 @@
   <feed>
     <loc>https://email-sdk.dev/rss.xml</loc>
     <format>application/rss+xml</format>
-    <description>Email SDK blog and changelog RSS feed.</description>
+    <description>Email SDK blog RSS feed.</description>
   </feed>
   <feed>
     <loc>https://email-sdk.dev/feed.json</loc>
     <format>application/feed+json</format>
-    <description>Email SDK blog and changelog JSON Feed.</description>
+    <description>Email SDK blog JSON Feed.</description>
   </feed>
 </schemamap>

--- a/apps/fumadocs/public/schemamap.xml
+++ b/apps/fumadocs/public/schemamap.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Schema Map for Email SDK (NLWeb Schema Feeds).
+  Lists the structured-data feeds an NLWeb / natural-language indexer can ingest.
+  Referenced from robots.txt via the `Schemamap:` directive. Spec: https://nlweb.ai
+-->
+<schemamap>
+  <feed>
+    <loc>https://email-sdk.dev/feeds/docs.jsonl</loc>
+    <format>application/x-ndjson</format>
+    <vocabulary>https://schema.org</vocabulary>
+    <description>Email SDK documentation as schema.org TechArticle entities, one JSON object per line.</description>
+  </feed>
+  <feed>
+    <loc>https://email-sdk.dev/rss.xml</loc>
+    <format>application/rss+xml</format>
+    <description>Email SDK blog and changelog RSS feed.</description>
+  </feed>
+  <feed>
+    <loc>https://email-sdk.dev/feed.json</loc>
+    <format>application/feed+json</format>
+    <description>Email SDK blog and changelog JSON Feed.</description>
+  </feed>
+</schemamap>

--- a/apps/fumadocs/src/lib/llms.ts
+++ b/apps/fumadocs/src/lib/llms.ts
@@ -3,29 +3,28 @@ import { llms } from "fumadocs-core/source";
 import { appName, llmsOverview } from "@/lib/shared";
 import { source } from "@/lib/source";
 
+// The generated index leads with its own H1; drop it so callers can prepend an
+// enriched header. Single source of truth for the stripping regex.
+function docsIndex() {
+  return llms(source)
+    .index()
+    .replace(/^#[^\n]*\r?\n+/, "");
+}
+
 // One canonical machine index, shared by /llms.txt and its /llms.md twin so the
 // enriched header (description + constraints) never drifts between the two URLs.
 export function buildLlmsIndex() {
-  // Drop the generated H1 and lead with our enriched header.
-  const index = llms(source)
-    .index()
-    .replace(/^#[^\n]*\r?\n+/, "");
-
-  return `# ${appName}\n\n${llmsOverview}\n\n## Documentation\n\n${index}`;
+  return `# ${appName}\n\n${llmsOverview}\n\n## Documentation\n\n${docsIndex()}`;
 }
 
 // Section-scoped index for agents that only want the documentation tree, served
 // at /docs/llms.txt so they can fetch docs context without the whole manual.
 export function buildDocsLlmsIndex() {
-  const index = llms(source)
-    .index()
-    .replace(/^#[^\n]*\r?\n+/, "");
-
   return `# ${appName} — Documentation
 
 > Scoped index of the ${appName} documentation. For the full machine guide (overview, constraints, agent usage) see /llms.txt; for every page inlined see /llms-full.txt.
 
 ## Documentation
 
-${index}`;
+${docsIndex()}`;
 }

--- a/apps/fumadocs/src/lib/llms.ts
+++ b/apps/fumadocs/src/lib/llms.ts
@@ -1,0 +1,31 @@
+import { llms } from "fumadocs-core/source";
+
+import { appName, llmsOverview } from "@/lib/shared";
+import { source } from "@/lib/source";
+
+// One canonical machine index, shared by /llms.txt and its /llms.md twin so the
+// enriched header (description + constraints) never drifts between the two URLs.
+export function buildLlmsIndex() {
+  // Drop the generated H1 and lead with our enriched header.
+  const index = llms(source)
+    .index()
+    .replace(/^#[^\n]*\r?\n+/, "");
+
+  return `# ${appName}\n\n${llmsOverview}\n\n## Documentation\n\n${index}`;
+}
+
+// Section-scoped index for agents that only want the documentation tree, served
+// at /docs/llms.txt so they can fetch docs context without the whole manual.
+export function buildDocsLlmsIndex() {
+  const index = llms(source)
+    .index()
+    .replace(/^#[^\n]*\r?\n+/, "");
+
+  return `# ${appName} — Documentation
+
+> Scoped index of the ${appName} documentation. For the full machine guide (overview, constraints, agent usage) see /llms.txt; for every page inlined see /llms-full.txt.
+
+## Documentation
+
+${index}`;
+}

--- a/apps/fumadocs/src/lib/metadata.ts
+++ b/apps/fumadocs/src/lib/metadata.ts
@@ -118,6 +118,40 @@ export const homeStructuredData = {
       },
     },
     {
+      "@type": "WebPage",
+      "@id": `${siteUrl}/#webpage`,
+      url: siteUrl,
+      name: siteTitle,
+      description: appDescription,
+      inLanguage: "en",
+      isPartOf: {
+        "@id": `${siteUrl}/#website`,
+      },
+      about: {
+        "@id": `${siteUrl}/#software`,
+      },
+      primaryImageOfPage: siteOgImageUrl,
+      // Tells assistants which sections of the homepage are suitable for
+      // text-to-speech readout (the hero heading and one-line summary).
+      speakable: {
+        "@type": "SpeakableSpecification",
+        cssSelector: ["#hero-heading", "#hero-summary"],
+      },
+    },
+    {
+      "@type": "Service",
+      "@id": `${siteUrl}/#service`,
+      name: "Email SDK transactional email integration",
+      serviceType: "Transactional email integration",
+      description:
+        "Send transactional email through 20+ providers behind one typed TypeScript client, with retries and compatible fallbacks.",
+      provider: {
+        "@id": `${siteUrl}/#organization`,
+      },
+      areaServed: "Worldwide",
+      url: `${siteUrl}/docs`,
+    },
+    {
       "@type": "SoftwareApplication",
       "@id": `${siteUrl}/#software`,
       name: appName,
@@ -161,7 +195,7 @@ export const homeStructuredData = {
           name: "Which email providers does Email SDK support?",
           acceptedAnswer: {
             "@type": "Answer",
-            text: "Email SDK supports adapters for Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare Email Sending, Unosend, AWS SES, MailerSend, Brevo, Mailchimp Transactional, SparkPost, Iterable, Loops, Sequenzy, Plunk, Mailtrap, Scaleway, ZeptoMail, and MailPace.",
+            text: "Email SDK supports adapters for Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare Email Sending, Unosend, AWS SES, MailerSend, Brevo, Mailchimp Transactional, SparkPost, Iterable, Loops, Sequenzy, JetEmail, Primitive, Lettermint, Plunk, Mailtrap, Scaleway, ZeptoMail, and MailPace.",
           },
         },
         {
@@ -196,6 +230,9 @@ export const homeStructuredData = {
         "Iterable",
         "Loops",
         "Sequenzy",
+        "JetEmail",
+        "Primitive",
+        "Lettermint",
         "Plunk",
         "Mailtrap",
         "Scaleway",

--- a/apps/fumadocs/src/lib/shared.ts
+++ b/apps/fumadocs/src/lib/shared.ts
@@ -8,6 +8,25 @@ export const llmsOverview = `> ${appDescription}
 
 Email SDK is an open-source TypeScript SDK (npm: \`@opencoredev/email-sdk\`) for sending transactional email through 20+ providers — Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare Email Sending, Unosend, AWS SES, and more — behind one typed \`send()\` call with retries and compatible fallbacks. It is a library you install into a TypeScript/JavaScript app, not a hosted API or a service you sign up for.
 
+## When to use Email SDK
+
+Reach for it when a TypeScript/JavaScript (Node, Bun, or edge/Workers) app needs to:
+
+- Send transactional email (receipts, verifications, alerts, password resets).
+- Start on one provider but keep the option to switch or add providers later without rewriting send sites.
+- Route across multiple providers with retries and compatible fallbacks.
+- Give an LLM agent a guarded \`send_email\` tool that runs the same validated pipeline as the rest of the app.
+
+## When not to use it
+
+- You need a marketing/campaign builder or a CRM — this is transactional sending.
+- You are not in a TypeScript/JavaScript runtime.
+- You want a hosted email API with its own dashboard and billing — Email SDK wraps providers you already pay (Resend, SES, Postmark, SMTP, …); it is not one itself.
+
+## How AI agents should use it
+
+Install the package, import the adapter for the provider whose credentials the app already holds, and call \`send()\`. There is nothing to authenticate against at email-sdk.dev — per-provider credentials live in /docs/authentication. Give models the \`send_email\` tool from \`@opencoredev/email-sdk/agent-tools\`, and follow the constraints below.
+
 ## Constraints
 
 - TypeScript/JavaScript runtimes only (Node, Bun, edge/Workers), for transactional email rather than marketing campaigns.

--- a/apps/fumadocs/src/routeTree.gen.ts
+++ b/apps/fumadocs/src/routeTree.gen.ts
@@ -14,13 +14,17 @@ import { Route as SitemapDotxmlRouteImport } from './routes/sitemap[.]xml'
 import { Route as RssDotxmlRouteImport } from './routes/rss[.]xml'
 import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as LlmsDottxtRouteImport } from './routes/llms[.]txt'
+import { Route as LlmsDotmdRouteImport } from './routes/llms[.]md'
 import { Route as LlmsFullDottxtRouteImport } from './routes/llms-full[.]txt'
+import { Route as IndexDotmdRouteImport } from './routes/index[.]md'
 import { Route as FeedDotjsonRouteImport } from './routes/feed[.]json'
 import { Route as ContactRouteImport } from './routes/contact'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
+import { Route as FeedsDocsDotjsonlRouteImport } from './routes/feeds/docs[.]jsonl'
 import { Route as DocsChar123Char125DotmdRouteImport } from './routes/docs/{$}[.]md'
+import { Route as DocsLlmsDottxtRouteImport } from './routes/docs/llms[.]txt'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
@@ -52,9 +56,19 @@ const LlmsDottxtRoute = LlmsDottxtRouteImport.update({
   path: '/llms.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LlmsDotmdRoute = LlmsDotmdRouteImport.update({
+  id: '/llms.md',
+  path: '/llms.md',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const LlmsFullDottxtRoute = LlmsFullDottxtRouteImport.update({
   id: '/llms-full.txt',
   path: '/llms-full.txt',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IndexDotmdRoute = IndexDotmdRouteImport.update({
+  id: '/index.md',
+  path: '/index.md',
   getParentRoute: () => rootRouteImport,
 } as any)
 const FeedDotjsonRoute = FeedDotjsonRouteImport.update({
@@ -82,9 +96,19 @@ const BlogIndexRoute = BlogIndexRouteImport.update({
   path: '/blog/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const FeedsDocsDotjsonlRoute = FeedsDocsDotjsonlRouteImport.update({
+  id: '/feeds/docs.jsonl',
+  path: '/feeds/docs.jsonl',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const DocsChar123Char125DotmdRoute = DocsChar123Char125DotmdRouteImport.update({
   id: '/docs/{$}.md',
   path: '/docs/{$}.md',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DocsLlmsDottxtRoute = DocsLlmsDottxtRouteImport.update({
+  id: '/docs/llms.txt',
+  path: '/docs/llms.txt',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DocsSplatRoute = DocsSplatRouteImport.update({
@@ -118,7 +142,9 @@ export interface FileRoutesByFullPath {
   '/about': typeof AboutRoute
   '/contact': typeof ContactRoute
   '/feed.json': typeof FeedDotjsonRoute
+  '/index.md': typeof IndexDotmdRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.md': typeof LlmsDotmdRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/privacy': typeof PrivacyRoute
   '/rss.xml': typeof RssDotxmlRoute
@@ -128,7 +154,9 @@ export interface FileRoutesByFullPath {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/docs/llms.txt': typeof DocsLlmsDottxtRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
+  '/feeds/docs.jsonl': typeof FeedsDocsDotjsonlRoute
   '/blog/': typeof BlogIndexRoute
   '/og/blog/$': typeof OgBlogSplatRoute
 }
@@ -137,7 +165,9 @@ export interface FileRoutesByTo {
   '/about': typeof AboutRoute
   '/contact': typeof ContactRoute
   '/feed.json': typeof FeedDotjsonRoute
+  '/index.md': typeof IndexDotmdRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.md': typeof LlmsDotmdRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/privacy': typeof PrivacyRoute
   '/rss.xml': typeof RssDotxmlRoute
@@ -147,7 +177,9 @@ export interface FileRoutesByTo {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/docs/llms.txt': typeof DocsLlmsDottxtRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
+  '/feeds/docs.jsonl': typeof FeedsDocsDotjsonlRoute
   '/blog': typeof BlogIndexRoute
   '/og/blog/$': typeof OgBlogSplatRoute
 }
@@ -157,7 +189,9 @@ export interface FileRoutesById {
   '/about': typeof AboutRoute
   '/contact': typeof ContactRoute
   '/feed.json': typeof FeedDotjsonRoute
+  '/index.md': typeof IndexDotmdRoute
   '/llms-full.txt': typeof LlmsFullDottxtRoute
+  '/llms.md': typeof LlmsDotmdRoute
   '/llms.txt': typeof LlmsDottxtRoute
   '/privacy': typeof PrivacyRoute
   '/rss.xml': typeof RssDotxmlRoute
@@ -167,7 +201,9 @@ export interface FileRoutesById {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/docs/$': typeof DocsSplatRoute
+  '/docs/llms.txt': typeof DocsLlmsDottxtRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
+  '/feeds/docs.jsonl': typeof FeedsDocsDotjsonlRoute
   '/blog/': typeof BlogIndexRoute
   '/og/blog/$': typeof OgBlogSplatRoute
 }
@@ -178,7 +214,9 @@ export interface FileRouteTypes {
     | '/about'
     | '/contact'
     | '/feed.json'
+    | '/index.md'
     | '/llms-full.txt'
+    | '/llms.md'
     | '/llms.txt'
     | '/privacy'
     | '/rss.xml'
@@ -188,7 +226,9 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
+    | '/docs/llms.txt'
     | '/docs/{$}.md'
+    | '/feeds/docs.jsonl'
     | '/blog/'
     | '/og/blog/$'
   fileRoutesByTo: FileRoutesByTo
@@ -197,7 +237,9 @@ export interface FileRouteTypes {
     | '/about'
     | '/contact'
     | '/feed.json'
+    | '/index.md'
     | '/llms-full.txt'
+    | '/llms.md'
     | '/llms.txt'
     | '/privacy'
     | '/rss.xml'
@@ -207,7 +249,9 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
+    | '/docs/llms.txt'
     | '/docs/{$}.md'
+    | '/feeds/docs.jsonl'
     | '/blog'
     | '/og/blog/$'
   id:
@@ -216,7 +260,9 @@ export interface FileRouteTypes {
     | '/about'
     | '/contact'
     | '/feed.json'
+    | '/index.md'
     | '/llms-full.txt'
+    | '/llms.md'
     | '/llms.txt'
     | '/privacy'
     | '/rss.xml'
@@ -226,7 +272,9 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/docs/$'
+    | '/docs/llms.txt'
     | '/docs/{$}.md'
+    | '/feeds/docs.jsonl'
     | '/blog/'
     | '/og/blog/$'
   fileRoutesById: FileRoutesById
@@ -236,7 +284,9 @@ export interface RootRouteChildren {
   AboutRoute: typeof AboutRoute
   ContactRoute: typeof ContactRoute
   FeedDotjsonRoute: typeof FeedDotjsonRoute
+  IndexDotmdRoute: typeof IndexDotmdRoute
   LlmsFullDottxtRoute: typeof LlmsFullDottxtRoute
+  LlmsDotmdRoute: typeof LlmsDotmdRoute
   LlmsDottxtRoute: typeof LlmsDottxtRoute
   PrivacyRoute: typeof PrivacyRoute
   RssDotxmlRoute: typeof RssDotxmlRoute
@@ -246,7 +296,9 @@ export interface RootRouteChildren {
   ApiSearchRoute: typeof ApiSearchRoute
   BlogSlugRoute: typeof BlogSlugRoute
   DocsSplatRoute: typeof DocsSplatRoute
+  DocsLlmsDottxtRoute: typeof DocsLlmsDottxtRoute
   DocsChar123Char125DotmdRoute: typeof DocsChar123Char125DotmdRoute
+  FeedsDocsDotjsonlRoute: typeof FeedsDocsDotjsonlRoute
   BlogIndexRoute: typeof BlogIndexRoute
   OgBlogSplatRoute: typeof OgBlogSplatRoute
 }
@@ -288,11 +340,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LlmsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/llms.md': {
+      id: '/llms.md'
+      path: '/llms.md'
+      fullPath: '/llms.md'
+      preLoaderRoute: typeof LlmsDotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/llms-full.txt': {
       id: '/llms-full.txt'
       path: '/llms-full.txt'
       fullPath: '/llms-full.txt'
       preLoaderRoute: typeof LlmsFullDottxtRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/index.md': {
+      id: '/index.md'
+      path: '/index.md'
+      fullPath: '/index.md'
+      preLoaderRoute: typeof IndexDotmdRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/feed.json': {
@@ -330,11 +396,25 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof BlogIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/feeds/docs.jsonl': {
+      id: '/feeds/docs.jsonl'
+      path: '/feeds/docs.jsonl'
+      fullPath: '/feeds/docs.jsonl'
+      preLoaderRoute: typeof FeedsDocsDotjsonlRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/docs/{$}.md': {
       id: '/docs/{$}.md'
       path: '/docs/{$}.md'
       fullPath: '/docs/{$}.md'
       preLoaderRoute: typeof DocsChar123Char125DotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docs/llms.txt': {
+      id: '/docs/llms.txt'
+      path: '/docs/llms.txt'
+      fullPath: '/docs/llms.txt'
+      preLoaderRoute: typeof DocsLlmsDottxtRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/docs/$': {
@@ -380,7 +460,9 @@ const rootRouteChildren: RootRouteChildren = {
   AboutRoute: AboutRoute,
   ContactRoute: ContactRoute,
   FeedDotjsonRoute: FeedDotjsonRoute,
+  IndexDotmdRoute: IndexDotmdRoute,
   LlmsFullDottxtRoute: LlmsFullDottxtRoute,
+  LlmsDotmdRoute: LlmsDotmdRoute,
   LlmsDottxtRoute: LlmsDottxtRoute,
   PrivacyRoute: PrivacyRoute,
   RssDotxmlRoute: RssDotxmlRoute,
@@ -390,7 +472,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSearchRoute: ApiSearchRoute,
   BlogSlugRoute: BlogSlugRoute,
   DocsSplatRoute: DocsSplatRoute,
+  DocsLlmsDottxtRoute: DocsLlmsDottxtRoute,
   DocsChar123Char125DotmdRoute: DocsChar123Char125DotmdRoute,
+  FeedsDocsDotjsonlRoute: FeedsDocsDotjsonlRoute,
   BlogIndexRoute: BlogIndexRoute,
   OgBlogSplatRoute: OgBlogSplatRoute,
 }

--- a/apps/fumadocs/src/routes/docs/llms[.]txt.ts
+++ b/apps/fumadocs/src/routes/docs/llms[.]txt.ts
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { buildDocsLlmsIndex } from "@/lib/llms";
+
+// Per-section machine index so agents can fetch documentation-scoped context
+// (/docs/llms.txt) instead of the whole-site /llms.txt manual.
+export const Route = createFileRoute("/docs/llms.txt")({
+  server: {
+    handlers: {
+      GET() {
+        return new Response(buildDocsLlmsIndex(), {
+          headers: { "content-type": "text/plain; charset=utf-8" },
+        });
+      },
+    },
+  },
+});

--- a/apps/fumadocs/src/routes/feeds/docs[.]jsonl.ts
+++ b/apps/fumadocs/src/routes/feeds/docs[.]jsonl.ts
@@ -1,0 +1,39 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { siteUrl } from "@/lib/shared";
+import { source } from "@/lib/source";
+
+// Schema.org content feed (JSON Lines) for NLWeb / natural-language retrieval.
+// One schema.org TechArticle per documentation page so an indexer can ingest the
+// docs as discrete, typed entities. Referenced from /schemamap.xml.
+export const Route = createFileRoute("/feeds/docs.jsonl")({
+  server: {
+    handlers: {
+      GET() {
+        const lines = source.getPages().map((page) => {
+          const entity = {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "@id": `${siteUrl}${page.url}`,
+            url: `${siteUrl}${page.url}`,
+            name: page.data.title,
+            description: page.data.description,
+            inLanguage: "en",
+            isPartOf: { "@id": `${siteUrl}/#website` },
+            encoding: {
+              "@type": "MediaObject",
+              encodingFormat: "text/markdown",
+              contentUrl: `${siteUrl}${page.url}.md`,
+            },
+          };
+
+          return JSON.stringify(entity);
+        });
+
+        return new Response(`${lines.join("\n")}\n`, {
+          headers: { "content-type": "application/x-ndjson; charset=utf-8" },
+        });
+      },
+    },
+  },
+});

--- a/apps/fumadocs/src/routes/index.tsx
+++ b/apps/fumadocs/src/routes/index.tsx
@@ -120,11 +120,17 @@ function Home() {
       <main className="border-b border-fd-border bg-fd-background text-fd-foreground">
         <section className="mx-auto grid min-h-[calc(100svh-64px)] max-w-[1512px] items-center gap-10 px-6 py-10 md:px-10 lg:grid-cols-[0.78fr_1.22fr] lg:px-14 xl:px-16">
           <div className="max-w-2xl py-4">
-            <h1 className="text-5xl font-medium leading-[1.04] text-fd-foreground md:text-6xl">
+            <h1
+              className="text-5xl font-medium leading-[1.04] text-fd-foreground md:text-6xl"
+              id="hero-heading"
+            >
               One email SDK for every provider.
             </h1>
 
-            <p className="mt-6 max-w-xl text-base leading-7 text-fd-muted-foreground md:text-lg">
+            <p
+              className="mt-6 max-w-xl text-base leading-7 text-fd-muted-foreground md:text-lg"
+              id="hero-summary"
+            >
               Email SDK is a TypeScript email SDK for transactional sending through Resend,
               Postmark, SendGrid, Mailgun, Unosend, AWS SES, Brevo, SMTP, and more with one clean
               API.
@@ -159,9 +165,7 @@ function Home() {
                   <div className="mb-3 grid grid-cols-[1fr_auto_1fr] items-center text-xs text-fd-muted-foreground">
                     <span>Provider</span>
                     <span className="inline-flex h-7 min-w-32 items-center justify-center rounded-full bg-fd-muted px-3 text-[11px] font-semibold text-fd-foreground shadow-inner shadow-black/10 sm:min-w-40">
-                      <span className="max-w-32 truncate sm:max-w-36">
-                        {activeProvider.label}
-                      </span>
+                      <span className="max-w-32 truncate sm:max-w-36">{activeProvider.label}</span>
                     </span>
                     <span className="hidden justify-self-end sm:block">
                       Use arrows or click a logo
@@ -338,7 +342,12 @@ function SyntaxCode({ provider }: { provider: ProviderProfile }) {
         <Token tone="keyword">from</Token> <Token tone="string">"@opencoredev/email-sdk"</Token>;
       </CodeLine>
       <CodeLine number={2}>
-        <Token tone="keyword">import</Token>{" { "}<Token tone="function">{provider.import}</Token>{" } "}<Token tone="keyword">from</Token>{" "}<Token tone="string">{`"${provider.importPath}"`}</Token>;
+        <Token tone="keyword">import</Token>
+        {" { "}
+        <Token tone="function">{provider.import}</Token>
+        {" } "}
+        <Token tone="keyword">from</Token> <Token tone="string">{`"${provider.importPath}"`}</Token>
+        ;
       </CodeLine>
       <CodeLine />
       <CodeLine number={4}>
@@ -421,8 +430,8 @@ function renderConfigLine(line: string) {
     return (
       <>
         {leadingWhitespace}
-        <Token tone="property">{envMatch[1]}</Token>:{" "}
-        <Token tone="variable">process</Token>.env.{envMatch[2]}
+        <Token tone="property">{envMatch[1]}</Token>: <Token tone="variable">process</Token>.env.
+        {envMatch[2]}
         {suffix}
       </>
     );
@@ -578,9 +587,7 @@ function ProviderLogo({ active, label, logo }: { active: boolean; label: string;
     return (
       <span
         className={`m-auto flex size-8 items-center justify-center rounded-full text-[9px] font-semibold sm:size-9 sm:text-[10px] ${
-          active
-            ? "bg-fd-background text-fd-foreground"
-            : "bg-fd-foreground text-fd-background"
+          active ? "bg-fd-background text-fd-foreground" : "bg-fd-foreground text-fd-background"
         }`}
       >
         {getProviderInitials(label)}

--- a/apps/fumadocs/src/routes/index[.]md.ts
+++ b/apps/fumadocs/src/routes/index[.]md.ts
@@ -1,0 +1,74 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { appName, siteUrl } from "@/lib/shared";
+
+// Markdown representation of the homepage. This is the cold-discovery path: an
+// agent that lands on the site root from web search can fetch /index.md (or be
+// pointed here by the markdown alternate Link header) and get structured prose
+// instead of marketing HTML. Kept in sync by hand with the homepage hero copy.
+const body = `# ${appName}
+
+> One TypeScript email SDK for every provider.
+
+${appName} is an open-source TypeScript SDK (npm: \`@opencoredev/email-sdk\`) for sending transactional email through 20+ providers — Resend, SMTP, Postmark, SendGrid, Mailgun, Cloudflare Email Sending, Unosend, AWS SES, and more — behind one typed \`send()\` call with retries and compatible fallbacks. It is a library you install into a TypeScript/JavaScript app, **not** a hosted API or a service you sign up for. There are no credentials to obtain from us; you bring the provider keys your app already has.
+
+## Install
+
+\`\`\`bash
+npm install @opencoredev/email-sdk
+\`\`\`
+
+## Send an email
+
+\`\`\`ts
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+  retry: { retries: 1 },
+});
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+\`\`\`
+
+## Why use it
+
+- **One API, every provider.** Swap or add a provider without rewriting send sites — adapters import from their own entry points (\`@opencoredev/email-sdk/resend\`, \`/smtp\`, \`/ses\`, …).
+- **Retries and fallbacks.** Retry transient failures and route across compatible adapters automatically.
+- **Agent-ready.** \`createEmailAgentTools(client)\` from \`@opencoredev/email-sdk/agent-tools\` returns a guarded \`send_email\` tool that runs the full validate/retry/fallback pipeline.
+- **Local CLI.** \`email-sdk doctor\` and \`send --dry-run\` check configuration and test sends before going live.
+
+## For agents
+
+- Agent guide: ${siteUrl}/agents.md
+- Authentication model: ${siteUrl}/auth.md
+- Machine index: ${siteUrl}/llms.txt and ${siteUrl}/llms-full.txt
+- Discovery file: ${siteUrl}/.well-known/agent.json
+
+## Links
+
+- Documentation: ${siteUrl}/docs
+- Source: https://github.com/opencoredev/email-sdk
+- Package: https://www.npmjs.com/package/@opencoredev/email-sdk
+`;
+
+export const Route = createFileRoute("/index.md")({
+  server: {
+    handlers: {
+      GET() {
+        return new Response(body, {
+          headers: {
+            "content-type": "text/markdown; charset=utf-8",
+            vary: "Accept",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/fumadocs/src/routes/index[.]md.ts
+++ b/apps/fumadocs/src/routes/index[.]md.ts
@@ -65,7 +65,6 @@ export const Route = createFileRoute("/index.md")({
         return new Response(body, {
           headers: {
             "content-type": "text/markdown; charset=utf-8",
-            vary: "Accept",
           },
         });
       },

--- a/apps/fumadocs/src/routes/llms[.]md.ts
+++ b/apps/fumadocs/src/routes/llms[.]md.ts
@@ -1,0 +1,21 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+import { buildLlmsIndex } from "@/lib/llms";
+
+// Markdown twin of /llms.txt. Cold-arrival agents that land from web search and
+// probe for a markdown representation (/llms.md) get the same canonical index
+// with a text/markdown content-type instead of having to know about llms.txt.
+export const Route = createFileRoute("/llms.md")({
+  server: {
+    handlers: {
+      GET() {
+        return new Response(buildLlmsIndex(), {
+          headers: {
+            "content-type": "text/markdown; charset=utf-8",
+            vary: "Accept",
+          },
+        });
+      },
+    },
+  },
+});

--- a/apps/fumadocs/src/routes/llms[.]md.ts
+++ b/apps/fumadocs/src/routes/llms[.]md.ts
@@ -12,7 +12,6 @@ export const Route = createFileRoute("/llms.md")({
         return new Response(buildLlmsIndex(), {
           headers: {
             "content-type": "text/markdown; charset=utf-8",
-            vary: "Accept",
           },
         });
       },

--- a/apps/fumadocs/src/routes/llms[.]txt.ts
+++ b/apps/fumadocs/src/routes/llms[.]txt.ts
@@ -1,21 +1,12 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { llms } from "fumadocs-core/source";
 
-import { appName, llmsOverview } from "@/lib/shared";
-import { source } from "@/lib/source";
+import { buildLlmsIndex } from "@/lib/llms";
 
 export const Route = createFileRoute("/llms.txt")({
   server: {
     handlers: {
       GET() {
-        // Replace the generated H1 with an enriched header: short description,
-        // overview, and agent constraints, then the documentation index.
-        const index = llms(source)
-          .index()
-          .replace(/^#[^\n]*\r?\n+/, "");
-        const body = `# ${appName}\n\n${llmsOverview}\n\n## Documentation\n\n${index}`;
-
-        return new Response(body, {
+        return new Response(buildLlmsIndex(), {
           headers: { "content-type": "text/plain; charset=utf-8" },
         });
       },

--- a/apps/fumadocs/src/routes/sitemap[.]xml.ts
+++ b/apps/fumadocs/src/routes/sitemap[.]xml.ts
@@ -89,6 +89,42 @@ function getSitemapEntries() {
       priority: "0.5",
     },
     {
+      loc: `${siteUrl}/llms.md`,
+      lastmod: "2026-06-01",
+      changefreq: "weekly",
+      priority: "0.5",
+    },
+    {
+      loc: `${siteUrl}/index.md`,
+      lastmod: "2026-06-01",
+      changefreq: "weekly",
+      priority: "0.5",
+    },
+    {
+      loc: `${siteUrl}/docs/llms.txt`,
+      lastmod: "2026-06-01",
+      changefreq: "weekly",
+      priority: "0.4",
+    },
+    {
+      loc: `${siteUrl}/agents.md`,
+      lastmod: "2026-06-01",
+      changefreq: "monthly",
+      priority: "0.5",
+    },
+    {
+      loc: `${siteUrl}/auth.md`,
+      lastmod: "2026-06-01",
+      changefreq: "monthly",
+      priority: "0.4",
+    },
+    {
+      loc: `${siteUrl}/schemamap.xml`,
+      lastmod: "2026-06-01",
+      changefreq: "monthly",
+      priority: "0.3",
+    },
+    {
       loc: `${siteUrl}/rss.xml`,
       lastmod: "2026-06-01",
       changefreq: "weekly",

--- a/apps/fumadocs/src/routes/sitemap[.]xml.ts
+++ b/apps/fumadocs/src/routes/sitemap[.]xml.ts
@@ -89,42 +89,6 @@ function getSitemapEntries() {
       priority: "0.5",
     },
     {
-      loc: `${siteUrl}/llms.md`,
-      lastmod: "2026-06-01",
-      changefreq: "weekly",
-      priority: "0.5",
-    },
-    {
-      loc: `${siteUrl}/index.md`,
-      lastmod: "2026-06-01",
-      changefreq: "weekly",
-      priority: "0.5",
-    },
-    {
-      loc: `${siteUrl}/docs/llms.txt`,
-      lastmod: "2026-06-01",
-      changefreq: "weekly",
-      priority: "0.4",
-    },
-    {
-      loc: `${siteUrl}/agents.md`,
-      lastmod: "2026-06-01",
-      changefreq: "monthly",
-      priority: "0.5",
-    },
-    {
-      loc: `${siteUrl}/auth.md`,
-      lastmod: "2026-06-01",
-      changefreq: "monthly",
-      priority: "0.4",
-    },
-    {
-      loc: `${siteUrl}/schemamap.xml`,
-      lastmod: "2026-06-01",
-      changefreq: "monthly",
-      priority: "0.3",
-    },
-    {
       loc: `${siteUrl}/rss.xml`,
       lastmod: "2026-06-01",
       changefreq: "weekly",

--- a/apps/fumadocs/vite.config.ts
+++ b/apps/fumadocs/vite.config.ts
@@ -132,6 +132,18 @@ export default defineConfig(({ mode }) => {
           {
             path: "llms.txt",
           },
+          {
+            path: "llms.md",
+          },
+          {
+            path: "index.md",
+          },
+          {
+            path: "/docs/llms.txt",
+          },
+          {
+            path: "/feeds/docs.jsonl",
+          },
         ],
       }),
       react(),

--- a/vercel.json
+++ b/vercel.json
@@ -54,6 +54,20 @@
     },
     {
       "source": "/",
+      "has": [{ "type": "query", "key": "mode", "value": "agent" }],
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        },
+        {
+          "key": "Vary",
+          "value": "Accept"
+        }
+      ]
+    },
+    {
+      "source": "/",
       "headers": [
         {
           "key": "Link",
@@ -80,6 +94,10 @@
         {
           "key": "Content-Type",
           "value": "application/x-ndjson; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -81,6 +81,19 @@
         {
           "key": "Vary",
           "value": "Accept-Encoding"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/(.*).txt",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600, stale-while-revalidate=86400"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,31 @@
 {
   "outputDirectory": "apps/fumadocs/.vercel/output/static",
+  "rewrites": [
+    {
+      "source": "/",
+      "has": [{ "type": "query", "key": "mode", "value": "agent" }],
+      "destination": "/agents.md"
+    }
+  ],
+  "redirects": [
+    { "source": "/docs/auth", "destination": "/docs/authentication", "permanent": true },
+    {
+      "source": "/docs/quickstart",
+      "destination": "/docs/getting-started/quickstart",
+      "permanent": true
+    },
+    { "source": "/docs/install", "destination": "/docs/getting-started/install", "permanent": true },
+    {
+      "source": "/docs/installation",
+      "destination": "/docs/getting-started/install",
+      "permanent": true
+    },
+    { "source": "/docs/errors", "destination": "/docs/reference/errors", "permanent": true },
+    { "source": "/docs/cli", "destination": "/docs/reference/cli", "permanent": true },
+    { "source": "/docs/api", "destination": "/docs/reference", "permanent": true },
+    { "source": "/docs/providers", "destination": "/docs/adapters", "permanent": true },
+    { "source": "/docs/provider", "destination": "/docs/adapters", "permanent": true }
+  ],
   "headers": [
     {
       "source": "/(.*)",
@@ -19,6 +45,41 @@
         {
           "key": "Content-Security-Policy",
           "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://cdn.simpleicons.org https://www.google.com; font-src 'self' data:; connect-src 'self' https://vitals.vercel-insights.com https://*.vercel-insights.com; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; object-src 'none'"
+        },
+        {
+          "key": "Link",
+          "value": "</sitemap.xml>; rel=\"sitemap\", </index.md>; rel=\"alternate\"; type=\"text/markdown\", </llms.txt>; rel=\"alternate\"; type=\"text/plain\", </.well-known/api-catalog>; rel=\"api-catalog\", </.well-known/agent.json>; rel=\"describedby\"; type=\"application/json\""
+        }
+      ]
+    },
+    {
+      "source": "/(.*).md",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "text/markdown; charset=utf-8"
+        },
+        {
+          "key": "Vary",
+          "value": "Accept, Accept-Encoding"
+        }
+      ]
+    },
+    {
+      "source": "/feeds/docs.jsonl",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/x-ndjson; charset=utf-8"
+        }
+      ]
+    },
+    {
+      "source": "/.well-known/api-catalog",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/linkset+json; profile=\"https://www.rfc-editor.org/info/rfc9727\""
         }
       ]
     }

--- a/vercel.json
+++ b/vercel.json
@@ -59,10 +59,6 @@
         {
           "key": "Content-Type",
           "value": "text/markdown; charset=utf-8"
-        },
-        {
-          "key": "Vary",
-          "value": "Accept"
         }
       ]
     },
@@ -84,7 +80,7 @@
         },
         {
           "key": "Vary",
-          "value": "Accept, Accept-Encoding"
+          "value": "Accept-Encoding"
         }
       ]
     },

--- a/vercel.json
+++ b/vercel.json
@@ -75,6 +75,15 @@
       ]
     },
     {
+      "source": "/.well-known/agent-skills",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/json; charset=utf-8"
+        }
+      ]
+    },
+    {
       "source": "/.well-known/api-catalog",
       "headers": [
         {

--- a/vercel.json
+++ b/vercel.json
@@ -48,7 +48,16 @@
         },
         {
           "key": "Link",
-          "value": "</sitemap.xml>; rel=\"sitemap\", </index.md>; rel=\"alternate\"; type=\"text/markdown\", </llms.txt>; rel=\"alternate\"; type=\"text/plain\", </.well-known/api-catalog>; rel=\"api-catalog\", </.well-known/agent.json>; rel=\"describedby\"; type=\"application/json\""
+          "value": "</sitemap.xml>; rel=\"sitemap\", </.well-known/api-catalog>; rel=\"api-catalog\", </.well-known/agent.json>; rel=\"describedby\"; type=\"application/json\""
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Link",
+          "value": "</index.md>; rel=\"alternate\"; type=\"text/markdown\", </llms.txt>; rel=\"alternate\"; type=\"text/plain\""
         }
       ]
     },


### PR DESCRIPTION
## Agent-readiness discovery surface

Adds an honest, additive AI/agent-discoverability layer to email-sdk.dev. The site is a static docs site for a **library** (not a hosted API), so this is all discovery / content / markdown / schema — **no fabricated REST/OAuth/MCP endpoints** (agent-readiness scanners penalize dead endpoints).

### Markdown & docs
- `/index.md`, `/llms.md` (markdown twins), `/docs/llms.txt` (docs-scoped index)
- New **`/docs/authentication`** page consolidating every adapter's credential model (config field + env var) in one table — fixes the `/docs/authentication` 404 agents were hitting; flows into `llms-full.txt` + a `.md` twin

### Discovery / well-known
- `/.well-known/agent.json`, `/auth.md`, `/.well-known/api-catalog` (RFC 9727)
- NLWeb `Schemamap:` + `/schemamap.xml` → `/feeds/docs.jsonl` (schema.org feed)
- `robots.txt`: Content-Signal + Schemamap directives

### Structured data
- JSON-LD `WebPage` + `speakable`, `Service`; when-to-use guidance in `llms.txt`
- Completed the supported-provider lists (added JetEmail, Primitive, Lettermint) across the auth table, `agents.md`, and JSON-LD so they match `providers.ts`

### Routing (`vercel.json`)
- RFC 8288 `Link` discovery header, `?mode=agent` → `/agents.md`, content-types for `.md` / ndjson / linkset+json
- Redirects for commonly-guessed doc paths (`/docs/auth`, `/docs/quickstart`, `/docs/cli`, `/docs/errors`, `/docs/api`, …)

### Verification
- `bun run build` (full prerender) ✓ · `types:check` ✓ · tests 18/0 ✓ · oxlint ✓ · oxfmt ✓
- Greptile CLI review: 5/5, no comments

Hosted-API / OAuth / MCP scanner checks are intentionally left N/A — the product is a library, and advertising endpoints that don't resolve hurts more than it helps.