### PR TITLE
feat(email-sdk): batch sends with per-recipient variable substitution

### DIFF
--- a/.changeset/batch-recipient-variables.md
+++ b/.changeset/batch-recipient-variables.md
@@ -1,0 +1,5 @@
+---
+"@opencoredev/email-sdk": minor
+---
+
+Add `recipientVariables` for per-recipient batch sends. Pass a single `to` list plus an address-keyed map of values and reference them with `%recipient.key%` tokens in `subject`, `html`, and `text`. Mailgun (`recipient-variables`) and SendGrid (one `personalizations` entry per recipient) substitute natively in a single API call; every other adapter falls back to one client-side rendered send per recipient, so the same code works on any route. Adapters can opt into native batch by implementing the new optional `EmailProvider.sendBulk`.

--- a/apps/fumadocs/content/docs/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs/adapters/field-support.mdx
@@ -52,6 +52,16 @@ Built in, no Nodemailer. SMTP maps address fields and headers directly into the 
 | ------- | --- | --- | -------- | ------- | -------- | ---- | ----------- |
 | SMTP    | Yes | Yes | Yes      | Yes     | No       | No   | No          |
 
+## Recipient variables
+
+`recipientVariables` personalizes a batch send with `%recipient.key%` tokens — see [the message reference](/docs/reference/message#recipient-variables). Unlike the fields above, it is never rejected: it works on **every** adapter. The difference is _how_:
+
+| Native batch — one API call | Client-side fallback — one send per recipient |
+| --------------------------- | --------------------------------------------- |
+| Mailgun, SendGrid           | every other adapter                           |
+
+Native routes substitute provider-side, so `%recipient.key%` reaches the provider untouched; fallback routes substitute before the request. The same message code runs on any route, so a fallback to a non-native adapter still personalizes every recipient.
+
 ## Choosing compatible routes
 
 A [fallback route](/docs/concepts/fallbacks-and-retries) is only safe when the backup adapter supports every field your messages actually use. Pick routes from your message shape, not provider popularity:

--- a/apps/fumadocs/content/docs/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailgun.mdx
@@ -75,6 +75,23 @@ console.log(result.id); // Mailgun message id, also exposed as result.messageId
 
 The response `id` is Mailgun's queued message id from the response body — match it against delivery events in webhooks or the Mailgun logs.
 
+### Batch sends with recipient variables
+
+Pass [`recipientVariables`](/docs/reference/message#recipient-variables) and Mailgun personalizes every recipient in a single call through its native `recipient-variables` field (up to 1000 recipients). `%recipient.key%` tokens in `subject`, `html`, and `text` are substituted server-side:
+
+```ts
+await email.send({
+  from: "Acme <hello@mg.acme.com>",
+  to: ["ada@example.com", "linus@example.com"],
+  subject: "Hi %recipient.name%",
+  html: '<a href="https://acme.com/unsub?id=%recipient.id%">Unsubscribe</a>',
+  recipientVariables: {
+    "ada@example.com": { name: "Ada", id: "u_1" },
+    "linus@example.com": { name: "Linus", id: "u_2" },
+  },
+});
+```
+
 ## Verify from the CLI
 
 ```bash

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -62,7 +62,7 @@ SendGrid's send endpoint returns `202 Accepted` with an empty body, so the adapt
 
 ### Batch sends with recipient variables
 
-Pass [`recipientVariables`](/docs/reference/message#recipient-variables) and the adapter emits one `personalizations` entry per recipient with SendGrid `substitutions`, personalizing every recipient in a single API call. `%recipient.key%` tokens in `subject`, `html`, and `text` are substituted server-side:
+Pass [`recipientVariables`](/docs/reference/message#recipient-variables) and the adapter emits one `personalizations` entry per recipient with SendGrid `substitutions`, personalizing every recipient in a single API call (up to 1000 recipients — SendGrid's personalizations cap). `%recipient.key%` tokens in `subject`, `html`, and `text` are substituted server-side:
 
 ```ts
 await email.send({

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -60,6 +60,23 @@ console.log(result.id); // SendGrid message id from the x-message-id header
 
 SendGrid's send endpoint returns `202 Accepted` with an empty body, so the adapter reads `result.id` from the `x-message-id` response header. `metadata` values arrive in SendGrid event webhooks as `custom_args`; tag values arrive as `categories`.
 
+### Batch sends with recipient variables
+
+Pass [`recipientVariables`](/docs/reference/message#recipient-variables) and the adapter emits one `personalizations` entry per recipient with SendGrid `substitutions`, personalizing every recipient in a single API call. `%recipient.key%` tokens in `subject`, `html`, and `text` are substituted server-side:
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: ["ada@example.com", "linus@example.com"],
+  subject: "Hi %recipient.name%",
+  html: '<a href="https://acme.com/unsub?id=%recipient.id%">Unsubscribe</a>',
+  recipientVariables: {
+    "ada@example.com": { name: "Ada", id: "u_1" },
+    "linus@example.com": { name: "Linus", id: "u_2" },
+  },
+});
+```
+
 ## Verify from the CLI
 
 ```bash

--- a/apps/fumadocs/content/docs/reference/client.mdx
+++ b/apps/fumadocs/content/docs/reference/client.mdx
@@ -77,6 +77,8 @@ const result = await email.send(message, {
 });
 ```
 
+For a personalized batch — one `send`, per-recipient content via [`recipientVariables`](/docs/reference/message#recipient-variables) — adapters with a native batch mechanism (Mailgun, SendGrid) send the whole list in one API call, and every other adapter renders one send per recipient.
+
 ### SendOptions
 
 <TypeTable

--- a/apps/fumadocs/content/docs/reference/message.mdx
+++ b/apps/fumadocs/content/docs/reference/message.mdx
@@ -175,13 +175,14 @@ await email.send({
 });
 ```
 
-Adapters with a native batch mechanism send the whole list in **one API call** with provider-side substitution — currently [Mailgun](/docs/adapters/mailgun) (`recipient-variables`, up to 1000 recipients) and [SendGrid](/docs/adapters/sendgrid) (one personalization per recipient). Every other adapter falls back to **one rendered send per recipient**, substituting tokens client-side, so the same code works on any route. The send resolves with a single [response](/docs/reference/client#response): native batches return the provider's id, and the client-side fallback aggregates per-recipient results into `accepted` and `rejected`.
+Adapters with a native batch mechanism send the whole list in **one API call** with provider-side substitution — currently [Mailgun](/docs/adapters/mailgun) (`recipient-variables`) and [SendGrid](/docs/adapters/sendgrid) (one personalization per recipient), each capped at 1000 recipients per call. Every other adapter falls back to **one rendered send per recipient**, substituting tokens client-side, so the same code works on any route. The send resolves with a single [response](/docs/reference/client#response): native batches return the provider's id, and the client-side fallback aggregates per-recipient results into `accepted` and `rejected`.
 
 - Each `recipientVariables` key must be an address in `to`; an unknown address fails fast.
+- Variable keys may only contain letters, numbers, underscores, and hyphens (`[\w-]`); anything else — like a dotted `user.name` — fails fast so substitution behaves identically on native and fallback routes.
 - `to` addresses must be unique; a duplicate combined with `recipientVariables` fails fast.
 - `cc` and `bcc` cannot be combined with `recipientVariables` — every recipient gets an individualized message.
 - An unknown `%recipient.key%` token is left intact, matching native provider behavior.
-- In the client-side fallback, each recipient is a real send: `afterSend` fires per delivered recipient and `onError` per failed one. If the send has an idempotency key (from send options or the message), it is suffixed per recipient (`<key>:<address>`) so retries dedupe per recipient instead of dropping the batch. Only when every recipient fails does the adapter count as failed and the next [fallback route](/docs/concepts/fallbacks-and-retries) run.
+- In the client-side fallback, each recipient is a real send: `afterSend` fires per delivered recipient and `onError` per failed one. If the send has an idempotency key (from send options or the message), it is suffixed per recipient (`<key>:<address>`) so retries dedupe per recipient instead of dropping the batch. The suffixed key counts toward provider key-length limits (Resend caps `Idempotency-Key` at 256 characters), so keep base keys short when using `recipientVariables`. Only when every recipient fails does the adapter count as failed and the next [fallback route](/docs/concepts/fallbacks-and-retries) run.
 
 ## Validation
 
@@ -197,6 +198,7 @@ Adapters with a native batch mechanism send the whole list in **one API call** w
 | `recipientVariables` with `cc`/`bcc` | `recipientVariables cannot be combined with cc or bcc because each recipient receives an individualized message.` |
 | `recipientVariables` address not in `to` | `recipientVariables reference addresses that are not in "to": <addresses>.` |
 | `recipientVariables` duplicate `to` | `recipientVariables require unique "to" addresses, but "<address>" appears more than once.` |
+| `recipientVariables` invalid key | `recipientVariables keys may only contain letters, numbers, underscores, and hyphens, but "<address>" has "<key>".` |
 
 Adapters add a second fail-fast layer for fields their provider cannot represent:
 

--- a/apps/fumadocs/content/docs/reference/message.mdx
+++ b/apps/fumadocs/content/docs/reference/message.mdx
@@ -20,6 +20,7 @@ type EmailMessage = {
   attachments?: EmailAttachment[];
   tags?: EmailTag[];
   metadata?: Record<string, string | number | boolean | null>;
+  recipientVariables?: Record<string, Record<string, string | number | boolean>>;
   idempotencyKey?: string;
 };
 ```
@@ -78,6 +79,10 @@ type EmailMessage = {
     metadata: {
       description: "Provider-side key-value data attached to the send.",
       type: "Record<string, string | number | boolean | null>",
+    },
+    recipientVariables: {
+      description: "Per-recipient %recipient.key% substitution values, keyed by recipient address.",
+      type: "Record<string, Record<string, string | number | boolean>>",
     },
     idempotencyKey: {
       description: "Stable send identity, used when send options set none.",
@@ -153,6 +158,31 @@ Support differs per provider — Resend has tags but no metadata, Iterable has m
 
 `idempotencyKey` gives the send a stable identity across retries. The send-options key wins when both are set; the message field is the fallback. Only Resend transmits it natively — see [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys) for per-adapter behavior.
 
+## Recipient variables
+
+`recipientVariables` turns one `send` into a personalized batch: keep a single `to` list and give each recipient its own values, keyed by email address. Reference a value anywhere in `subject`, `html`, or `text` with the `%recipient.key%` token.
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: ["ada@example.com", "linus@example.com"],
+  subject: "Hi %recipient.name%",
+  html: '<p>Hi %recipient.name%</p><a href="https://acme.com/unsub?id=%recipient.id%">Unsubscribe</a>',
+  recipientVariables: {
+    "ada@example.com": { name: "Ada", id: "u_1" },
+    "linus@example.com": { name: "Linus", id: "u_2" },
+  },
+});
+```
+
+Adapters with a native batch mechanism send the whole list in **one API call** with provider-side substitution — currently [Mailgun](/docs/adapters/mailgun) (`recipient-variables`, up to 1000 recipients) and [SendGrid](/docs/adapters/sendgrid) (one personalization per recipient). Every other adapter falls back to **one rendered send per recipient**, substituting tokens client-side, so the same code works on any route. The send resolves with a single [response](/docs/reference/client#response): native batches return the provider's id, and the client-side fallback aggregates per-recipient results into `accepted` and `rejected`.
+
+- Each `recipientVariables` key must be an address in `to`; an unknown address fails fast.
+- `to` addresses must be unique; a duplicate combined with `recipientVariables` fails fast.
+- `cc` and `bcc` cannot be combined with `recipientVariables` — every recipient gets an individualized message.
+- An unknown `%recipient.key%` token is left intact, matching native provider behavior.
+- In the client-side fallback, each recipient is a real send: `afterSend` fires per delivered recipient and `onError` per failed one. If the send has an idempotency key (from send options or the message), it is suffixed per recipient (`<key>:<address>`) so retries dedupe per recipient instead of dropping the batch. Only when every recipient fails does the adapter count as failed and the next [fallback route](/docs/concepts/fallbacks-and-retries) run.
+
 ## Validation
 
 `send` validates the message before any adapter runs and throws `EmailValidationError` (code `validation_error`) with one of these exact messages:
@@ -164,6 +194,9 @@ Support differs per provider — Resend has tags but no metadata, Iterable has m
 | `subject` is required | `Email message requires a subject.` |
 | `html` or `text` is required | `Email message requires either html or text content.` |
 | Attachments need data | `Attachment "<filename>" requires content or path.` |
+| `recipientVariables` with `cc`/`bcc` | `recipientVariables cannot be combined with cc or bcc because each recipient receives an individualized message.` |
+| `recipientVariables` address not in `to` | `recipientVariables reference addresses that are not in "to": <addresses>.` |
+| `recipientVariables` duplicate `to` | `recipientVariables require unique "to" addresses, but "<address>" appears more than once.` |
 
 Adapters add a second fail-fast layer for fields their provider cannot represent:
 

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -162,6 +162,40 @@ describe("provider payloads", () => {
     });
   });
 
+  test("SendGrid batch sending emits one personalization with substitutions per recipient", async () => {
+    const capture = jsonCapture({}, { headers: { "x-message-id": "sg_batch" } });
+    const provider = sendgrid({ apiKey: "sg", fetch: capture.fetch });
+
+    expect(provider.sendBulk).toBeDefined();
+    const response = await provider.sendBulk?.(
+      {
+        from: "Acme <hello@acme.com>",
+        to: ["a@example.com", { email: "b@example.com", name: "Linus" }],
+        subject: "Hi %recipient.name%",
+        html: "<p>Hi %recipient.name%</p>",
+        recipientVariables: {
+          "a@example.com": { name: "Ada", id: "u_1" },
+          "b@example.com": { name: "Linus", id: "u_2" },
+        },
+      },
+      context,
+    );
+
+    expect(response?.id).toBe("sg_batch");
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.calls[0]?.json.personalizations).toEqual([
+      {
+        to: [{ email: "a@example.com" }],
+        substitutions: { "%recipient.name%": "Ada", "%recipient.id%": "u_1" },
+      },
+      {
+        to: [{ email: "b@example.com", name: "Linus" }],
+        substitutions: { "%recipient.name%": "Linus", "%recipient.id%": "u_2" },
+      },
+    ]);
+    expect(capture.calls[0]?.json.subject).toBe("Hi %recipient.name%");
+  });
+
   test("Cloudflare maps REST payloads and delivery status", async () => {
     const capture = jsonCapture({
       success: true,
@@ -362,6 +396,54 @@ describe("provider payloads", () => {
     expect(capture.calls[0]?.form.getAll("to")).toEqual(["Ada <ada@example.com>"]);
     expect(capture.calls[0]?.form.get("h:X-Test")).toBe("yes");
     expect(capture.calls[0]?.files).toEqual([{ field: "attachment", name: "hello.txt" }]);
+  });
+
+  test("Mailgun batch sending attaches recipient-variables for one personalized call", async () => {
+    const capture = formCapture({ id: "<mailgun_batch>" });
+    const provider = mailgun({ apiKey: "mg", domain: "mg.example.com", fetch: capture.fetch });
+
+    expect(provider.sendBulk).toBeDefined();
+    await provider.sendBulk?.(
+      {
+        from: "Acme <hello@acme.com>",
+        to: ["a@example.com", "b@example.com"],
+        subject: "Hi %recipient.name%",
+        html: "<p>Hi %recipient.name%</p>",
+        recipientVariables: {
+          "a@example.com": { name: "Ada", id: "u_1" },
+          "b@example.com": { name: "Linus", id: "u_2" },
+        },
+      },
+      context,
+    );
+
+    expect(capture.calls).toHaveLength(1);
+    expect(capture.calls[0]?.form.getAll("to")).toEqual(["a@example.com", "b@example.com"]);
+    expect(capture.calls[0]?.form.get("subject")).toBe("Hi %recipient.name%");
+    expect(JSON.parse(String(capture.calls[0]?.form.get("recipient-variables")))).toEqual({
+      "a@example.com": { name: "Ada", id: "u_1" },
+      "b@example.com": { name: "Linus", id: "u_2" },
+    });
+  });
+
+  test("Mailgun batch sending rejects more than 1000 recipients", async () => {
+    const capture = formCapture({ id: "<mailgun_batch>" });
+    const provider = mailgun({ apiKey: "mg", domain: "mg.example.com", fetch: capture.fetch });
+    const to = Array.from({ length: 1001 }, (_, index) => `user${index}@example.com`);
+
+    await expect(
+      provider.sendBulk?.(
+        {
+          from: "Acme <hello@acme.com>",
+          to,
+          subject: "Hi %recipient.name%",
+          text: "Hi %recipient.name%",
+          recipientVariables: { "user0@example.com": { name: "Ada" } },
+        },
+        context,
+      ),
+    ).rejects.toThrow(EmailValidationError);
+    expect(capture.calls).toHaveLength(0);
   });
 
   test("JSON adapters expose fetch injection and stable core fields", async () => {

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -196,6 +196,26 @@ describe("provider payloads", () => {
     expect(capture.calls[0]?.json.subject).toBe("Hi %recipient.name%");
   });
 
+  test("SendGrid batch sending rejects more than 1000 recipients", async () => {
+    const capture = jsonCapture({}, { headers: { "x-message-id": "sg_batch" } });
+    const provider = sendgrid({ apiKey: "sg", fetch: capture.fetch });
+    const to = Array.from({ length: 1001 }, (_, index) => `user${index}@example.com`);
+
+    await expect(
+      provider.sendBulk?.(
+        {
+          from: "Acme <hello@acme.com>",
+          to,
+          subject: "Hi %recipient.name%",
+          text: "Hi %recipient.name%",
+          recipientVariables: { "user0@example.com": { name: "Ada" } },
+        },
+        context,
+      ),
+    ).rejects.toThrow(EmailValidationError);
+    expect(capture.calls).toHaveLength(0);
+  });
+
   test("Cloudflare maps REST payloads and delivery status", async () => {
     const capture = jsonCapture({
       success: true,

--- a/packages/email-sdk/src/core.test.ts
+++ b/packages/email-sdk/src/core.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { createEmailClient } from "./core.js";
 import { EmailProviderError, EmailValidationError } from "./errors.js";
 import { failingProvider, memoryProvider } from "./testing.js";
+import type { EmailMessage, EmailProvider, EmailProviderContext } from "./types.js";
 
 const message = {
   from: "hello@example.com",
@@ -281,3 +282,212 @@ describe("createEmailClient", () => {
     });
   });
 });
+
+const batchMessage: EmailMessage = {
+  from: "Acme <hello@acme.com>",
+  to: ["a@example.com", "b@example.com"],
+  subject: "Hi %recipient.name%",
+  html: '<p>Hi %recipient.name%</p><a href="https://acme.com/u?id=%recipient.id%">Unsub</a>',
+  recipientVariables: {
+    "a@example.com": { name: "Ada", id: "u_1" },
+    "b@example.com": { name: "Linus", id: "u_2" },
+  },
+};
+
+describe("recipientVariables", () => {
+  test("routes to a native sendBulk in a single call", async () => {
+    const { provider, calls } = recordingProvider("native", { bulk: true });
+    const client = createEmailClient({ adapters: [provider] });
+
+    const response = await client.send(batchMessage);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.kind).toBe("sendBulk");
+    expect(calls[0]?.message.to).toEqual(["a@example.com", "b@example.com"]);
+    expect(calls[0]?.message.recipientVariables).toEqual(batchMessage.recipientVariables);
+    expect(response.provider).toBe("native");
+  });
+
+  test("expands per recipient when the adapter has no native batch", async () => {
+    const provider = memoryProvider();
+    const client = createEmailClient({ adapters: [provider] });
+
+    const response = await client.send(batchMessage);
+
+    expect(provider.raw.sent).toHaveLength(2);
+    const [first, second] = provider.raw.sent;
+    expect(first?.message.to).toBe("a@example.com");
+    expect(first?.message.subject).toBe("Hi Ada");
+    expect(first?.message.html).toContain("Hi Ada");
+    expect(first?.message.html).toContain("id=u_1");
+    expect(first?.message.recipientVariables).toBeUndefined();
+    expect(second?.message.subject).toBe("Hi Linus");
+    expect(second?.message.html).toContain("id=u_2");
+
+    expect(response.provider).toBe("memory");
+    expect(response.accepted).toEqual(["a@example.com", "b@example.com"]);
+  });
+
+  test("substitutes html and text and keeps regex-special values literal", async () => {
+    const provider = memoryProvider();
+    const client = createEmailClient({ adapters: [provider] });
+
+    await client.send({
+      from: "hello@example.com",
+      to: ["a@example.com"],
+      subject: "Hi %recipient.name%",
+      html: "<p>%recipient.name% owes %recipient.amount%</p>",
+      text: "%recipient.name% owes %recipient.amount%",
+      recipientVariables: {
+        "a@example.com": { name: "A. $& (Ada)", amount: "$100.50" },
+      },
+    });
+
+    const sent = provider.raw.sent[0]?.message;
+    expect(sent?.subject).toBe("Hi A. $& (Ada)");
+    expect(sent?.html).toBe("<p>A. $& (Ada) owes $100.50</p>");
+    expect(sent?.text).toBe("A. $& (Ada) owes $100.50");
+  });
+
+  test("leaves unknown %recipient% tokens intact", async () => {
+    const provider = memoryProvider();
+    const client = createEmailClient({ adapters: [provider] });
+
+    await client.send({
+      from: "hello@example.com",
+      to: ["a@example.com"],
+      subject: "Hi %recipient.name% %recipient.missing%",
+      text: "x",
+      recipientVariables: { "a@example.com": { name: "Ada" } },
+    });
+
+    expect(provider.raw.sent[0]?.message.subject).toBe("Hi Ada %recipient.missing%");
+  });
+
+  test("derives a per-recipient idempotency key in the fallback", async () => {
+    const { provider, calls } = recordingProvider("rec");
+    const client = createEmailClient({ adapters: [provider] });
+
+    await client.send({ ...batchMessage, idempotencyKey: "batch-1" });
+
+    expect(calls.map((call) => call.context.idempotencyKey)).toEqual([
+      "batch-1:a@example.com",
+      "batch-1:b@example.com",
+    ]);
+  });
+
+  test("falls back to the next adapter when every recipient fails", async () => {
+    const client = createEmailClient({
+      adapters: [failingProvider("primary"), memoryProvider("backup")],
+      fallback: ["backup"],
+    });
+
+    const response = await client.send(batchMessage);
+
+    expect(response.provider).toBe("backup");
+    expect(response.accepted).toEqual(["a@example.com", "b@example.com"]);
+  });
+
+  test("rejects recipientVariables combined with cc", async () => {
+    const client = createEmailClient({ adapters: [memoryProvider()] });
+
+    await expect(client.send({ ...batchMessage, cc: "cc@example.com" })).rejects.toBeInstanceOf(
+      EmailValidationError,
+    );
+  });
+
+  test("rejects recipientVariables for addresses not in to", async () => {
+    const client = createEmailClient({ adapters: [memoryProvider()] });
+
+    await expect(
+      client.send({
+        ...batchMessage,
+        recipientVariables: { "stranger@example.com": { name: "X" } },
+      }),
+    ).rejects.toBeInstanceOf(EmailValidationError);
+  });
+
+  test("treats empty recipientVariables as a normal send", async () => {
+    const { provider, calls } = recordingProvider("native", { bulk: true });
+    const client = createEmailClient({ adapters: [provider] });
+
+    await client.send({
+      from: "hello@example.com",
+      to: ["a@example.com", "b@example.com"],
+      subject: "Hi",
+      text: "x",
+      recipientVariables: {},
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.kind).toBe("send");
+  });
+
+  test("rejects duplicate to addresses with recipientVariables", async () => {
+    const client = createEmailClient({ adapters: [memoryProvider()] });
+
+    await expect(
+      client.send({
+        from: "hello@example.com",
+        to: ["a@example.com", "a@example.com"],
+        subject: "Hi",
+        text: "x",
+        recipientVariables: { "a@example.com": { name: "Ada" } },
+      }),
+    ).rejects.toBeInstanceOf(EmailValidationError);
+  });
+
+  test("fires onError per rejected recipient and reports partial results in the fallback", async () => {
+    const errored: string[] = [];
+    const provider: EmailProvider = {
+      name: "partial",
+      send(outgoing) {
+        if (outgoing.to === "b@example.com") {
+          throw new EmailProviderError("rejected", { provider: "partial", retryable: false });
+        }
+
+        return { provider: "partial", id: "ok" };
+      },
+    };
+    const client = createEmailClient({
+      adapters: [provider],
+      hooks: {
+        onError(event) {
+          errored.push(String(event.message.to));
+        },
+      },
+    });
+
+    const response = await client.send(batchMessage);
+
+    expect(response.accepted).toEqual(["a@example.com"]);
+    expect(response.rejected).toEqual(["b@example.com"]);
+    expect(errored).toEqual(["b@example.com"]);
+  });
+});
+
+type RecordedCall = {
+  kind: "send" | "sendBulk";
+  message: EmailMessage;
+  context: EmailProviderContext;
+};
+
+function recordingProvider(name: string, options: { bulk?: boolean } = {}) {
+  const calls: RecordedCall[] = [];
+  const provider: EmailProvider = {
+    name,
+    send(message, context) {
+      calls.push({ kind: "send", message, context });
+      return { provider: name, id: `${name}_${calls.length}` };
+    },
+  };
+
+  if (options.bulk) {
+    provider.sendBulk = (message, context) => {
+      calls.push({ kind: "sendBulk", message, context });
+      return { provider: name, id: `${name}_bulk` };
+    };
+  }
+
+  return { provider, calls };
+}

--- a/packages/email-sdk/src/core.test.ts
+++ b/packages/email-sdk/src/core.test.ts
@@ -308,6 +308,30 @@ describe("recipientVariables", () => {
     expect(response.provider).toBe("native");
   });
 
+  test("invokes sendBulk on the provider so class-based adapters keep `this`", async () => {
+    class ClassProvider implements EmailProvider {
+      name = "class";
+      apiKey = "secret_key";
+
+      send() {
+        return { provider: this.name, id: "single" };
+      }
+
+      sendBulk() {
+        // Regression: a detached `perform: provider.sendBulk` loses `this`, making
+        // fields like apiKey silently undefined for class-based adapters.
+        return { provider: this.name, id: this.apiKey };
+      }
+    }
+
+    const client = createEmailClient({ adapters: [new ClassProvider()] });
+
+    const response = await client.send(batchMessage);
+
+    expect(response.provider).toBe("class");
+    expect(response.id).toBe("secret_key");
+  });
+
   test("expands per recipient when the adapter has no native batch", async () => {
     const provider = memoryProvider();
     const client = createEmailClient({ adapters: [provider] });
@@ -405,6 +429,39 @@ describe("recipientVariables", () => {
         recipientVariables: { "stranger@example.com": { name: "X" } },
       }),
     ).rejects.toBeInstanceOf(EmailValidationError);
+  });
+
+  test("rejects variable keys outside letters, numbers, underscores, and hyphens", async () => {
+    const client = createEmailClient({ adapters: [memoryProvider()] });
+
+    // Dotted keys personalize on native provider routes but stay literal in the
+    // client-side fallback regex, so they must fail fast on every route.
+    await expect(
+      client.send({
+        from: "hello@example.com",
+        to: ["a@example.com"],
+        subject: "Hi %recipient.user.name%",
+        text: "x",
+        recipientVariables: { "a@example.com": { "user.name": "Ada" } },
+      }),
+    ).rejects.toThrow(
+      'recipientVariables keys may only contain letters, numbers, underscores, and hyphens, but "a@example.com" has "user.name".',
+    );
+  });
+
+  test("accepts variable keys with underscores and hyphens", async () => {
+    const provider = memoryProvider();
+    const client = createEmailClient({ adapters: [provider] });
+
+    await client.send({
+      from: "hello@example.com",
+      to: ["a@example.com"],
+      subject: "Hi %recipient.first_name% %recipient.last-name%",
+      text: "x",
+      recipientVariables: { "a@example.com": { first_name: "Ada", "last-name": "Lovelace" } },
+    });
+
+    expect(provider.raw.sent[0]?.message.subject).toBe("Hi Ada Lovelace");
   });
 
   test("treats empty recipientVariables as a normal send", async () => {

--- a/packages/email-sdk/src/core.ts
+++ b/packages/email-sdk/src/core.ts
@@ -262,9 +262,20 @@ type ProviderAttempt = {
 
 function attemptProvider(input: ProviderAttempt): Promise<EmailProviderResponse> {
   if (hasRecipientVariables(input.message)) {
-    return input.provider.sendBulk
-      ? sendWithRetry({ ...input, perform: input.provider.sendBulk })
-      : sendBulkViaFallback(input);
+    const { provider } = input;
+    const sendBulk = provider.sendBulk;
+
+    if (!sendBulk) {
+      return sendBulkViaFallback(input);
+    }
+
+    // 2026-07-06: sendBulk must stay invoked on the provider (not passed detached), so
+    // class-based adapters that read `this` inside sendBulk keep working. `send` already
+    // gets this via `input.provider.send(...)` in sendWithRetry.
+    return sendWithRetry({
+      ...input,
+      perform: (message, context) => sendBulk.call(provider, message, context),
+    });
   }
 
   return sendWithRetry(input);

--- a/packages/email-sdk/src/core.ts
+++ b/packages/email-sdk/src/core.ts
@@ -4,6 +4,7 @@ import {
   EmailValidationError,
   isRetryableEmailError,
 } from "./errors.js";
+import { expandRecipientMessage, recipientVariableEntries } from "./payloads.js";
 import type {
   EmailAfterSendEvent,
   EmailBeforeSendEvent,
@@ -22,7 +23,12 @@ import type {
   SendBatchResult,
   SendOptions,
 } from "./types.js";
-import { assertMessage, toProviderError } from "./utils.js";
+import {
+  assertMessage,
+  assertRecipientVariables,
+  hasRecipientVariables,
+  toProviderError,
+} from "./utils.js";
 
 const defaultDelay = (attempt: number) => Math.min(100 * 2 ** (attempt - 1), 2_000);
 
@@ -189,6 +195,7 @@ async function sendWithAdapters(input: {
   });
 
   assertMessage(prepared.message);
+  assertRecipientVariables(prepared.message);
 
   const adapterNames = resolveAdapterOrder({
     adapter:
@@ -209,7 +216,7 @@ async function sendWithAdapters(input: {
     }
 
     try {
-      return await sendWithRetry({
+      return await attemptProvider({
         provider,
         message: prepared.message,
         hookList: input.options.hookList,
@@ -223,15 +230,13 @@ async function sendWithAdapters(input: {
     } catch (error) {
       const failure = unwrapProviderAttemptFailure(error);
       failures.push(failure.error);
-      const event = {
+      await invokeErrorHooks(input.options.middleware, input.options.hookList, {
         provider: provider.name,
         message: prepared.message,
         attempt: failure.attempt,
         metadata: prepared.options?.metadata,
         error: failure.error,
-      };
-      await invokeErrorMiddleware(input.options.middleware, event);
-      await invokeHooks(input.options.hookList, "onError", event);
+      });
     }
   }
 
@@ -246,14 +251,95 @@ async function sendWithAdapters(input: {
   });
 }
 
-async function sendWithRetry(input: {
+type ProviderAttempt = {
   provider: EmailProvider;
   message: EmailMessage;
   hookList: NonNullable<EmailClientOptions["hooks"]>[];
   middleware: EmailSendMiddleware[];
   retry: EmailClientOptions["retry"];
   sendOptions?: SendOptions;
-}) {
+};
+
+function attemptProvider(input: ProviderAttempt): Promise<EmailProviderResponse> {
+  if (hasRecipientVariables(input.message)) {
+    return input.provider.sendBulk
+      ? sendWithRetry({ ...input, perform: input.provider.sendBulk })
+      : sendBulkViaFallback(input);
+  }
+
+  return sendWithRetry(input);
+}
+
+async function sendBulkViaFallback(input: ProviderAttempt): Promise<EmailProviderResponse> {
+  const accepted: string[] = [];
+  const rejected: string[] = [];
+  const responses: EmailProviderResponse[] = [];
+  const failures: unknown[] = [];
+
+  for (const entry of recipientVariableEntries(input.message)) {
+    const message = expandRecipientMessage(input.message, entry);
+
+    try {
+      const response = await sendWithRetry({
+        provider: input.provider,
+        message,
+        hookList: input.hookList,
+        middleware: input.middleware,
+        retry: input.retry,
+        sendOptions: withRecipientIdempotencyKey(input.sendOptions, input.message, entry.address),
+      });
+      responses.push(response);
+      accepted.push(entry.address);
+    } catch (error) {
+      const failure = unwrapProviderAttemptFailure(error);
+      rejected.push(entry.address);
+      failures.push(failure.error);
+      await invokeErrorHooks(input.middleware, input.hookList, {
+        provider: input.provider.name,
+        message,
+        attempt: failure.attempt,
+        metadata: input.sendOptions?.metadata,
+        error: failure.error,
+      });
+    }
+  }
+
+  if (accepted.length === 0) {
+    throw new ProviderAttemptFailure(
+      failures.length === 1
+        ? failures[0]
+        : new EmailSdkError("All batch recipients failed.", {
+            code: "all_recipients_failed",
+            retryable: false,
+            details: failures,
+          }),
+      1,
+    );
+  }
+
+  return {
+    provider: input.provider.name,
+    accepted,
+    rejected: rejected.length > 0 ? rejected : undefined,
+    raw: responses,
+  };
+}
+
+function withRecipientIdempotencyKey(
+  sendOptions: SendOptions | undefined,
+  message: EmailMessage,
+  address: string,
+): SendOptions | undefined {
+  const base = sendOptions?.idempotencyKey ?? message.idempotencyKey;
+
+  if (!base) {
+    return sendOptions;
+  }
+
+  return { ...sendOptions, idempotencyKey: `${base}:${address}` };
+}
+
+async function sendWithRetry(input: ProviderAttempt & { perform?: EmailProvider["send"] }) {
   const retries = input.retry?.retries ?? 0;
   const shouldRetry = input.retry?.shouldRetry ?? isRetryableEmailError;
   const delayFor = input.retry?.delay ?? defaultDelay;
@@ -267,12 +353,15 @@ async function sendWithRetry(input: {
     });
 
     try {
-      const response = await input.provider.send(input.message, {
+      const context = {
         signal: input.sendOptions?.signal,
         idempotencyKey: input.sendOptions?.idempotencyKey ?? input.message.idempotencyKey,
         attempt,
         metadata: input.sendOptions?.metadata,
-      });
+      };
+      const response = input.perform
+        ? await input.perform(input.message, context)
+        : await input.provider.send(input.message, context);
 
       const normalizedResponse = {
         ...response,
@@ -413,6 +502,15 @@ async function invokeErrorMiddleware(middleware: EmailSendMiddleware[], event: E
   for (const item of middleware) {
     await invokeHook(item.onError, event);
   }
+}
+
+async function invokeErrorHooks(
+  middleware: EmailSendMiddleware[],
+  hookList: NonNullable<EmailClientOptions["hooks"]>[],
+  event: EmailErrorEvent,
+) {
+  await invokeErrorMiddleware(middleware, event);
+  await invokeHooks(hookList, "onError", event);
 }
 
 class ProviderAttemptFailure {

--- a/packages/email-sdk/src/index.ts
+++ b/packages/email-sdk/src/index.ts
@@ -28,6 +28,7 @@ export type {
   EmailRetryConfig,
   EmailSendMiddleware,
   EmailTag,
+  RecipientVariables,
   SendBatchItem,
   SendBatchResult,
   SendOptions,

--- a/packages/email-sdk/src/mailgun.ts
+++ b/packages/email-sdk/src/mailgun.ts
@@ -1,9 +1,13 @@
 import { EmailProviderError } from "./errors.js";
+import { recipientVariablesMap } from "./payloads.js";
 import type { EmailProvider } from "./types.js";
 import {
+  arrayify,
+  assertMaxItems,
   attachmentToBytes,
   formatAddress,
   formatAddresses,
+  hasRecipientVariables,
   isRetryableStatus,
   readErrorBody,
   httpErrorMessage,
@@ -19,85 +23,96 @@ export type MailgunProviderOptions = {
 export function mailgun(options: MailgunProviderOptions): EmailProvider<{ baseUrl: string }> {
   const baseUrl = options.baseUrl ?? "https://api.mailgun.net";
 
+  const send: EmailProvider["send"] = async (message, context) => {
+    const body = new FormData();
+    body.set("from", formatAddress(message.from));
+    body.set("subject", message.subject);
+
+    for (const to of formatAddresses(message.to)) body.append("to", to);
+    for (const cc of formatAddresses(message.cc)) body.append("cc", cc);
+    for (const bcc of formatAddresses(message.bcc)) body.append("bcc", bcc);
+    for (const replyTo of formatAddresses(message.replyTo)) body.append("h:Reply-To", replyTo);
+    for (const [name, value] of Object.entries(message.headers ?? {})) {
+      if (Array.isArray(message.headers)) {
+        break;
+      }
+
+      body.append(`h:${name}`, value);
+    }
+
+    if (Array.isArray(message.headers)) {
+      for (const header of message.headers) {
+        body.append(`h:${header.name}`, header.value);
+      }
+    }
+
+    if (message.text) body.set("text", message.text);
+    if (message.html) body.set("html", message.html);
+
+    // Mailgun batch sending: %recipient.key% tokens in the body are substituted per
+    // recipient, and recipient-variables tells Mailgun to send an individual email to
+    // each address (≤1000 per call) instead of one shared message.
+    if (hasRecipientVariables(message)) {
+      assertMaxItems("mailgun", "recipient", arrayify(message.to), 1000);
+      body.set("recipient-variables", JSON.stringify(recipientVariablesMap(message)));
+    }
+
+    for (const [name, value] of Object.entries(message.metadata ?? {})) {
+      body.set(`v:${name}`, String(value));
+    }
+
+    for (const tag of message.tags ?? []) {
+      body.append("o:tag", tag.value);
+    }
+
+    for (const attachment of message.attachments ?? []) {
+      const bytes = await attachmentToBytes(attachment);
+      const blob = new Blob([bytes], {
+        type: attachment.contentType ?? "application/octet-stream",
+      });
+      body.append(
+        attachment.disposition === "inline" ? "inline" : "attachment",
+        blob,
+        attachment.filename,
+      );
+    }
+
+    const fetcher = options.fetch ?? fetch;
+    const response = await fetcher(`${baseUrl}/v3/${options.domain}/messages`, {
+      method: "POST",
+      signal: context.signal,
+      headers: {
+        Authorization: `Basic ${Buffer.from(`api:${options.apiKey}`).toString("base64")}`,
+      },
+      body,
+    });
+
+    const responseBody = await readErrorBody(response);
+
+    if (!response.ok) {
+      throw new EmailProviderError(httpErrorMessage("mailgun", response.status, responseBody), {
+        provider: "mailgun",
+        status: response.status,
+        retryable: isRetryableStatus(response.status),
+        details: responseBody,
+      });
+    }
+
+    const record = responseBody as Record<string, unknown>;
+    const id = typeof record.id === "string" ? record.id : undefined;
+
+    return {
+      provider: "mailgun",
+      id,
+      messageId: id,
+      raw: responseBody,
+    };
+  };
+
   return {
     name: "mailgun",
     raw: { baseUrl },
-    async send(message, context) {
-      const body = new FormData();
-      body.set("from", formatAddress(message.from));
-      body.set("subject", message.subject);
-
-      for (const to of formatAddresses(message.to)) body.append("to", to);
-      for (const cc of formatAddresses(message.cc)) body.append("cc", cc);
-      for (const bcc of formatAddresses(message.bcc)) body.append("bcc", bcc);
-      for (const replyTo of formatAddresses(message.replyTo)) body.append("h:Reply-To", replyTo);
-      for (const [name, value] of Object.entries(message.headers ?? {})) {
-        if (Array.isArray(message.headers)) {
-          break;
-        }
-
-        body.append(`h:${name}`, value);
-      }
-
-      if (Array.isArray(message.headers)) {
-        for (const header of message.headers) {
-          body.append(`h:${header.name}`, header.value);
-        }
-      }
-
-      if (message.text) body.set("text", message.text);
-      if (message.html) body.set("html", message.html);
-
-      for (const [name, value] of Object.entries(message.metadata ?? {})) {
-        body.set(`v:${name}`, String(value));
-      }
-
-      for (const tag of message.tags ?? []) {
-        body.append("o:tag", tag.value);
-      }
-
-      for (const attachment of message.attachments ?? []) {
-        const bytes = await attachmentToBytes(attachment);
-        const blob = new Blob([bytes], {
-          type: attachment.contentType ?? "application/octet-stream",
-        });
-        body.append(
-          attachment.disposition === "inline" ? "inline" : "attachment",
-          blob,
-          attachment.filename,
-        );
-      }
-
-      const fetcher = options.fetch ?? fetch;
-      const response = await fetcher(`${baseUrl}/v3/${options.domain}/messages`, {
-        method: "POST",
-        signal: context.signal,
-        headers: {
-          Authorization: `Basic ${Buffer.from(`api:${options.apiKey}`).toString("base64")}`,
-        },
-        body,
-      });
-
-      const responseBody = await readErrorBody(response);
-
-      if (!response.ok) {
-        throw new EmailProviderError(httpErrorMessage("mailgun", response.status, responseBody), {
-          provider: "mailgun",
-          status: response.status,
-          retryable: isRetryableStatus(response.status),
-          details: responseBody,
-        });
-      }
-
-      const record = responseBody as Record<string, unknown>;
-      const id = typeof record.id === "string" ? record.id : undefined;
-
-      return {
-        provider: "mailgun",
-        id,
-        messageId: id,
-        raw: responseBody,
-      };
-    },
+    send,
+    sendBulk: send,
   };
 }

--- a/packages/email-sdk/src/payloads.ts
+++ b/packages/email-sdk/src/payloads.ts
@@ -1,7 +1,9 @@
-import type { EmailMessage } from "./types.js";
+import type { EmailAddress, EmailMessage, RecipientVariables } from "./types.js";
 import {
+  arrayify,
   assertMaxItems,
   attachmentToBase64,
+  emailAddressOf,
   formatAddress,
   formatAddresses,
   headersToArray,
@@ -95,6 +97,66 @@ export async function sendgridAttachments(message: EmailMessage) {
     content_id: attachment.contentId,
     disposition: attachment.disposition,
   }));
+}
+
+export type RecipientEntry = {
+  to: EmailAddress;
+  address: string;
+  variables: Record<string, string | number | boolean>;
+};
+
+/** Replace `%recipient.key%` tokens; unknown keys are left intact to match native providers. */
+export function substituteRecipientVariables(
+  text: string,
+  variables: Record<string, string | number | boolean>,
+): string {
+  return text.replace(/%recipient\.([\w-]+)%/g, (token, key) =>
+    Object.prototype.hasOwnProperty.call(variables, key) ? String(variables[key]) : token,
+  );
+}
+
+function recipientVariablesLookup(recipientVariables: RecipientVariables | undefined) {
+  const lookup = new Map<string, Record<string, string | number | boolean>>();
+
+  for (const [address, variables] of Object.entries(recipientVariables ?? {})) {
+    lookup.set(address.toLowerCase(), variables);
+  }
+
+  return lookup;
+}
+
+/** One entry per `to` recipient, each paired with its variables (empty object when none). */
+export function recipientVariableEntries(message: EmailMessage): RecipientEntry[] {
+  const lookup = recipientVariablesLookup(message.recipientVariables);
+
+  return arrayify(message.to).map((to) => {
+    const address = emailAddressOf(to);
+    return { to, address, variables: lookup.get(address.toLowerCase()) ?? {} };
+  });
+}
+
+/** Address-keyed map covering every recipient, so providers like Mailgun individualize each one. */
+export function recipientVariablesMap(message: EmailMessage): RecipientVariables {
+  const map: RecipientVariables = {};
+
+  for (const entry of recipientVariableEntries(message)) {
+    map[entry.address] = entry.variables;
+  }
+
+  return map;
+}
+
+/** Render one single-recipient message with its variables substituted into the content. */
+export function expandRecipientMessage(message: EmailMessage, entry: RecipientEntry): EmailMessage {
+  return {
+    ...message,
+    to: entry.to,
+    recipientVariables: undefined,
+    idempotencyKey: undefined,
+    subject: substituteRecipientVariables(message.subject, entry.variables),
+    html: message.html ? substituteRecipientVariables(message.html, entry.variables) : undefined,
+    text: message.text ? substituteRecipientVariables(message.text, entry.variables) : undefined,
+  };
 }
 
 export function commonHeadersObject(message: EmailMessage) {

--- a/packages/email-sdk/src/sendgrid.ts
+++ b/packages/email-sdk/src/sendgrid.ts
@@ -4,9 +4,11 @@ import {
   apiAddresses,
   commonHeadersObject,
   optionalApiAddresses,
+  recipientVariableEntries,
   sendgridAttachments,
 } from "./payloads.js";
-import type { EmailProvider } from "./types.js";
+import type { EmailMessage, EmailProvider } from "./types.js";
+import { hasRecipientVariables } from "./utils.js";
 
 export type SendGridProviderOptions = {
   apiKey: string;
@@ -15,7 +17,7 @@ export type SendGridProviderOptions = {
 };
 
 export function sendgrid(options: SendGridProviderOptions): EmailProvider<{ baseUrl: string }> {
-  return jsonProvider({
+  const provider = jsonProvider({
     name: "sendgrid",
     baseUrl: options.baseUrl ?? "https://api.sendgrid.com",
     endpoint: "/v3/mail/send",
@@ -25,15 +27,7 @@ export function sendgrid(options: SendGridProviderOptions): EmailProvider<{ base
     fetch: options.fetch,
     async buildPayload(message) {
       return {
-        personalizations: [
-          {
-            to: apiAddresses(message.to),
-            cc: optionalApiAddresses(message.cc),
-            bcc: optionalApiAddresses(message.bcc),
-            headers: commonHeadersObject(message),
-            custom_args: message.metadata,
-          },
-        ],
+        personalizations: sendgridPersonalizations(message),
         from: apiAddress(message.from),
         reply_to_list: optionalApiAddresses(message.replyTo),
         subject: message.subject,
@@ -56,4 +50,39 @@ export function sendgrid(options: SendGridProviderOptions): EmailProvider<{ base
       };
     },
   });
+
+  return { ...provider, sendBulk: provider.send };
+}
+
+// With recipientVariables, emit one personalization per recipient so SendGrid substitutes
+// each recipient's %recipient.key% tokens in a single API call; otherwise one shared personalization.
+function sendgridPersonalizations(message: EmailMessage) {
+  if (hasRecipientVariables(message)) {
+    return recipientVariableEntries(message).map((entry) => ({
+      to: [apiAddress(entry.to)],
+      headers: commonHeadersObject(message),
+      custom_args: message.metadata,
+      substitutions: recipientSubstitutions(entry.variables),
+    }));
+  }
+
+  return [
+    {
+      to: apiAddresses(message.to),
+      cc: optionalApiAddresses(message.cc),
+      bcc: optionalApiAddresses(message.bcc),
+      headers: commonHeadersObject(message),
+      custom_args: message.metadata,
+    },
+  ];
+}
+
+function recipientSubstitutions(variables: Record<string, string | number | boolean>) {
+  const substitutions: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(variables)) {
+    substitutions[`%recipient.${key}%`] = String(value);
+  }
+
+  return substitutions;
 }

--- a/packages/email-sdk/src/sendgrid.ts
+++ b/packages/email-sdk/src/sendgrid.ts
@@ -8,7 +8,7 @@ import {
   sendgridAttachments,
 } from "./payloads.js";
 import type { EmailMessage, EmailProvider } from "./types.js";
-import { hasRecipientVariables } from "./utils.js";
+import { arrayify, assertMaxItems, hasRecipientVariables } from "./utils.js";
 
 export type SendGridProviderOptions = {
   apiKey: string;
@@ -58,6 +58,9 @@ export function sendgrid(options: SendGridProviderOptions): EmailProvider<{ base
 // each recipient's %recipient.key% tokens in a single API call; otherwise one shared personalization.
 function sendgridPersonalizations(message: EmailMessage) {
   if (hasRecipientVariables(message)) {
+    // SendGrid caps personalizations at 1000 per request; fail fast like Mailgun does.
+    assertMaxItems("sendgrid", "recipient", arrayify(message.to), 1000);
+
     return recipientVariableEntries(message).map((entry) => ({
       to: [apiAddress(entry.to)],
       headers: commonHeadersObject(message),

--- a/packages/email-sdk/src/types.ts
+++ b/packages/email-sdk/src/types.ts
@@ -29,6 +29,14 @@ export type EmailTag = {
   value: string;
 };
 
+/**
+ * Per-recipient substitution values, keyed by recipient email address. Reference
+ * a value inside `subject`, `html`, or `text` with the `%recipient.key%` token.
+ * Providers with a native batch mechanism (Mailgun, SendGrid) substitute these in
+ * a single API call; other adapters fall back to one rendered send per recipient.
+ */
+export type RecipientVariables = Record<string, Record<string, string | number | boolean>>;
+
 export type EmailMessage = {
   from: EmailAddress;
   to: OneOrMany<EmailAddress>;
@@ -42,6 +50,7 @@ export type EmailMessage = {
   attachments?: EmailAttachment[];
   tags?: EmailTag[];
   metadata?: Record<string, string | number | boolean | null>;
+  recipientVariables?: RecipientVariables;
   idempotencyKey?: string;
 };
 
@@ -75,6 +84,16 @@ export type EmailProviderContext = {
 export type EmailProvider<TRaw = unknown> = {
   name: string;
   send(message: EmailMessage, context: EmailProviderContext): MaybePromise<EmailProviderResponse>;
+  /**
+   * Optional native batch send for messages carrying `recipientVariables`. When
+   * present, the client routes such messages here so the provider can personalize
+   * every recipient in a single API call. Adapters without this method fall back to
+   * one client-side rendered `send` per recipient.
+   */
+  sendBulk?(
+    message: EmailMessage,
+    context: EmailProviderContext,
+  ): MaybePromise<EmailProviderResponse>;
   raw?: TRaw;
 };
 

--- a/packages/email-sdk/src/utils.ts
+++ b/packages/email-sdk/src/utils.ts
@@ -33,6 +33,15 @@ export function formatAddresses(addresses: OneOrMany<EmailAddress> | undefined):
   return arrayify(addresses).map(formatAddress);
 }
 
+export function emailAddressOf(address: EmailAddress): string {
+  if (typeof address !== "string") {
+    return address.email;
+  }
+
+  const match = address.match(/<([^>]+)>/);
+  return (match?.[1] ?? address).trim();
+}
+
 export function headersToObject(
   headers: EmailMessage["headers"],
 ): Record<string, string> | undefined {
@@ -82,6 +91,48 @@ export function assertMessage(message: EmailMessage) {
         `Attachment "${attachment.filename}" requires content or path.`,
       );
     }
+  }
+}
+
+export function hasRecipientVariables(message: EmailMessage): boolean {
+  return Boolean(message.recipientVariables && Object.keys(message.recipientVariables).length > 0);
+}
+
+export function assertRecipientVariables(message: EmailMessage) {
+  if (!hasRecipientVariables(message)) {
+    return;
+  }
+
+  if (message.cc || message.bcc) {
+    throw new EmailValidationError(
+      "recipientVariables cannot be combined with cc or bcc because each recipient receives an individualized message.",
+    );
+  }
+
+  const recipients = new Set<string>();
+
+  for (const recipient of arrayify(message.to)) {
+    const address = emailAddressOf(recipient);
+    const normalized = address.toLowerCase();
+
+    if (recipients.has(normalized)) {
+      throw new EmailValidationError(
+        `recipientVariables require unique "to" addresses, but "${address}" appears more than once.`,
+      );
+    }
+
+    recipients.add(normalized);
+  }
+
+  const unknown = Object.keys(message.recipientVariables ?? {}).filter(
+    (address) => !recipients.has(address.toLowerCase()),
+  );
+
+  if (unknown.length > 0) {
+    throw new EmailValidationError(
+      `recipientVariables reference addresses that are not in "to": ${unknown.join(", ")}.`,
+      { unknown },
+    );
   }
 }
 

--- a/packages/email-sdk/src/utils.ts
+++ b/packages/email-sdk/src/utils.ts
@@ -134,6 +134,20 @@ export function assertRecipientVariables(message: EmailMessage) {
       { unknown },
     );
   }
+
+  // 2026-07-06: variable keys must match the fallback substitution token `%recipient.<key>%`
+  // (regex [\w-]+). Keys like "user.name" would personalize on native provider routes but
+  // silently stay literal in the client-side fallback, so reject them everywhere instead.
+  for (const [address, variables] of Object.entries(message.recipientVariables ?? {})) {
+    for (const key of Object.keys(variables)) {
+      if (!/^[\w-]+$/.test(key)) {
+        throw new EmailValidationError(
+          `recipientVariables keys may only contain letters, numbers, underscores, and hyphens, but "${address}" has "${key}".`,
+          { address, key },
+        );
+      }
+    }
+  }
 }
 
 export async function readErrorBody(response: Response): Promise<unknown> {


### PR DESCRIPTION
Closes #99

## What

Adds an optional `recipientVariables` map to `EmailMessage` so one `send` can personalize a whole `to` list with `%recipient.key%` tokens in `subject`, `html`, and `text`:

```ts
await email.send({
  from: "Acme <hello@acme.com>",
  to: ["a@example.com", "b@example.com"],
  subject: "Hi %recipient.name%",
  html: '<a href="https://acme.com/unsub?id=%recipient.id%">Unsubscribe</a>',
  recipientVariables: {
    "a@example.com": { name: "Ada", id: "u_1" },
    "b@example.com": { name: "Linus", id: "u_2" },
  },
});
```

## How

- **Native batch, one API call**: adapters can implement the new optional `EmailProvider.sendBulk`. Mailgun maps to its `recipient-variables` form field and SendGrid emits one `personalizations` entry per recipient with `substitutions`, so the provider substitutes tokens server-side. Both native paths fail fast past 1000 recipients via the existing `assertMaxItems` pattern (Mailgun's batch limit, SendGrid's personalizations cap).
- **Client-side fallback, every other adapter**: the client expands the message into one rendered send per recipient — tokens substituted locally in subject/html/text, `afterSend`/`onError` firing per recipient, idempotency keys suffixed `<key>:<address>` so retries dedupe per recipient. Results aggregate into the response `accepted`/`rejected` fields; the adapter only counts as failed (triggering the next fallback route) when every recipient fails. This means `recipientVariables` works on all adapters instead of needing an unsupported-field error.
- **Validation** (fail-fast, before any adapter runs): `recipientVariables` cannot combine with `cc`/`bcc`, `to` addresses must be unique, every `recipientVariables` key must match a `to` address, and variable keys must match `[\w-]+` (a dotted key like `user.name` would personalize on native routes but stay literal in the fallback regex, so it fails fast on every route instead). Unknown `%recipient.key%` tokens are left intact, matching native provider behavior. Substitution uses a replacer function, so values containing `$`/regex-special characters stay literal.

## Deliberately skipped

- **Brevo `messageVersions`**: per Brevo's batch docs, a message version can override `subject`, `htmlContent`, and `params` — but not `textContent`. Text-only or html+text messages could not be fully personalized in one call, so wiring it up would make Brevo's native path behave differently from the rest of the feature. The client-side fallback already covers Brevo correctly; native support can come later if the API grows per-version text content.
- `convex-email` keeps its own message shim/validators and release track, so it is untouched.

## Testing

- `packages/email-sdk`: `bun run build` and `bun test` — 108 pass / 0 fail.
- New tests: native `sendBulk` routing, Mailgun `recipient-variables` payload + 1000-recipient cap, SendGrid per-recipient personalizations, client-side expansion (subject/html/text all substituted), unknown-token passthrough, regex-special values, per-recipient idempotency keys, partial-failure `accepted`/`rejected` + `onError`, full-failure route fallback, the new validation errors (including the `[\w-]+` key charset), a class-based-adapter regression test proving `sendBulk` keeps its `this` binding, and the 1000-recipient cap on both native paths.
- `bunx oxlint packages/email-sdk/src` clean; `apps/fumadocs` `bun run types:check` passes.

Docs updated: message and client references, Mailgun/SendGrid adapter pages, and the field-support matrix. Changeset included (minor bump for `@opencoredev/email-sdk`).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
