### PR TITLE
fix(docs): re-fetch Notra posts on every build + webhook trigger

### DIFF
--- a/.github/workflows/blog-schedule.yml
+++ b/.github/workflows/blog-schedule.yml
@@ -1,11 +1,17 @@
 name: Refresh blog posts from Notra
 
+# Triggers a Vercel rebuild, which re-fetches published posts from Notra and bakes
+# them into the static blog. apps/fumadocs build caching is off (apps/fumadocs/turbo.json)
+# so each rebuild actually re-runs the fetch instead of serving a cached build.
 on:
   workflow_dispatch:
+  repository_dispatch:
+    # Point a Notra "post published" webhook at GitHub's repository_dispatch API with
+    # event_type "notra-published" for near-instant updates.
+    types: [notra-published]
   schedule:
-    # Weekly rebuild so newly published Notra posts get baked into the static
-    # blog. Notra can also POST the same deploy hook on publish for instant updates.
-    - cron: "30 13 * * 3"
+    # Daily safety net in case a webhook is missed.
+    - cron: "30 13 * * *"
 
 permissions:
   contents: read
@@ -24,7 +30,7 @@ jobs:
           VERCEL_DEPLOY_HOOK_URL: ${{ secrets.VERCEL_DEPLOY_HOOK_URL }}
         run: |
           if [ -z "$VERCEL_DEPLOY_HOOK_URL" ]; then
-            echo "::notice::Set VERCEL_DEPLOY_HOOK_URL to rebuild the static blog (pulls the latest published posts from Notra) plus sitemap, RSS, and JSON feed."
+            echo "::notice::Set the VERCEL_DEPLOY_HOOK_URL secret (Vercel -> Settings -> Git -> Deploy Hooks, branch main) to enable automatic blog rebuilds."
             exit 0
           fi
 

--- a/apps/fumadocs/turbo.json
+++ b/apps/fumadocs/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["$TURBO_DEFAULT$", ".env*"],
+      "outputs": [".output/**", ".vercel/output/**"],
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #110 so newly published Notra posts actually reach the live blog.

## Problem
The blog is static. A rebuild of the same commit can hit the turbo/Vercel build cache and **skip the Notra fetch**, so a published post never appears (only a forced no-cache build picked it up).

## Changes
- **apps/fumadocs/turbo.json** — disables build caching for the docs app only, so every deploy re-runs `fetch-notra-posts.ts`. Verified: turbo reports `cache bypass, force executing` and the build re-fetches.
- **Refresh workflow** — adds a `repository_dispatch` (`notra-published`) trigger so a Notra publish webhook can fire a near-instant rebuild, plus a daily safety-net rebuild. No-ops cleanly until `VERCEL_DEPLOY_HOOK_URL` is set.

## To finish enabling hands-off auto-publish
Create a Vercel Deploy Hook (Settings -> Git -> Deploy Hooks, branch `main`) and set it as the `VERCEL_DEPLOY_HOOK_URL` repo secret; optionally point a Notra publish webhook at it (or at GitHub `repository_dispatch`) for instant updates.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*