### PR TITLE
feat(convex-email): finish the Convex component

### DIFF
--- a/apps/fumadocs/content/docs/components/convex-email.mdx
+++ b/apps/fumadocs/content/docs/components/convex-email.mdx
@@ -186,7 +186,7 @@ export const emailStatus = query({
 });
 ```
 
-`status` returns the stored email: `status`, `message`, `attemptedAdapters`, `attemptCount`/`maxAttempts`, `providerMessageId`, `lastError`, and timestamps. `listEvents` returns the append-only history.
+`status` returns the stored email: `status`, `message`, `attemptedAdapters`, `attemptCount`/`maxAttempts`, `providerMessageId`, `lastError`, `deliveryStatus`, and timestamps. `listEvents` returns the append-only history.
 
 | Status | Meaning |
 | --- | --- |
@@ -195,6 +195,8 @@ export const emailStatus = query({
 | `sent` | A provider accepted the message. Terminal. |
 | `failed` | All attempts and fallbacks exhausted. Terminal. |
 | `canceled` | Canceled before processing started. Terminal. |
+
+`status` covers the send lifecycle — it ends at "a provider accepted the message". What happened after acceptance lives in `deliveryStatus`, filled in by [webhooks](#webhooks): `delivered`, `bounced`, or `complained`, plus `deliveredAt` on delivery. It stays unset until a matching webhook arrives.
 
 Event types: `queued`, `processing`, `provider_attempt`, `sent`, `retry_scheduled`, `failed`, `canceled`, `webhook`. `provider_attempt` and `retry_scheduled` carry the adapter, attempt number, and delay, so the full routing story is queryable.
 
@@ -220,7 +222,7 @@ Larger arrays throw before enqueueing anything — split them in your app so Con
 
 ## Configuration
 
-Runtime config lives in a Convex table, managed with `setConfig` / `getConfig`:
+Runtime config lives in a Convex table, managed with `setConfig` / `getConfig`. `setConfig` replaces the stored document — pass every field you want to keep, because omitted fields are cleared rather than merged:
 
 ```ts
 await email.setConfig(ctx, {
@@ -272,6 +274,8 @@ The fail-before-enqueue rule is deliberate: enabling `testMode` without `sandbox
 ## Webhooks
 
 `registerRoutes` mounts `POST <pathPrefix>/webhooks/<provider>` on your HTTP router and records deliveries as `webhook` events. Deliveries are stored by provider and delivery id, so provider retries stay idempotent.
+
+When a webhook matches a stored email by provider message id, the component also normalizes the provider's event name onto the email's `deliveryStatus`. Resend `email.delivered`, Postmark `Delivery`, Mailgun `delivered`, and the like become `delivered`; bounce events become `bounced`; spam complaints become `complained`. Bounces and complaints are sticky — a `delivered` event that arrives late or out of order never overwrites them. Opens, clicks, and other events stay in the event history without touching `deliveryStatus`.
 
 ```ts title="convex/http.ts"
 import { httpRouter } from "convex/server";

--- a/apps/fumadocs/content/docs/components/convex-email.mdx
+++ b/apps/fumadocs/content/docs/components/convex-email.mdx
@@ -275,7 +275,11 @@ The fail-before-enqueue rule is deliberate: enabling `testMode` without `sandbox
 
 `registerRoutes` mounts `POST <pathPrefix>/webhooks/<provider>` on your HTTP router and records deliveries as `webhook` events. Deliveries are stored by provider and delivery id, so provider retries stay idempotent.
 
-When a webhook matches a stored email by provider message id, the component also normalizes the provider's event name onto the email's `deliveryStatus`. Resend `email.delivered`, Postmark `Delivery`, Mailgun `delivered`, and the like become `delivered`; bounce events become `bounced`; spam complaints become `complained`. Bounces and complaints are sticky — a `delivered` event that arrives late or out of order never overwrites them. Opens, clicks, and other events stay in the event history without touching `deliveryStatus`.
+When a webhook matches a stored email by provider message id, the component also normalizes the provider's event name onto the email's `deliveryStatus`. Resend `email.delivered`, Postmark `Delivery`, Mailgun `delivered`, and the like become `delivered`; hard bounces become `bounced`; spam complaints become `complained`.
+
+Only permanent failures count as `bounced` — that's deliberate, so a retryable soft bounce never poisons the status of an email that later delivers. Mailgun `failed` events map to `bounced` only when `severity` is `"permanent"`; a `"temporary"` failure is recorded in the event history but leaves `deliveryStatus` alone. Postmark `Bounce` records map to `bounced` only when `Type` is a permanent class (`HardBounce`, `BadEmailAddress`, `ManuallyDeactivated`); `Transient`, `SoftBounce`, and other retryable types are stored without touching the status, so a later `Delivery` still lands as `delivered`.
+
+Bounces and complaints are sticky against `delivered` — a `delivered` event that arrives late or out of order never overwrites them. Between `bounced` and `complained` themselves, the most recent webhook wins; both mean "stop mailing this recipient", and the full sequence stays in the event history. Opens, clicks, and other events stay in the event history without touching `deliveryStatus`.
 
 ```ts title="convex/http.ts"
 import { httpRouter } from "convex/server";

--- a/packages/convex-email/README.md
+++ b/packages/convex-email/README.md
@@ -195,7 +195,9 @@ export default http;
 This creates `POST /email/webhooks/resend` and records duplicate deliveries idempotently.
 Omitting `verify` is only suitable for local development; public routes should always verify provider signatures or a shared secret.
 
-When a webhook matches a stored email by provider message id, the component records a `webhook` event and normalizes the provider's event name onto the email's `deliveryStatus`: delivered, bounced, or complained. Bounces and complaints are sticky, so a delivery event that arrives late (or is retried out of order) never hides a recorded bounce. Other events, such as opens and clicks, are kept in the event history without changing `deliveryStatus`.
+When a webhook matches a stored email by provider message id, the component records a `webhook` event and normalizes the provider's event name onto the email's `deliveryStatus`: delivered, bounced, or complained. Only permanent failures count as `bounced`: Mailgun `failed` events map to `bounced` only when `severity` is `"permanent"`, and Postmark `Bounce` records only when `Type` is a permanent class (`HardBounce`, `BadEmailAddress`, `ManuallyDeactivated`). Soft/temporary failures stay in the event history without touching `deliveryStatus`, because the provider retries them and the message may still deliver.
+
+Bounces and complaints are sticky against `delivered`: a delivery event that arrives late (or is retried out of order) never hides a recorded bounce or complaint. Between `bounced` and `complained` themselves, the most recent webhook wins. Other events, such as opens and clicks, are kept in the event history without changing `deliveryStatus`.
 
 ## Test Mode
 

--- a/packages/convex-email/README.md
+++ b/packages/convex-email/README.md
@@ -13,7 +13,7 @@ bun add @opencoredev/convex-email @opencoredev/email-sdk
 - Route through Resend, Postmark, SendGrid, SES, SMTP, Mailgun, Brevo, and other Email SDK adapters.
 - Use fallback adapters when the primary route fails.
 - Deduplicate repeated sends with an idempotency key.
-- Capture provider webhooks as delivery events.
+- Capture provider webhooks as delivery events and track delivered/bounced/complained state per email.
 - Redirect real messages to sandbox recipients in test mode.
 
 Use the official `@convex-dev/resend` component for a Resend-only app that wants the official Resend integration. Use Convex Email Ops when provider portability, fallback routing, status history, or test-safe multi-provider operations matter.
@@ -103,7 +103,7 @@ export const sendWelcomeEmail = mutation({
 });
 ```
 
-`email.send()` returns the Convex document id for the queued email. Query `email.status(ctx, { emailId })` and `email.listEvents(ctx, { emailId })` from app functions when you need delivery state, attempted adapters, provider message ids, or errors.
+`email.send()` returns the Convex document id for the queued email. Query `email.status(ctx, { emailId })` and `email.listEvents(ctx, { emailId })` from app functions when you need delivery state, attempted adapters, provider message ids, or errors. Once webhooks are wired up, the stored email also carries a `deliveryStatus` (`delivered`, `bounced`, or `complained`) and a `deliveredAt` timestamp.
 
 ## Provider Coverage
 
@@ -195,6 +195,8 @@ export default http;
 This creates `POST /email/webhooks/resend` and records duplicate deliveries idempotently.
 Omitting `verify` is only suitable for local development; public routes should always verify provider signatures or a shared secret.
 
+When a webhook matches a stored email by provider message id, the component records a `webhook` event and normalizes the provider's event name onto the email's `deliveryStatus`: delivered, bounced, or complained. Bounces and complaints are sticky, so a delivery event that arrives late (or is retried out of order) never hides a recorded bounce. Other events, such as opens and clicks, are kept in the event history without changing `deliveryStatus`.
+
 ## Test Mode
 
 Use `setConfig` to redirect sends while keeping the queue and provider flow intact:
@@ -207,6 +209,8 @@ await email.setConfig(ctx, {
 ```
 
 If `testMode` is enabled without `sandboxTo`, sends fail before enqueueing so real recipients are not contacted by mistake.
+
+`setConfig` replaces the whole stored config, so pass every field you want to keep. Omitting a field clears it; there is no partial merge.
 
 For local or CI tests, use the memory adapter:
 

--- a/packages/convex-email/src/client/index.ts
+++ b/packages/convex-email/src/client/index.ts
@@ -11,6 +11,9 @@ import { v } from "convex/values";
 import type {
   ConvexEmailAdapterConfig,
   ConvexEmailConfig,
+  ConvexEmailDeliveryStatus,
+  ConvexEmailDoc,
+  ConvexEmailEventDoc,
   ConvexEmailMessage,
   ConvexEmailSendArgs,
 } from "../shared/types.js";
@@ -89,7 +92,10 @@ export class ConvexEmail {
   ) {}
 
   send(ctx: MutationCtx, args: ConvexEmailSendArgs) {
-    return ctx.runMutation(this.component.lib.enqueue as AnyMutationRef, this.withDefaults(args));
+    return ctx.runMutation(
+      this.component.lib.enqueue as AnyMutationRef,
+      this.withDefaults(args),
+    ) as Promise<string>;
   }
 
   sendBatch(ctx: MutationCtx, messages: ConvexEmailSendArgs[]) {
@@ -99,34 +105,47 @@ export class ConvexEmail {
 
     return ctx.runMutation(this.component.lib.enqueueBatch as AnyMutationRef, {
       messages: messages.map((message) => this.withDefaults(message)),
-    });
+    }) as Promise<string[]>;
   }
 
   status(ctx: QueryCtx, args: { emailId: string }) {
-    return ctx.runQuery(this.component.lib.status as AnyQueryRef, args);
+    return ctx.runQuery(
+      this.component.lib.status as AnyQueryRef,
+      args,
+    ) as Promise<ConvexEmailDoc | null>;
   }
 
   listEvents(ctx: QueryCtx, args: { emailId: string }) {
-    return ctx.runQuery(this.component.lib.listEvents as AnyQueryRef, args);
+    return ctx.runQuery(this.component.lib.listEvents as AnyQueryRef, args) as Promise<
+      ConvexEmailEventDoc[]
+    >;
   }
 
   cancel(ctx: MutationCtx, args: { emailId: string }) {
-    return ctx.runMutation(this.component.lib.cancel as AnyMutationRef, args);
+    return ctx.runMutation(this.component.lib.cancel as AnyMutationRef, args) as Promise<boolean>;
   }
 
   setConfig(ctx: MutationCtx, config: ConvexEmailConfig) {
-    return ctx.runMutation(this.component.lib.setConfig as AnyMutationRef, { config });
+    return ctx.runMutation(this.component.lib.setConfig as AnyMutationRef, {
+      config,
+    }) as Promise<null>;
   }
 
   getConfig(ctx: QueryCtx) {
-    return ctx.runQuery(this.component.lib.getConfig as AnyQueryRef, {});
+    return ctx.runQuery(
+      this.component.lib.getConfig as AnyQueryRef,
+      {},
+    ) as Promise<ConvexEmailConfig | null>;
   }
 
   processWebhook(
     ctx: ActionCtx,
     args: { provider: string; headers: Record<string, string>; body: string },
   ) {
-    return ctx.runAction(this.component.worker.handleWebhook as AnyActionRef, args);
+    return ctx.runAction(this.component.worker.handleWebhook as AnyActionRef, args) as Promise<{
+      ok: boolean;
+      duplicate?: boolean;
+    }>;
   }
 
   registerRoutes(
@@ -175,12 +194,12 @@ export class ConvexEmail {
       send: mutationGeneric({
         args: vSendEmailArgs,
         returns: v.string(),
-        handler: async (ctx, args) => (await this.send(ctx, args)) as string,
+        handler: async (ctx, args) => await this.send(ctx, args),
       }),
       sendBatch: mutationGeneric({
         args: vSendBatchEmailsArgs,
         returns: v.array(v.string()),
-        handler: async (ctx, args) => (await this.sendBatch(ctx, args.messages)) as string[],
+        handler: async (ctx, args) => await this.sendBatch(ctx, args.messages),
       }),
       status: queryGeneric({
         args: vStatusArgs,
@@ -195,7 +214,7 @@ export class ConvexEmail {
       cancel: mutationGeneric({
         args: vCancelEmailArgs,
         returns: v.boolean(),
-        handler: async (ctx, args) => (await this.cancel(ctx, args)) as boolean,
+        handler: async (ctx, args) => await this.cancel(ctx, args),
       }),
     };
 
@@ -236,6 +255,9 @@ export class ConvexEmail {
 export type {
   ConvexEmailAdapterConfig,
   ConvexEmailConfig,
+  ConvexEmailDeliveryStatus,
+  ConvexEmailDoc,
+  ConvexEmailEventDoc,
   ConvexEmailMessage,
   ConvexEmailSendArgs,
 };

--- a/packages/convex-email/src/component.test.ts
+++ b/packages/convex-email/src/component.test.ts
@@ -402,6 +402,81 @@ describe("convex-email component", () => {
     expect(status?.deliveryStatus).toBe("bounced");
   });
 
+  test("Postmark hard bounces stick even when a late Delivery arrives", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "postmark",
+      headers: {},
+      body: JSON.stringify({
+        RecordType: "Bounce",
+        Type: "HardBounce",
+        ID: 42,
+        MessageID: providerMessageId,
+      }),
+    });
+    await t.action(api.worker.handleWebhook, {
+      provider: "postmark",
+      headers: {},
+      body: JSON.stringify({ RecordType: "Delivery", MessageID: providerMessageId }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+
+    expect(status?.deliveryStatus).toBe("bounced");
+    expect(status?.deliveredAt).toBeUndefined();
+  });
+
+  test("Postmark transient bounces do not block a later Delivery", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "postmark",
+      headers: {},
+      body: JSON.stringify({
+        RecordType: "Bounce",
+        Type: "Transient",
+        ID: 43,
+        MessageID: providerMessageId,
+      }),
+    });
+
+    const afterBounce = await t.query(api.lib.status, { emailId });
+    expect(afterBounce?.deliveryStatus).toBeUndefined();
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "postmark",
+      headers: {},
+      body: JSON.stringify({ RecordType: "Delivery", MessageID: providerMessageId }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+    const events = await t.query(api.lib.listEvents, { emailId });
+
+    expect(status?.deliveryStatus).toBe("delivered");
+    expect(events.filter((event) => event.type === "webhook")).toHaveLength(2);
+  });
+
+  test("deduplicates Postmark webhooks by numeric ID even when the retry body differs", async () => {
+    const t = createTest();
+
+    const first = await t.action(api.worker.handleWebhook, {
+      provider: "postmark",
+      headers: {},
+      body: JSON.stringify({ RecordType: "Bounce", Type: "HardBounce", ID: 4242 }),
+    });
+    const second = await t.action(api.worker.handleWebhook, {
+      provider: "postmark",
+      headers: {},
+      body: JSON.stringify({ RecordType: "Bounce", Type: "HardBounce", ID: 4242, Tag: "retry" }),
+    });
+
+    expect(first).toEqual({ ok: true });
+    expect(second).toEqual({ ok: true, duplicate: true });
+  });
+
   test("normalizes Mailgun-style webhooks through event-data", async () => {
     const t = createTest();
     const { emailId, providerMessageId } = await sendToSent(t);
@@ -422,6 +497,74 @@ describe("convex-email component", () => {
     const status = await t.query(api.lib.status, { emailId });
 
     expect(status?.deliveryStatus).toBe("delivered");
+  });
+
+  test("Mailgun permanent failures map to bounced", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "mailgun",
+      headers: {},
+      body: JSON.stringify({
+        signature: { token: "tok" },
+        "event-data": {
+          event: "failed",
+          severity: "permanent",
+          id: "mg_evt_perm",
+          message: { headers: { "message-id": providerMessageId } },
+        },
+      }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+
+    expect(status?.deliveryStatus).toBe("bounced");
+  });
+
+  test("Mailgun temporary failures are stored without touching deliveryStatus", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "mailgun",
+      headers: {},
+      body: JSON.stringify({
+        signature: { token: "tok" },
+        "event-data": {
+          event: "failed",
+          severity: "temporary",
+          id: "mg_evt_temp",
+          message: { headers: { "message-id": providerMessageId } },
+        },
+      }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+    const events = await t.query(api.lib.listEvents, { emailId });
+
+    expect(status?.deliveryStatus).toBeUndefined();
+    expect(events.map((event) => event.type)).toContain("webhook");
+  });
+
+  test("between bounced and complained the most recent webhook wins", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "resend",
+      headers: { "svix-id": "evt_bounce_first" },
+      body: JSON.stringify({ type: "email.bounced", data: { email_id: providerMessageId } }),
+    });
+    await t.action(api.worker.handleWebhook, {
+      provider: "resend",
+      headers: { "svix-id": "evt_complaint_second" },
+      body: JSON.stringify({ type: "email.complained", data: { email_id: providerMessageId } }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+
+    expect(status?.deliveryStatus).toBe("complained");
   });
 
   test("SMTP adapter reads numeric port from component environment", () => {

--- a/packages/convex-email/src/component.test.ts
+++ b/packages/convex-email/src/component.test.ts
@@ -29,6 +29,24 @@ const message = {
   text: "Your account is ready.",
 };
 
+async function sendToSent(t: TestConvex<typeof schema>) {
+  const emailId = await t.mutation(api.lib.enqueue, {
+    ...message,
+    adapters: [{ kind: "memory" }],
+    adapter: "memory",
+    maxAttempts: 1,
+  });
+
+  await flushScheduled(t);
+
+  const status = await t.query(api.lib.status, { emailId });
+  if (status?.status !== "sent" || !status.providerMessageId) {
+    throw new Error("Expected the memory adapter send to reach sent.");
+  }
+
+  return { emailId, providerMessageId: status.providerMessageId };
+}
+
 describe("convex-email component", () => {
   afterEach(() => {
     delete process.env.SMTP_HOST;
@@ -97,6 +115,43 @@ describe("convex-email component", () => {
     expect(secondId).toBe(firstId);
   });
 
+  test("enqueues a batch, applies config defaults, and returns ids in order", async () => {
+    const t = createTest();
+
+    await t.mutation(api.lib.setConfig, {
+      config: { defaultFrom: "Ops <ops@example.com>" },
+    });
+    const ids = await t.mutation(api.lib.enqueueBatch, {
+      messages: [
+        { to: "a@example.com", subject: "One", text: "1", adapters: [{ kind: "memory" }], adapter: "memory" },
+        { to: "b@example.com", subject: "Two", text: "2", adapters: [{ kind: "memory" }], adapter: "memory" },
+      ],
+    });
+
+    expect(ids).toHaveLength(2);
+    await flushScheduled(t);
+
+    const first = await t.query(api.lib.status, { emailId: ids[0] });
+    const second = await t.query(api.lib.status, { emailId: ids[1] });
+
+    expect(first?.message).toMatchObject({ from: "Ops <ops@example.com>", to: "a@example.com" });
+    expect(second?.message).toMatchObject({ from: "Ops <ops@example.com>", to: "b@example.com" });
+    expect(first?.status).toBe("sent");
+    expect(second?.status).toBe("sent");
+  });
+
+  test("deduplicates idempotency keys inside one batch", async () => {
+    const t = createTest();
+    const ids = await t.mutation(api.lib.enqueueBatch, {
+      messages: [
+        { ...message, idempotencyKey: "batch:ada", adapters: [{ kind: "memory" }], adapter: "memory" },
+        { ...message, subject: "Duplicate", idempotencyKey: "batch:ada", adapters: [{ kind: "memory" }], adapter: "memory" },
+      ],
+    });
+
+    expect(ids[1]).toBe(ids[0]);
+  });
+
   test("limits batch size to avoid mutation operation blowups", async () => {
     const t = createTest();
 
@@ -163,6 +218,86 @@ describe("convex-email component", () => {
     ).rejects.toThrow("testMode is enabled but sandboxTo is not configured");
   });
 
+  test("requires from or a configured defaultFrom", async () => {
+    const t = createTest();
+
+    await expect(
+      t.mutation(api.lib.enqueue, {
+        to: "ada@example.com",
+        subject: "No sender",
+        text: "Missing from.",
+        adapters: [{ kind: "memory" }],
+        adapter: "memory",
+      }),
+    ).rejects.toThrow("Provide `from` when sending email or configure `defaultFrom`");
+  });
+
+  test("cancels queued emails and refuses everything else", async () => {
+    const t = createTest();
+    const emailId = await t.mutation(api.lib.enqueue, {
+      ...message,
+      adapters: [{ kind: "memory" }],
+      adapter: "memory",
+    });
+
+    const canceled = await t.mutation(api.lib.cancel, { emailId });
+    const again = await t.mutation(api.lib.cancel, { emailId });
+    await flushScheduled(t);
+
+    const status = await t.query(api.lib.status, { emailId });
+    const events = await t.query(api.lib.listEvents, { emailId });
+
+    expect(canceled).toBe(true);
+    expect(again).toBe(false);
+    expect(status?.status).toBe("canceled");
+    expect(events.map((event) => event.type)).toEqual(["queued", "canceled"]);
+  });
+
+  test("retries with backoff and fails once attempts are exhausted", async () => {
+    const t = createTest();
+    delete process.env.RESEND_API_KEY;
+
+    const emailId = await t.mutation(api.lib.enqueue, {
+      ...message,
+      adapters: [{ kind: "resend" }],
+      adapter: "resend",
+      maxAttempts: 2,
+      retryBaseMs: 0,
+    });
+
+    await flushScheduled(t);
+    await flushScheduled(t);
+    await flushScheduled(t);
+
+    const status = await t.query(api.lib.status, { emailId });
+    const events = await t.query(api.lib.listEvents, { emailId });
+    const types = events.map((event) => event.type);
+
+    expect(status).toMatchObject({
+      status: "failed",
+      attemptCount: 2,
+      lastError: expect.stringContaining("RESEND_API_KEY"),
+    });
+    expect(types).toEqual(["queued", "processing", "retry_scheduled", "processing", "failed"]);
+  });
+
+  test("setConfig replaces the stored config instead of merging", async () => {
+    const t = createTest();
+
+    await t.mutation(api.lib.setConfig, {
+      config: { defaultFrom: "Ops <ops@example.com>", cleanupAfterDays: 30 },
+    });
+    await t.mutation(api.lib.setConfig, {
+      config: { testMode: true, sandboxTo: ["dev@example.test"] },
+    });
+
+    const config = await t.query(api.lib.getConfig, {});
+
+    expect(config).toMatchObject({ testMode: true, sandboxTo: ["dev@example.test"] });
+    expect(config?.defaultFrom).toBeUndefined();
+    expect(config?.cleanupAfterDays).toBeUndefined();
+  });
+
   test("records duplicate webhook deliveries idempotently", async () => {
     const t = createTest();
     const args = {
@@ -191,6 +326,102 @@ describe("convex-email component", () => {
 
     expect(first).toEqual({ ok: true });
     expect(second).toEqual({ ok: true, duplicate: true });
+  });
+
+  test("delivered webhooks set deliveryStatus on the matching email", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "resend",
+      headers: { "svix-id": "evt_delivered" },
+      body: JSON.stringify({ type: "email.delivered", data: { email_id: providerMessageId } }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+    const events = await t.query(api.lib.listEvents, { emailId });
+
+    expect(status).toMatchObject({
+      status: "sent",
+      deliveryStatus: "delivered",
+      deliveredAt: expect.any(Number),
+    });
+    expect(events.map((event) => event.type)).toContain("webhook");
+  });
+
+  test("bounces stick even when a late delivered webhook arrives", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "resend",
+      headers: { "svix-id": "evt_bounced" },
+      body: JSON.stringify({ type: "email.bounced", data: { email_id: providerMessageId } }),
+    });
+    await t.action(api.worker.handleWebhook, {
+      provider: "resend",
+      headers: { "svix-id": "evt_late_delivered" },
+      body: JSON.stringify({ type: "email.delivered", data: { email_id: providerMessageId } }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+
+    expect(status?.deliveryStatus).toBe("bounced");
+    expect(status?.deliveredAt).toBeUndefined();
+  });
+
+  test("unknown webhook events are recorded without touching deliveryStatus", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "resend",
+      headers: { "svix-id": "evt_opened" },
+      body: JSON.stringify({ type: "email.opened", data: { email_id: providerMessageId } }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+    const events = await t.query(api.lib.listEvents, { emailId });
+
+    expect(status?.deliveryStatus).toBeUndefined();
+    expect(events.map((event) => event.type)).toContain("webhook");
+  });
+
+  test("normalizes Postmark-style webhooks through MessageID", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "postmark",
+      headers: {},
+      body: JSON.stringify({ RecordType: "Bounce", MessageID: providerMessageId }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+
+    expect(status?.deliveryStatus).toBe("bounced");
+  });
+
+  test("normalizes Mailgun-style webhooks through event-data", async () => {
+    const t = createTest();
+    const { emailId, providerMessageId } = await sendToSent(t);
+
+    await t.action(api.worker.handleWebhook, {
+      provider: "mailgun",
+      headers: {},
+      body: JSON.stringify({
+        signature: { token: "tok" },
+        "event-data": {
+          event: "delivered",
+          id: "mg_evt_1",
+          message: { headers: { "message-id": providerMessageId } },
+        },
+      }),
+    });
+
+    const status = await t.query(api.lib.status, { emailId });
+
+    expect(status?.deliveryStatus).toBe("delivered");
   });
 
   test("SMTP adapter reads numeric port from component environment", () => {

--- a/packages/convex-email/src/component/lib.ts
+++ b/packages/convex-email/src/component/lib.ts
@@ -548,8 +548,9 @@ async function applyDeliveryStatus(
   now: number,
 ) {
   if (event === "delivered") {
-    // 2026-07-06: bounced/complained are sticky. Provider webhook retries can arrive out of
-    // order, so a late "delivered" event must never overwrite a recorded bounce or complaint.
+    // 2026-07-06: bounced/complained are sticky against "delivered". Provider webhook retries
+    // can arrive out of order, so a late "delivered" event must never overwrite a recorded
+    // bounce or complaint.
     if (email.deliveryStatus) {
       return;
     }
@@ -564,6 +565,9 @@ async function applyDeliveryStatus(
   }
 
   if (event === "bounced" || event === "complained") {
+    // Between bounced and complained the most recent event wins (both overwrite "delivered"
+    // and each other). Either value means "stop mailing this recipient", so ordering between
+    // them is not load-bearing; the full sequence stays in the event history.
     await ctx.db.patch(email._id, {
       deliveryStatus: event,
       updatedAt: now,

--- a/packages/convex-email/src/component/lib.ts
+++ b/packages/convex-email/src/component/lib.ts
@@ -49,10 +49,12 @@ export const enqueueBatch = mutation({
       });
     }
 
+    // Read the shared config once for the whole batch instead of once per message.
+    const config = await readConfig(ctx);
     const ids: string[] = [];
 
     for (const message of args.messages) {
-      ids.push(await enqueueEmail(ctx, message));
+      ids.push(await enqueueEmail(ctx, message, config));
     }
 
     return ids;
@@ -109,8 +111,11 @@ export const setConfig = mutation({
     const existing = await getConfigDoc(ctx);
     const now = Date.now();
 
+    // 2026-07-06: setConfig replaces the stored config document instead of merging into it.
+    // Merge semantics made it impossible to clear a field (the validator cannot carry an
+    // explicit undefined), so stale defaultFrom/cleanupAfterDays values could never be unset.
     if (existing) {
-      await ctx.db.patch(existing._id, { ...args.config, updatedAt: now });
+      await ctx.db.replace(existing._id, { key: configKey, ...args.config, updatedAt: now });
     } else {
       await ctx.db.insert("config", { key: configKey, ...args.config, updatedAt: now });
     }
@@ -311,6 +316,7 @@ export const recordWebhook = internalMutation({
     provider: v.string(),
     deliveryId: v.string(),
     providerMessageId: v.optional(v.string()),
+    event: v.optional(v.string()),
     payload: v.any(),
   },
   returns: v.object({ ok: v.boolean(), duplicate: v.optional(v.boolean()) }),
@@ -341,6 +347,7 @@ export const recordWebhook = internalMutation({
       deliveryId: args.deliveryId,
       emailId: email?._id,
       providerMessageId: args.providerMessageId,
+      event: args.event,
       receivedAt: now,
       processedAt: now,
       status: "processed",
@@ -354,13 +361,18 @@ export const recordWebhook = internalMutation({
         providerMessageId: args.providerMessageId,
         payload: args.payload,
       });
+      await applyDeliveryStatus(ctx, email, args.event, now);
     }
 
     return { ok: true };
   },
 });
 
-async function enqueueEmail(ctx: any, args: ConvexEmailSendArgs) {
+async function enqueueEmail(
+  ctx: any,
+  args: ConvexEmailSendArgs,
+  preloadedConfig?: ConvexEmailConfig,
+) {
   const idempotencyKey = args.idempotencyKey;
 
   if (idempotencyKey) {
@@ -374,7 +386,7 @@ async function enqueueEmail(ctx: any, args: ConvexEmailSendArgs) {
     }
   }
 
-  const config = await readConfig(ctx);
+  const config = preloadedConfig ?? (await readConfig(ctx));
   const now = Date.now();
   const message = applyConfigToMessage(args, config);
   const emailId = await ctx.db.insert("emails", {
@@ -527,6 +539,36 @@ async function markEmailFailedOrRetry(
     attempt: email.attemptCount,
     error,
   });
+}
+
+async function applyDeliveryStatus(
+  ctx: any,
+  email: { _id: Id<"emails">; deliveryStatus?: string },
+  event: string | undefined,
+  now: number,
+) {
+  if (event === "delivered") {
+    // 2026-07-06: bounced/complained are sticky. Provider webhook retries can arrive out of
+    // order, so a late "delivered" event must never overwrite a recorded bounce or complaint.
+    if (email.deliveryStatus) {
+      return;
+    }
+
+    await ctx.db.patch(email._id, {
+      deliveryStatus: "delivered",
+      deliveredAt: now,
+      updatedAt: now,
+    });
+
+    return;
+  }
+
+  if (event === "bounced" || event === "complained") {
+    await ctx.db.patch(email._id, {
+      deliveryStatus: event,
+      updatedAt: now,
+    });
+  }
 }
 
 async function cleanupExpiredEmailRecords(ctx: any, now: number, limit: number) {

--- a/packages/convex-email/src/component/schema.ts
+++ b/packages/convex-email/src/component/schema.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 
 import {
   vAdapterConfig,
+  vDeliveryStatusValue,
   vEmailEventType,
   vEmailMessage,
   vEmailMetadata,
@@ -25,6 +26,8 @@ export default defineSchema({
     retryBaseMs: v.number(),
     nextAttemptAt: v.optional(v.number()),
     lastError: v.optional(v.string()),
+    deliveryStatus: v.optional(vDeliveryStatusValue),
+    deliveredAt: v.optional(v.number()),
     createdAt: v.number(),
     updatedAt: v.number(),
     sentAt: v.optional(v.number()),
@@ -55,6 +58,7 @@ export default defineSchema({
     deliveryId: v.string(),
     emailId: v.optional(v.id("emails")),
     providerMessageId: v.optional(v.string()),
+    event: v.optional(v.string()),
     receivedAt: v.number(),
     processedAt: v.optional(v.number()),
     status: v.union(v.literal("processed"), v.literal("ignored"), v.literal("failed")),

--- a/packages/convex-email/src/component/worker.ts
+++ b/packages/convex-email/src/component/worker.ts
@@ -137,11 +137,18 @@ function parseProviderWebhook(provider: string, body: string, headers: Record<st
       stringValue(record.type) ??
       stringValue(record.RecordType) ??
       stringValue(eventData?.event),
+    {
+      // Mailgun marks failure events with event-data.severity: "permanent" | "temporary".
+      severity: stringValue(eventData?.severity),
+      // Postmark bounce webhooks carry the bounce class in Type (e.g. "HardBounce", "Transient").
+      bounceType: stringValue(record.Type),
+    },
   );
 
   return {
     deliveryId:
       stringValue(record.id) ??
+      idValue(record.ID) ??
       stringValue(record.eventId) ??
       stringValue(record.webhookId) ??
       stringValue(record.deliveryId) ??
@@ -157,10 +164,24 @@ function parseProviderWebhook(provider: string, body: string, headers: Record<st
   };
 }
 
+// Postmark bounce Types that indicate a permanent/hard failure. Everything else
+// ("Transient", "SoftBounce", "DnsError", ...) is retried by Postmark and may still deliver,
+// so it must not set deliveryStatus. See Postmark's bounce-type table.
+const permanentPostmarkBounceTypes = new Set([
+  "hardbounce",
+  "bademailaddress",
+  "manuallydeactivated",
+]);
+
 // Maps provider-specific webhook event names onto the component's delivery vocabulary:
 // "delivered" | "bounced" | "complained". Unknown events pass through lowercased so they are
 // still stored on the delivery record, but only the three known values touch deliveryStatus.
-function normalizeWebhookEvent(value: string | undefined) {
+// Soft/temporary failures deliberately stay unmapped: Mailgun "failed" only counts as bounced
+// when severity is "permanent", and Postmark "Bounce" only when Type is a permanent class.
+function normalizeWebhookEvent(
+  value: string | undefined,
+  context: { severity?: string; bounceType?: string } = {},
+) {
   if (!value) {
     return undefined;
   }
@@ -171,7 +192,19 @@ function normalizeWebhookEvent(value: string | undefined) {
     case "delivered":
     case "delivery":
       return "delivered";
+    case "failed":
+      // Mailgun fires event "failed" for both hard and soft bounces; severity disambiguates.
+      // Temporary failures are retried by Mailgun, so leave them stored-but-unmapped.
+      return context.severity?.toLowerCase() === "permanent" ? "bounced" : event;
     case "bounce":
+      // Postmark fires RecordType "Bounce" for hard AND soft bounces. Only permanent Types
+      // become "bounced"; a Transient bounce may still end in a later Delivery webhook.
+      if (context.bounceType !== undefined) {
+        return permanentPostmarkBounceTypes.has(context.bounceType.toLowerCase())
+          ? "bounced"
+          : event;
+      }
+      return "bounced";
     case "bounced":
     case "permanent_fail":
       return "bounced";
@@ -210,6 +243,15 @@ function parseJson(body: string) {
 
 function stringValue(value: unknown) {
   return typeof value === "string" ? value : undefined;
+}
+
+// Postmark's dedupe id arrives as a numeric uppercase `ID`; accept numbers as well as strings.
+function idValue(value: unknown) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  return typeof value === "number" && Number.isFinite(value) ? String(value) : undefined;
 }
 
 function deterministicDeliveryId(provider: string, body: string) {

--- a/packages/convex-email/src/component/worker.ts
+++ b/packages/convex-email/src/component/worker.ts
@@ -97,6 +97,7 @@ export const handleWebhook = internalAction({
       provider: args.provider,
       deliveryId: parsed.deliveryId,
       providerMessageId: parsed.providerMessageId,
+      event: parsed.event,
       payload: parsed.payload,
     })) as { ok: boolean; duplicate?: boolean };
   },
@@ -121,21 +122,82 @@ function parseProviderWebhook(provider: string, body: string, headers: Record<st
       headers["resend-signature"] ??
       deterministicDeliveryId(provider, body);
     const providerMessageId = stringValue(data.email_id) ?? stringValue(data.id);
+    const event = normalizeWebhookEvent(stringValue(record.type));
 
-    return { deliveryId, providerMessageId, payload };
+    return { deliveryId, providerMessageId, event, payload };
   }
 
   const record = payload as Record<string, unknown>;
+  const eventData =
+    typeof record["event-data"] === "object" && record["event-data"]
+      ? (record["event-data"] as Record<string, unknown>)
+      : undefined;
+  const event = normalizeWebhookEvent(
+    stringValue(record.event) ??
+      stringValue(record.type) ??
+      stringValue(record.RecordType) ??
+      stringValue(eventData?.event),
+  );
+
   return {
     deliveryId:
       stringValue(record.id) ??
       stringValue(record.eventId) ??
       stringValue(record.webhookId) ??
       stringValue(record.deliveryId) ??
+      stringValue(eventData?.id) ??
       deterministicDeliveryId(provider, body),
-    providerMessageId: stringValue(record.messageId) ?? stringValue(record.message_id),
+    providerMessageId:
+      stringValue(record.messageId) ??
+      stringValue(record.message_id) ??
+      stringValue(record.MessageID) ??
+      eventDataMessageId(eventData),
+    event,
     payload,
   };
+}
+
+// Maps provider-specific webhook event names onto the component's delivery vocabulary:
+// "delivered" | "bounced" | "complained". Unknown events pass through lowercased so they are
+// still stored on the delivery record, but only the three known values touch deliveryStatus.
+function normalizeWebhookEvent(value: string | undefined) {
+  if (!value) {
+    return undefined;
+  }
+
+  const event = value.toLowerCase().replace(/^email\./, "");
+
+  switch (event) {
+    case "delivered":
+    case "delivery":
+      return "delivered";
+    case "bounce":
+    case "bounced":
+    case "permanent_fail":
+      return "bounced";
+    case "complained":
+    case "complaint":
+    case "spamcomplaint":
+    case "spam_complaint":
+    case "spamreport":
+      return "complained";
+    default:
+      return event;
+  }
+}
+
+// Mailgun nests the original Message-ID under event-data.message.headers["message-id"].
+function eventDataMessageId(eventData: Record<string, unknown> | undefined) {
+  if (!eventData || typeof eventData.message !== "object" || !eventData.message) {
+    return undefined;
+  }
+
+  const message = eventData.message as Record<string, unknown>;
+  if (typeof message.headers !== "object" || !message.headers) {
+    return undefined;
+  }
+
+  return stringValue((message.headers as Record<string, unknown>)["message-id"]);
 }
 
 function parseJson(body: string) {

--- a/packages/convex-email/src/shared/types.ts
+++ b/packages/convex-email/src/shared/types.ts
@@ -198,6 +198,46 @@ export type ConvexEmailConfig = {
 
 export type ConvexEmailStatus = "queued" | "processing" | "sent" | "failed" | "canceled";
 
+export type ConvexEmailDeliveryStatus = "delivered" | "bounced" | "complained";
+
+export type ConvexEmailDoc = {
+  _id: string;
+  _creationTime: number;
+  status: ConvexEmailStatus;
+  message: ConvexEmailMessage;
+  adapter?: string;
+  attemptedAdapters: string[];
+  fallbackAdapters: string[];
+  adapters: ConvexEmailAdapterConfig[];
+  providerMessageId?: string;
+  idempotencyKey?: string;
+  sendMetadata?: Record<string, string | number | boolean | null>;
+  attemptCount: number;
+  maxAttempts: number;
+  retryBaseMs: number;
+  nextAttemptAt?: number;
+  lastError?: string;
+  deliveryStatus?: ConvexEmailDeliveryStatus;
+  deliveredAt?: number;
+  createdAt: number;
+  updatedAt: number;
+  sentAt?: number;
+  terminalAt?: number;
+};
+
+export type ConvexEmailEventDoc = {
+  _id: string;
+  _creationTime: number;
+  emailId: string;
+  type: ConvexEmailEventType;
+  adapter?: string;
+  attempt?: number;
+  providerMessageId?: string;
+  payload?: unknown;
+  error?: string;
+  createdAt: number;
+};
+
 export type ConvexEmailEventType =
   | "queued"
   | "processing"

--- a/packages/convex-email/src/shared/validators.ts
+++ b/packages/convex-email/src/shared/validators.ts
@@ -201,6 +201,12 @@ export const vEmailConfig = v.object({
   cleanupAfterDays: v.optional(v.number()),
 });
 
+export const vDeliveryStatusValue = v.union(
+  v.literal("delivered"),
+  v.literal("bounced"),
+  v.literal("complained"),
+);
+
 export const vEmailStatusValue = v.union(
   v.literal("queued"),
   v.literal("processing"),
@@ -237,6 +243,8 @@ export const vStoredEmail = v.object({
   retryBaseMs: v.number(),
   nextAttemptAt: v.optional(v.number()),
   lastError: v.optional(v.string()),
+  deliveryStatus: v.optional(vDeliveryStatusValue),
+  deliveredAt: v.optional(v.number()),
   createdAt: v.number(),
   updatedAt: v.number(),
   sentAt: v.optional(v.number()),


### PR DESCRIPTION
Part of #106.

The package turned out to be in better shape than the empty issue suggested — the queue, retries, fallback plumbing, idempotency, test mode, cron recovery, and cleanup all exist and work. What was actually unfinished, from a full audit of the package against its README and docs page:

## What was missing

- **Delivery status tracking.** The README promises "reactive delivery state", but webhooks were only appended to the event log — nothing on the email row ever reflected delivered/bounced/complained. This was the biggest promised-but-missing piece.
- **Narrow webhook parsing.** Generic webhooks only matched `messageId`/`message_id`, so Postmark (`MessageID`) and Mailgun (`event-data.message.headers["message-id"]`) payloads could never link back to a stored email.
- **`enqueueBatch` perf bug.** The config document was read once per message inside the loop instead of once per batch.
- **`setConfig` merge trap.** Patch-merge semantics meant a config field could never be cleared (the validator can't carry an explicit `undefined`), so a stale `defaultFrom` or `cleanupAfterDays` was permanent.
- **Untyped client.** Every `ConvexEmail` method returned `unknown`.
- **Test gaps.** No coverage for the retry/backoff path to terminal failure, cancel, missing-`from`, batch happy path, in-batch idempotency, or any webhook-to-email linking.

## What this PR does

- Normalizes provider webhook event names (Resend `email.*`, Postmark `RecordType`, Mailgun `event-data`, common generic keys) onto a per-email `deliveryStatus` of `delivered` / `bounced` / `complained`, plus `deliveredAt`. Only permanent failures count as `bounced`: Mailgun `failed` events are gated on `severity: "permanent"` and Postmark `Bounce` records on a permanent `Type` (`HardBounce`, `BadEmailAddress`, `ManuallyDeactivated`) — soft/temporary failures stay stored-but-unmapped so a retried send can still land as `delivered`. Bounces and complaints are sticky against `delivered` (out-of-order webhook retries never overwrite them with a late "delivered"); between themselves the most recent webhook wins. Unknown events (opens, clicks) stay in the event history without touching `deliveryStatus`.
- Stores the normalized event on `webhookDeliveries` and widens generic message-id extraction so Postmark- and Mailgun-shaped payloads link to their emails. Postmark's numeric uppercase `ID` now serves as the dedupe delivery id instead of falling back to a body hash.
- Hoists the config read in `enqueueBatch` to one read per batch (`enqueueEmail` still reads it standalone) — same shape as the unmerged fix on `tembo/optimize-performance-bottlenecks`.
- Changes `setConfig` to replace the stored config document; omitted fields are now cleared, documented in README and docs.
- Types the client surface: `send` → `Promise<string>`, `status` → `Promise<ConvexEmailDoc | null>`, etc., with new `ConvexEmailDoc`, `ConvexEmailEventDoc`, and `ConvexEmailDeliveryStatus` exports.
- Adds 17 tests covering the above (35 total, all green) and updates the README plus the fumadocs page to match the finished behavior exactly.

## Deliberately not done

- **No changeset.** `.changeset/config.json` sets `privatePackages: { version: false, tag: false }`, and I verified locally that `changeset version` neither bumps nor consumes a changeset referencing this package — it would linger in `.changeset/` forever and keep triggering the release workflow's path filter. No merged changeset has referenced convex-email since it went private in #84. When the package goes public for npm Trusted Publishing, this work should ride in that first public version bump.
- **No provider-native batch sending in the worker.** The component's `sendBatch` is a queue-level batch (one durable row per message); per-provider batch APIs are the SDK's concern.
- **No fallback-at-send integration test.** All real adapter kinds resolve credentials from env at client build time, so there is no config-constructible adapter that fails at send without network. The fallback logic itself lives in and is tested by `@opencoredev/email-sdk`.
- **No per-provider signature verification helpers.** The docs already delegate verification to the app-mounted route's `verify` callback by design.

## Maintainer notes

- **No codegen or deployment needed.** The committed `_generated` stubs derive their types from `schema.ts` (`DataModelFromSchemaDefinition`) and use `anyApi`, so the schema additions (`emails.deliveryStatus`, `emails.deliveredAt`, `webhookDeliveries.event`) flow through without regen. All new fields are optional, so existing deployments need no migration.
- `setConfig` is a behavior change (replace vs merge) — safe while the package is private/unpublished, and now documented.

## Validation

- `packages/convex-email`: `check-types`, `build`, `bun test` → 35 pass / 0 fail (repeated runs)
- `apps/fumadocs`: `types:check` passes
- `.launch-smoke/convex-email-smoke.test.ts` passes against the rebuilt package
- `bunx oxlint` clean on all touched files

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
