### PR TITLE
fix(docs): pass NOTRA_API_KEY through turbo so the blog builds with posts

### DIFF
--- a/apps/fumadocs/turbo.json
+++ b/apps/fumadocs/turbo.json
@@ -6,7 +6,8 @@
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".output/**", ".vercel/output/**"],
-      "cache": false
+      "cache": false,
+      "passThroughEnv": ["NOTRA_API_KEY"]
     }
   }
 }


### PR DESCRIPTION
The production blog rendered empty because turbo strict env mode strips undeclared env vars: the Vercel build logged \`NOTRA_API_KEY is not set\` and kept the empty snapshot. (Local builds worked only because Bun loads \`.env.local\`; PR #110/#113 missed this.)

**Fix:** declare \`passThroughEnv: ["NOTRA_API_KEY"]\` on the fumadocs build task so the Vercel project env var reaches \`scripts/fetch-notra-posts.ts\`.

**Verified locally** (key only in shell env, no \`.env.local\`): without it turbo logs \"not set\" and skips; with it the fetch writes the published post.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*