### PR TITLE
feat(email-sdk): scheduled sends via sendAt

### DIFF
--- a/.changeset/scheduled-delivery.md
+++ b/.changeset/scheduled-delivery.md
@@ -1,0 +1,5 @@
+---
+"@opencoredev/email-sdk": minor
+---
+
+Add scheduled delivery via an optional `sendAt` on `EmailMessage` (a `Date` or ISO 8601 string). Seven adapters map it to their provider's native scheduling parameter: Resend (`scheduled_at`, ISO 8601), SendGrid (`send_at`, Unix seconds), Mailgun (`o:deliverytime`, RFC 2822), MailerSend (`send_at`, Unix seconds), Brevo (`scheduledAt`, ISO 8601), Mailchimp Transactional (`send_at`, UTC `YYYY-MM-DD HH:MM:SS`), and SparkPost (`options.start_time`, ISO 8601 with UTC offset). An unparseable `sendAt` fails validation before any request, and adapters without provider-side scheduling reject the field with an `EmailValidationError` instead of sending immediately — the SDK stays stateless and never queues sends itself.

--- a/.changeset/scheduled-delivery.md
+++ b/.changeset/scheduled-delivery.md
@@ -1,5 +1,0 @@
----
-"@opencoredev/email-sdk": minor
----
-
-Add scheduled delivery via an optional `sendAt` on `EmailMessage` (a `Date` or ISO 8601 string). Seven adapters map it to their provider's native scheduling parameter: Resend (`scheduled_at`, ISO 8601), SendGrid (`send_at`, Unix seconds), Mailgun (`o:deliverytime`, RFC 2822), MailerSend (`send_at`, Unix seconds), Brevo (`scheduledAt`, ISO 8601), Mailchimp Transactional (`send_at`, UTC `YYYY-MM-DD HH:MM:SS`), and SparkPost (`options.start_time`, ISO 8601 with UTC offset). An unparseable `sendAt` fails validation before any request, and adapters without provider-side scheduling reject the field with an `EmailValidationError` instead of sending immediately — the SDK stays stateless and never queues sends itself.

--- a/.changeset/scheduled-sends.md
+++ b/.changeset/scheduled-sends.md
@@ -1,0 +1,5 @@
+---
+"@opencoredev/email-sdk": minor
+---
+
+Add scheduled sends via an optional `sendAt` on `EmailMessage` (a `Date` or ISO 8601 string). Seven adapters map it to their provider's native scheduling parameter: Resend (`scheduled_at`, ISO 8601), SendGrid (`send_at`, Unix seconds), Mailgun (`o:deliverytime`, RFC 2822), MailerSend (`send_at`, Unix seconds), Brevo (`scheduledAt`, ISO 8601), Mailchimp Transactional (`send_at`, UTC `YYYY-MM-DD HH:MM:SS`), and SparkPost (`options.start_time`, ISO 8601 with UTC offset). An unparseable `sendAt` fails validation before any request, and adapters without provider-side scheduling reject the field with an `EmailValidationError` instead of sending immediately — the SDK stays stateless and never queues sends itself.

--- a/apps/fumadocs/content/docs/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs/adapters/brevo.mdx
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Brevo maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata` (as `params`). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request.
+Brevo maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata` (as `params`). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request. `sendAt` schedules the send natively as Brevo's `scheduledAt` (ISO 8601).
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs/adapters/brevo.mdx
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Brevo maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata` (as `params`). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request. `sendAt` schedules the send natively as Brevo's `scheduledAt` (ISO 8601).
+Brevo maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata` (as `params`). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request. `sendAt` schedules the send natively as Brevo's `scheduledAt` (ISO 8601) — Brevo accepts at most 72 hours in the future.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs/adapters/field-support.mdx
@@ -12,45 +12,45 @@ Email SDK keeps one message shape, but provider APIs do not expose the same feat
 
 The best fit when your app needs CC, BCC, reply-to, custom headers, tags, metadata, or attachments.
 
-| Adapter                 | CC  | BCC | Reply-To | Headers | Metadata | Tags    | Attachments |
-| ----------------------- | --- | --- | -------- | ------- | -------- | ------- | ----------- |
-| Resend                  | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         |
-| Postmark                | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         |
-| SendGrid                | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
-| Cloudflare              | Yes | Yes | Yes      | Yes     | No       | No      | Yes         |
-| Unosend                 | Yes | Yes | Yes      | Yes     | No       | Values  | Yes         |
-| AWS SES                 | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         |
-| Mailgun                 | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
-| MailerSend              | Yes | Yes | Yes      | Yes     | No       | Values  | Yes         |
-| Brevo                   | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
-| Mailchimp Transactional | Yes | Yes | No       | Yes     | Yes      | Values  | Yes         |
-| Mailtrap                | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         |
-| JetEmail                | Yes | Yes | Yes      | Yes     | No       | No      | Yes         |
-| Lettermint              | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         |
+| Adapter                 | CC  | BCC | Reply-To | Headers | Metadata | Tags    | Attachments | Send at |
+| ----------------------- | --- | --- | -------- | ------- | -------- | ------- | ----------- | ------- |
+| Resend                  | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         | Yes     |
+| Postmark                | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         | No      |
+| SendGrid                | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         | Yes     |
+| Cloudflare              | Yes | Yes | Yes      | Yes     | No       | No      | Yes         | No      |
+| Unosend                 | Yes | Yes | Yes      | Yes     | No       | Values  | Yes         | No      |
+| AWS SES                 | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         | No      |
+| Mailgun                 | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         | Yes     |
+| MailerSend              | Yes | Yes | Yes      | Yes     | No       | Values  | Yes         | Yes     |
+| Brevo                   | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         | Yes     |
+| Mailchimp Transactional | Yes | Yes | No       | Yes     | Yes      | Values  | Yes         | Yes     |
+| Mailtrap                | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         | No      |
+| JetEmail                | Yes | Yes | Yes      | Yes     | No       | No      | Yes         | No      |
+| Lettermint              | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         | No      |
 
 ## Narrow adapters
 
 Useful services whose public APIs cover less of the `EmailMessage` shape. The SDK keeps them safe by rejecting what they cannot represent.
 
-| Adapter   | CC  | BCC | Reply-To | Headers | Metadata | Tags   | Attachments |
-| --------- | --- | --- | -------- | ------- | -------- | ------ | ----------- |
-| SparkPost | No  | No  | Yes      | Yes     | Yes      | Values | Yes         |
-| Iterable  | No  | No  | No       | No      | Yes      | No     | No          |
-| Loops     | No  | No  | No       | No      | Yes      | No     | Yes         |
-| Primitive | No  | No  | No       | No      | No       | No     | Yes         |
-| Sequenzy  | No  | No  | Yes      | No      | Yes      | No     | Yes         |
-| Plunk     | No  | No  | Yes      | Yes     | Yes      | No     | Yes         |
-| Scaleway  | Yes | Yes | Yes      | Yes     | No       | No     | Yes         |
-| ZeptoMail | Yes | Yes | Yes      | No      | No       | No     | Yes         |
-| MailPace  | Yes | Yes | Yes      | No      | No       | No     | No          |
+| Adapter   | CC  | BCC | Reply-To | Headers | Metadata | Tags   | Attachments | Send at |
+| --------- | --- | --- | -------- | ------- | -------- | ------ | ----------- | ------- |
+| SparkPost | No  | No  | Yes      | Yes     | Yes      | Values | Yes         | Yes     |
+| Iterable  | No  | No  | No       | No      | Yes      | No     | No          | No      |
+| Loops     | No  | No  | No       | No      | Yes      | No     | Yes         | No      |
+| Primitive | No  | No  | No       | No      | No       | No     | Yes         | No      |
+| Sequenzy  | No  | No  | Yes      | No      | Yes      | No     | Yes         | No      |
+| Plunk     | No  | No  | Yes      | Yes     | Yes      | No     | Yes         | No      |
+| Scaleway  | Yes | Yes | Yes      | Yes     | No       | No     | Yes         | No      |
+| ZeptoMail | Yes | Yes | Yes      | No      | No       | No     | Yes         | No      |
+| MailPace  | Yes | Yes | Yes      | No      | No       | No     | No          | No      |
 
 ## SMTP transport
 
 Built in, no Nodemailer. SMTP maps address fields and headers directly into the message but has no provider-side concepts like tags or metadata.
 
-| Adapter | CC  | BCC | Reply-To | Headers | Metadata | Tags | Attachments |
-| ------- | --- | --- | -------- | ------- | -------- | ---- | ----------- |
-| SMTP    | Yes | Yes | Yes      | Yes     | No       | No   | No          |
+| Adapter | CC  | BCC | Reply-To | Headers | Metadata | Tags | Attachments | Send at |
+| ------- | --- | --- | -------- | ------- | -------- | ---- | ----------- | ------- |
+| SMTP    | Yes | Yes | Yes      | Yes     | No       | No   | No          | No      |
 
 ## Recipient variables
 
@@ -72,6 +72,7 @@ A [fallback route](/docs/concepts/fallbacks-and-retries) is only safe when the b
 | Attachments                           | Resend, Postmark, SendGrid, Mailgun, MailerSend…   |
 | Metadata for analytics or routing     | Postmark, SendGrid, Mailgun, Brevo, Mailtrap       |
 | Tags and metadata together            | SendGrid, Mailgun, Brevo, Mailtrap                 |
+| Scheduled sends (`sendAt`)            | Resend, SendGrid, Mailgun, Brevo, MailerSend       |
 
 This pair works because both routes can carry every field used:
 
@@ -100,6 +101,25 @@ Before adding a backup route, run through this checklist:
 - Does it preserve `metadata` or `tags` your app relies on for provider dashboards, analytics, or routing?
 - Does it support `replyTo` and `headers` if support workflows depend on them?
 - Has the backup provider account been live-verified (one real smoke send) in the target environment?
+
+## Scheduled delivery
+
+`sendAt` (a `Date` or ISO 8601 string) maps to each provider's native scheduling parameter — the SDK never queues or delays anything itself:
+
+| Adapter                 | Provider parameter    | Wire format                          |
+| ----------------------- | --------------------- | ------------------------------------ |
+| Resend                  | `scheduled_at`        | ISO 8601                             |
+| SendGrid                | `send_at`             | Unix timestamp (seconds)             |
+| Mailgun                 | `o:deliverytime`      | RFC 2822                             |
+| MailerSend              | `send_at`             | Unix timestamp (seconds)             |
+| Brevo                   | `scheduledAt`         | ISO 8601                             |
+| Mailchimp Transactional | `send_at`             | `YYYY-MM-DD HH:MM:SS` (UTC)          |
+| SparkPost               | `options.start_time`  | `YYYY-MM-DDTHH:MM:SS+00:00`          |
+
+Two things to keep in mind:
+
+- The SDK validates that `sendAt` parses to a real date but does not enforce a scheduling window — providers apply their own limits (SendGrid and MailerSend cap at 72 hours out, Mailgun at 3–7 days depending on plan, SparkPost at 3 days) and most treat a past date as "send now".
+- Adapters without a `Yes` in the *Send at* column reject `sendAt` before any request, like every other unmapped field. If you need scheduling with those providers, delay the `send` call with your own queue or job scheduler.
 
 ## Attachment rules
 

--- a/apps/fumadocs/content/docs/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs/adapters/field-support.mdx
@@ -72,7 +72,7 @@ A [fallback route](/docs/concepts/fallbacks-and-retries) is only safe when the b
 | Attachments                           | Resend, Postmark, SendGrid, Mailgun, MailerSend…   |
 | Metadata for analytics or routing     | Postmark, SendGrid, Mailgun, Brevo, Mailtrap       |
 | Tags and metadata together            | SendGrid, Mailgun, Brevo, Mailtrap                 |
-| Scheduled sends (`sendAt`)            | Resend, SendGrid, Mailgun, Brevo, MailerSend       |
+| Scheduled sends (`sendAt`)            | Resend, SendGrid, Mailgun, Brevo, MailerSend…      |
 
 This pair works because both routes can carry every field used:
 
@@ -102,7 +102,7 @@ Before adding a backup route, run through this checklist:
 - Does it support `replyTo` and `headers` if support workflows depend on them?
 - Has the backup provider account been live-verified (one real smoke send) in the target environment?
 
-## Scheduled delivery
+## Scheduled sends
 
 `sendAt` (a `Date` or ISO 8601 string) maps to each provider's native scheduling parameter — the SDK never queues or delays anything itself:
 
@@ -118,7 +118,7 @@ Before adding a backup route, run through this checklist:
 
 Two things to keep in mind:
 
-- The SDK validates that `sendAt` parses to a real date but does not enforce a scheduling window — providers apply their own limits (SendGrid and MailerSend cap at 72 hours out, Mailgun at 3–7 days depending on plan, SparkPost at 3 days) and most treat a past date as "send now".
+- The SDK validates that `sendAt` parses to a real date but does not enforce a scheduling window — providers apply their own limits (SendGrid, MailerSend, and Brevo cap at 72 hours out, Mailgun at 3–7 days depending on plan, SparkPost at 3 days) and most treat a past date as "send now".
 - Adapters without a `Yes` in the *Send at* column reject `sendAt` before any request, like every other unmapped field. If you need scheduling with those providers, delay the `send` call with your own queue or job scheduler.
 
 ## Attachment rules

--- a/apps/fumadocs/content/docs/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailchimp.mdx
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Mailchimp maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata`.
+Mailchimp maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata`. `sendAt` schedules the send natively as `send_at` (UTC) — note Mailchimp only schedules email for accounts with a positive balance.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailersend.mdx
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-MailerSend maps `cc`, `bcc`, `headers`, `attachments` (an attachment's `contentId` becomes MailerSend's `id`), and `tags` (values only). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request.
+MailerSend maps `cc`, `bcc`, `headers`, `attachments` (an attachment's `contentId` becomes MailerSend's `id`), and `tags` (values only). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request. `sendAt` schedules the send natively as `send_at` (a Unix timestamp in seconds) — MailerSend accepts at most 72 hours in the future.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailgun.mdx
@@ -57,7 +57,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Mailgun maps every common field: `cc`, `bcc`, `replyTo`, `headers` (as `h:Name`), `attachments` (multipart `attachment`/`inline` parts by disposition), `tags` (values as `o:tag`), and `metadata` (as `v:key` variables, surfaced later in webhooks and logs).
+Mailgun maps every common field: `cc`, `bcc`, `replyTo`, `headers` (as `h:Name`), `attachments` (multipart `attachment`/`inline` parts by disposition), `tags` (values as `o:tag`), and `metadata` (as `v:key` variables, surfaced later in webhooks and logs). `sendAt` schedules delivery natively as `o:deliverytime` (RFC 2822) — Mailgun accepts up to 3 days out on most plans, 7 with extended storage.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailgun.mdx
@@ -57,7 +57,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Mailgun maps every common field: `cc`, `bcc`, `replyTo`, `headers` (as `h:Name`), `attachments` (multipart `attachment`/`inline` parts by disposition), `tags` (values as `o:tag`), and `metadata` (as `v:key` variables, surfaced later in webhooks and logs). `sendAt` schedules delivery natively as `o:deliverytime` (RFC 2822) — Mailgun accepts up to 3 days out on most plans, 7 with extended storage.
+Mailgun maps every common field: `cc`, `bcc`, `replyTo`, `headers` (as `h:Name`), `attachments` (multipart `attachment`/`inline` parts by disposition), `tags` (values as `o:tag`), and `metadata` (as `v:key` variables, surfaced later in webhooks and logs). `sendAt` becomes a native scheduled send via `o:deliverytime` (RFC 2822) — Mailgun accepts up to 3 days out on most plans, 7 with extended storage.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs/adapters/resend.mdx
@@ -46,7 +46,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Resend maps every common transactional field: `cc`, `bcc`, `replyTo`, `headers`, `attachments`, and `tags`.
+Resend maps every common transactional field: `cc`, `bcc`, `replyTo`, `headers`, `attachments`, and `tags`. `sendAt` schedules the send natively — it is sent as `scheduled_at` in ISO 8601 form.
 
 ```ts
 const result = await email.send(

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Everything maps: `cc`, `bcc`, `headers`, `attachments`, `tags`, `metadata`, and even multiple `replyTo` addresses (sent as `reply_to_list`).
+Everything maps: `cc`, `bcc`, `headers`, `attachments`, `tags`, `metadata`, and even multiple `replyTo` addresses (sent as `reply_to_list`). `sendAt` schedules the send natively as `send_at` (a Unix timestamp in seconds) — SendGrid accepts at most 72 hours in the future.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs/adapters/sparkpost.mdx
@@ -46,7 +46,7 @@ export const email = createEmailClient({
 
 ## Send
 
-SparkPost maps `replyTo`, `headers`, `attachments`, `metadata`, and `tags` (each tag becomes a `substitution_data` entry keyed by its name).
+SparkPost maps `replyTo`, `headers`, `attachments`, `metadata`, and `tags` (each tag becomes a `substitution_data` entry keyed by its name). `sendAt` schedules the transmission natively as `options.start_time` — SparkPost accepts at most 3 days in the future.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/reference/message.mdx
+++ b/apps/fumadocs/content/docs/reference/message.mdx
@@ -21,6 +21,7 @@ type EmailMessage = {
   tags?: EmailTag[];
   metadata?: Record<string, string | number | boolean | null>;
   recipientVariables?: Record<string, Record<string, string | number | boolean>>;
+  sendAt?: Date | string;
   idempotencyKey?: string;
 };
 ```
@@ -83,6 +84,10 @@ type EmailMessage = {
     recipientVariables: {
       description: "Per-recipient %recipient.key% substitution values, keyed by recipient address.",
       type: "Record<string, Record<string, string | number | boolean>>",
+    },
+    sendAt: {
+      description: "Future delivery time, scheduled by the provider.",
+      type: "Date | string",
     },
     idempotencyKey: {
       description: "Stable send identity, used when send options set none.",
@@ -154,6 +159,22 @@ Both attach data to a send on the provider side, but they are different provider
 
 Support differs per provider — Resend has tags but no metadata, Iterable has metadata but no tags. Check the [field support matrix](/docs/adapters/field-support) before relying on either, especially for fallback routes.
 
+## Scheduled delivery
+
+`sendAt` asks the provider to deliver the message at a future time. It takes a `Date` or any string `new Date()` can parse — ISO 8601 is the safe choice:
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  html: "<p>Glad you're here.</p>",
+  sendAt: new Date(Date.now() + 5 * 60_000), // five minutes from now
+});
+```
+
+The SDK is stateless — it never queues or delays a send itself. Each adapter translates `sendAt` into its provider's native scheduling parameter, and adapters whose provider has no scheduling API reject the field before any request. The SDK also does not enforce a scheduling window: providers cap how far out you can schedule (72 hours for SendGrid and MailerSend, for example) and most send immediately when the date is in the past. See [scheduled delivery in the field support matrix](/docs/adapters/field-support#scheduled-delivery) for the per-provider parameters and limits.
+
 ## Idempotency key
 
 `idempotencyKey` gives the send a stable identity across retries. The send-options key wins when both are set; the message field is the fallback. Only Resend transmits it natively — see [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys) for per-adapter behavior.
@@ -199,6 +220,7 @@ Adapters with a native batch mechanism send the whole list in **one API call** w
 | `recipientVariables` address not in `to` | `recipientVariables reference addresses that are not in "to": <addresses>.` |
 | `recipientVariables` duplicate `to` | `recipientVariables require unique "to" addresses, but "<address>" appears more than once.` |
 | `recipientVariables` invalid key | `recipientVariables keys may only contain letters, numbers, underscores, and hyphens, but "<address>" has "<key>".` |
+| `sendAt` must parse | `Email message sendAt is not a valid date: "<value>".` |
 
 Adapters add a second fail-fast layer for fields their provider cannot represent:
 
@@ -206,4 +228,4 @@ Adapters add a second fail-fast layer for fields their provider cannot represent
 smtp does not support these EmailMessage fields: tags, metadata.
 ```
 
-That error fires before any request — fields are rejected, never silently dropped. The per-adapter availability of `cc`, `bcc`, `replyTo`, `headers`, `attachments`, `tags`, and `metadata` is the [field support matrix](/docs/adapters/field-support).
+That error fires before any request — fields are rejected, never silently dropped. The per-adapter availability of `cc`, `bcc`, `replyTo`, `headers`, `attachments`, `tags`, `metadata`, and `sendAt` is the [field support matrix](/docs/adapters/field-support).

--- a/apps/fumadocs/content/docs/reference/message.mdx
+++ b/apps/fumadocs/content/docs/reference/message.mdx
@@ -159,9 +159,9 @@ Both attach data to a send on the provider side, but they are different provider
 
 Support differs per provider — Resend has tags but no metadata, Iterable has metadata but no tags. Check the [field support matrix](/docs/adapters/field-support) before relying on either, especially for fallback routes.
 
-## Scheduled delivery
+## Scheduled sends
 
-`sendAt` asks the provider to deliver the message at a future time. It takes a `Date` or any string `new Date()` can parse — ISO 8601 is the safe choice:
+`sendAt` asks the provider to deliver the message at a future time. Pass a `Date` object or an ISO 8601 string with an explicit offset — `"2026-07-10T12:30:00Z"` or `"2026-07-10T14:30:00+02:00"`. Offset-less strings like `"2026-07-10T12:30:00"` are parsed by `new Date()` in the **server's local timezone**, so the actual send time shifts with wherever your code happens to run. Always include the offset, or build a `Date` yourself:
 
 ```ts
 await email.send({
@@ -173,7 +173,7 @@ await email.send({
 });
 ```
 
-The SDK is stateless — it never queues or delays a send itself. Each adapter translates `sendAt` into its provider's native scheduling parameter, and adapters whose provider has no scheduling API reject the field before any request. The SDK also does not enforce a scheduling window: providers cap how far out you can schedule (72 hours for SendGrid and MailerSend, for example) and most send immediately when the date is in the past. See [scheduled delivery in the field support matrix](/docs/adapters/field-support#scheduled-delivery) for the per-provider parameters and limits.
+The SDK is stateless — it never queues or delays a send itself. Each adapter translates `sendAt` into its provider's native scheduling parameter, and adapters whose provider has no scheduling API reject the field before any request. The SDK also does not enforce a scheduling window: providers cap how far out you can schedule (72 hours for SendGrid, MailerSend, and Brevo, for example) and most send immediately when the date is in the past. See [scheduled sends in the field support matrix](/docs/adapters/field-support#scheduled-sends) for the per-provider parameters and limits.
 
 ## Idempotency key
 

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -1223,6 +1223,39 @@ describe("provider payloads", () => {
     expect(mailchimpCapture.calls[0]?.json.send_at).toBe("2026-07-10 12:30:00");
   });
 
+  test("native batch sends carry sendAt in the same scheduled call", async () => {
+    const sendAt = new Date("2026-07-10T12:30:00.000Z");
+    const batch = {
+      from: "Acme <hello@acme.com>",
+      to: ["a@example.com", "b@example.com"],
+      subject: "Hi %recipient.name%",
+      html: "<p>Hi %recipient.name%</p>",
+      recipientVariables: {
+        "a@example.com": { name: "Ada" },
+        "b@example.com": { name: "Linus" },
+      },
+      sendAt,
+    } satisfies EmailMessage;
+
+    const mailgunCapture = formCapture({ id: "<mailgun_batch>" });
+    await mailgun({
+      apiKey: "mg",
+      domain: "mg.example.com",
+      fetch: mailgunCapture.fetch,
+    }).sendBulk?.(batch, context);
+    expect(mailgunCapture.calls).toHaveLength(1);
+    expect(mailgunCapture.calls[0]?.form.get("recipient-variables")).toBeTruthy();
+    expect(mailgunCapture.calls[0]?.form.get("o:deliverytime")).toBe(
+      "Fri, 10 Jul 2026 12:30:00 +0000",
+    );
+
+    const sendgridCapture = jsonCapture({}, { headers: { "x-message-id": "sg_batch" } });
+    await sendgrid({ apiKey: "sg", fetch: sendgridCapture.fetch }).sendBulk?.(batch, context);
+    expect(sendgridCapture.calls).toHaveLength(1);
+    expect(sendgridCapture.calls[0]?.json.personalizations).toHaveLength(2);
+    expect(sendgridCapture.calls[0]?.json.send_at).toBe(Math.floor(sendAt.getTime() / 1000));
+  });
+
   test("sendAt accepts ISO strings and rejects unparseable dates", async () => {
     const stringCapture = jsonCapture({ id: "res_123" });
     await resend({ apiKey: "key", fetch: stringCapture.fetch }).send(

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -1173,6 +1173,106 @@ describe("provider payloads", () => {
     expect(capture.calls[0]?.headers.get("idempotency-key")).toBe("idem_123");
   });
 
+  test("adapters map sendAt to their native scheduling parameters", async () => {
+    const sendAt = new Date("2026-07-10T12:30:00.000Z");
+    const scheduledMessage: EmailMessage = { ...messageWithoutMetadata, sendAt };
+
+    const resendCapture = jsonCapture({ id: "res_123" });
+    await resend({ apiKey: "key", fetch: resendCapture.fetch }).send(scheduledMessage, context);
+    expect(resendCapture.calls[0]?.json.scheduled_at).toBe("2026-07-10T12:30:00.000Z");
+
+    const sendgridCapture = jsonCapture({});
+    await sendgrid({ apiKey: "key", fetch: sendgridCapture.fetch }).send(
+      { ...message, sendAt },
+      context,
+    );
+    expect(sendgridCapture.calls[0]?.json.send_at).toBe(Math.floor(sendAt.getTime() / 1000));
+
+    const brevoCapture = jsonCapture({ messageId: "brevo_123" });
+    await brevo({ apiKey: "key", fetch: brevoCapture.fetch }).send({ ...message, sendAt }, context);
+    expect(brevoCapture.calls[0]?.json.scheduledAt).toBe("2026-07-10T12:30:00.000Z");
+
+    const mailgunCapture = formCapture({ id: "<mailgun_123>" });
+    await mailgun({ apiKey: "mg", domain: "mg.example.com", fetch: mailgunCapture.fetch }).send(
+      { ...message, sendAt },
+      context,
+    );
+    expect(mailgunCapture.calls[0]?.form.get("o:deliverytime")).toBe(
+      "Fri, 10 Jul 2026 12:30:00 +0000",
+    );
+
+    const mailersendCapture = jsonCapture({});
+    await mailersend({ apiKey: "key", fetch: mailersendCapture.fetch }).send(
+      { ...messageWithoutMetadata, sendAt },
+      context,
+    );
+    expect(mailersendCapture.calls[0]?.json.send_at).toBe(Math.floor(sendAt.getTime() / 1000));
+
+    const sparkpostCapture = jsonCapture({ results: { id: "spark_123" } });
+    await sparkpost({ apiKey: "key", fetch: sparkpostCapture.fetch }).send(
+      { ...message, cc: undefined, bcc: undefined, sendAt },
+      context,
+    );
+    expect(sparkpostCapture.calls[0]?.json.options.start_time).toBe("2026-07-10T12:30:00+00:00");
+
+    const mailchimpCapture = jsonCapture([{ _id: "mc_123" }]);
+    await mailchimp({ apiKey: "key", fetch: mailchimpCapture.fetch }).send(
+      { ...messageWithoutReplyTo, sendAt },
+      context,
+    );
+    expect(mailchimpCapture.calls[0]?.json.send_at).toBe("2026-07-10 12:30:00");
+  });
+
+  test("sendAt accepts ISO strings and rejects unparseable dates", async () => {
+    const stringCapture = jsonCapture({ id: "res_123" });
+    await resend({ apiKey: "key", fetch: stringCapture.fetch }).send(
+      { ...messageWithoutMetadata, sendAt: "2026-07-10T12:30:00.000Z" },
+      context,
+    );
+    expect(stringCapture.calls[0]?.json.scheduled_at).toBe("2026-07-10T12:30:00.000Z");
+
+    await expect(
+      resend({ apiKey: "key", fetch: jsonCapture({ id: "res_123" }).fetch }).send(
+        { ...messageWithoutMetadata, sendAt: "tomorrow-ish" },
+        context,
+      ),
+    ).rejects.toThrow('Email message sendAt is not a valid date: "tomorrow-ish".');
+
+    await expect(
+      resend({ apiKey: "key", fetch: jsonCapture({ id: "res_123" }).fetch }).send(
+        { ...messageWithoutMetadata, sendAt: new Date(Number.NaN) },
+        context,
+      ),
+    ).rejects.toThrow(EmailValidationError);
+  });
+
+  test("adapters without native scheduling reject sendAt instead of sending immediately", async () => {
+    const sendAt = "2026-07-10T12:30:00.000Z";
+
+    await expect(
+      postmark({ serverToken: "server", fetch: jsonCapture({ MessageID: "pm_123" }).fetch }).send(
+        { ...message, sendAt },
+        context,
+      ),
+    ).rejects.toThrow("postmark does not support these EmailMessage fields: sendAt");
+
+    await expect(
+      ses({
+        accessKeyId: "access",
+        secretAccessKey: "secret",
+        region: "us-east-1",
+        fetch: jsonCapture({ MessageId: "ses_123" }).fetch,
+      }).send({ ...messageWithoutMetadata, sendAt }, context),
+    ).rejects.toThrow("ses does not support these EmailMessage fields: sendAt");
+
+    await expect(
+      mailtrap({ apiKey: "key", fetch: jsonCapture({ message_ids: ["mt_123"] }).fetch }).send(
+        { ...message, sendAt },
+        context,
+      ),
+    ).rejects.toThrow("mailtrap does not support these EmailMessage fields: sendAt");
+  });
+
   test("limited adapters reject fields they cannot send instead of dropping them", async () => {
     const limitedMessage = {
       ...message,

--- a/packages/email-sdk/src/brevo.ts
+++ b/packages/email-sdk/src/brevo.ts
@@ -6,6 +6,7 @@ import {
   commonHeadersObject,
   optionalApiAddresses,
   optionalSingleApiAddress,
+  sendAtIso,
 } from "./payloads.js";
 import type { EmailProvider } from "./types.js";
 
@@ -39,6 +40,7 @@ export function brevo(options: BrevoProviderOptions): EmailProvider<{ baseUrl: s
         headers: commonHeadersObject(message),
         params: message.metadata,
         tags: message.tags?.map((tag) => tag.value),
+        scheduledAt: sendAtIso(message),
         attachment: attachments?.map((attachment) => ({
           name: attachment.filename,
           content: attachment.content,

--- a/packages/email-sdk/src/core.test.ts
+++ b/packages/email-sdk/src/core.test.ts
@@ -110,6 +110,19 @@ describe("createEmailClient", () => {
     ).rejects.toBeInstanceOf(EmailValidationError);
   });
 
+  test("validates sendAt before any adapter runs", async () => {
+    const provider = memoryProvider();
+    const client = createEmailClient({ adapters: [provider] });
+
+    await expect(client.send({ ...message, sendAt: "not-a-date" })).rejects.toThrow(
+      'Email message sendAt is not a valid date: "not-a-date".',
+    );
+    expect(provider.raw.sent).toHaveLength(0);
+
+    const response = await client.send({ ...message, sendAt: new Date("2026-07-10T12:30:00Z") });
+    expect(response.provider).toBe("memory");
+  });
+
   test("captures batch failures without throwing", async () => {
     const client = createEmailClient({ adapters: [memoryProvider()] });
     const results = await client.sendBatch([

--- a/packages/email-sdk/src/core.test.ts
+++ b/packages/email-sdk/src/core.test.ts
@@ -462,6 +462,49 @@ describe("recipientVariables", () => {
     expect(response.accepted).toEqual(["a@example.com", "b@example.com"]);
   });
 
+  test("expanded per-recipient sends inherit sendAt", async () => {
+    const sendAt = new Date("2026-07-10T12:30:00.000Z");
+    const provider = memoryProvider();
+    const client = createEmailClient({ adapters: [provider] });
+
+    await client.send({ ...batchMessage, sendAt });
+
+    expect(provider.raw.sent).toHaveLength(2);
+    for (const sent of provider.raw.sent) {
+      expect(sent.message.sendAt).toBe(sendAt);
+    }
+  });
+
+  test("sendAt with recipientVariables on an adapter without scheduling rejects every expanded send", async () => {
+    let requests = 0;
+    const adapter = postmark({
+      serverToken: "server",
+      fetch: () => {
+        requests += 1;
+        throw new Error("unreachable — postmark must reject sendAt before any request");
+      },
+    });
+    const client = createEmailClient({ adapters: [adapter] });
+
+    const error = await client
+      .send({ ...batchMessage, sendAt: new Date("2026-07-10T12:30:00.000Z") })
+      .then(() => {
+        throw new Error("send should have failed");
+      })
+      .catch((caught: unknown) => caught);
+
+    // Every expanded per-recipient send runs the adapter's field assertion, so the
+    // whole batch fails fast instead of delivering unscheduled mail.
+    expect(error).toBeInstanceOf(EmailSdkError);
+    expect((error as EmailSdkError).code).toBe("all_recipients_failed");
+    const failures = (error as EmailSdkError).details as EmailProviderError[];
+    expect(failures).toHaveLength(2);
+    for (const failure of failures) {
+      expect(failure.message).toBe("postmark does not support these EmailMessage fields: sendAt.");
+    }
+    expect(requests).toBe(0);
+  });
+
   test("rejects recipientVariables combined with cc", async () => {
     const client = createEmailClient({ adapters: [memoryProvider()] });
 

--- a/packages/email-sdk/src/core.test.ts
+++ b/packages/email-sdk/src/core.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import { createEmailClient } from "./core.js";
-import { EmailProviderError, EmailValidationError } from "./errors.js";
+import { EmailProviderError, EmailSdkError, EmailValidationError } from "./errors.js";
+import { postmark } from "./postmark.js";
 import { failingProvider, memoryProvider } from "./testing.js";
 import type { EmailMessage, EmailProvider, EmailProviderContext } from "./types.js";
 
@@ -121,6 +122,42 @@ describe("createEmailClient", () => {
 
     const response = await client.send({ ...message, sendAt: new Date("2026-07-10T12:30:00Z") });
     expect(response.provider).toBe("memory");
+  });
+
+  test("sendAt on a fallback route without scheduling support fails instead of sending unscheduled", async () => {
+    let fallbackRequests = 0;
+    const backup = postmark({
+      serverToken: "server",
+      fetch: () => {
+        fallbackRequests += 1;
+        throw new Error("unreachable — postmark must reject sendAt before any request");
+      },
+    });
+
+    const client = createEmailClient({
+      adapters: [failingProvider(), backup],
+      fallback: ["postmark"],
+    });
+
+    const error = await client
+      .send({ ...message, sendAt: new Date("2026-07-10T12:30:00Z") })
+      .then(() => {
+        throw new Error("send should have failed");
+      })
+      .catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(EmailSdkError);
+    expect((error as EmailSdkError).code).toBe("all_providers_failed");
+
+    // The fallback's rejection is recorded as an EmailProviderError wrapping the
+    // adapter's EmailValidationError (toProviderError keeps the original as `cause`).
+    const failures = (error as EmailSdkError).details as EmailProviderError[];
+    const fallbackFailure = failures.find((failure) => failure.provider === "postmark");
+    expect(fallbackFailure?.message).toBe(
+      "postmark does not support these EmailMessage fields: sendAt.",
+    );
+    expect(fallbackFailure?.cause).toBeInstanceOf(EmailValidationError);
+    expect(fallbackRequests).toBe(0);
   });
 
   test("captures batch failures without throwing", async () => {

--- a/packages/email-sdk/src/mailchimp.ts
+++ b/packages/email-sdk/src/mailchimp.ts
@@ -1,5 +1,5 @@
 import { firstString, jsonProvider } from "./http.js";
-import { base64Attachments, emailParts } from "./payloads.js";
+import { base64Attachments, emailParts, sendAtUtcDateTime } from "./payloads.js";
 import type { EmailAddress, EmailProvider, OneOrMany } from "./types.js";
 import {
   SUPPORTED_MESSAGE_FIELDS,
@@ -27,6 +27,7 @@ export function mailchimp(options: MailchimpProviderOptions): EmailProvider<{ ba
 
       return {
         key: options.apiKey,
+        send_at: sendAtUtcDateTime(message),
         message: {
           from_email: from.email,
           from_name: from.name,

--- a/packages/email-sdk/src/mailersend.ts
+++ b/packages/email-sdk/src/mailersend.ts
@@ -6,6 +6,7 @@ import {
   commonHeadersArray,
   optionalApiAddresses,
   optionalSingleApiAddress,
+  sendAtUnixSeconds,
 } from "./payloads.js";
 import type { EmailProvider } from "./types.js";
 import { SUPPORTED_MESSAGE_FIELDS, assertSupportedMessageFields } from "./utils.js";
@@ -46,6 +47,7 @@ export function mailersend(options: MailerSendProviderOptions): EmailProvider<{ 
           id: attachment.contentId,
         })),
         tags: message.tags?.map((tag) => tag.value),
+        send_at: sendAtUnixSeconds(message),
       };
     },
     parseResponse(body, _message, response) {

--- a/packages/email-sdk/src/mailgun.ts
+++ b/packages/email-sdk/src/mailgun.ts
@@ -1,5 +1,5 @@
 import { EmailProviderError } from "./errors.js";
-import { recipientVariablesMap } from "./payloads.js";
+import { recipientVariablesMap, sendAtRfc2822 } from "./payloads.js";
 import type { EmailProvider } from "./types.js";
 import {
   arrayify,
@@ -64,6 +64,9 @@ export function mailgun(options: MailgunProviderOptions): EmailProvider<{ baseUr
     for (const tag of message.tags ?? []) {
       body.append("o:tag", tag.value);
     }
+
+    const deliveryTime = sendAtRfc2822(message);
+    if (deliveryTime) body.set("o:deliverytime", deliveryTime);
 
     for (const attachment of message.attachments ?? []) {
       const bytes = await attachmentToBytes(attachment);

--- a/packages/email-sdk/src/payloads.ts
+++ b/packages/email-sdk/src/payloads.ts
@@ -8,6 +8,7 @@ import {
   formatAddresses,
   headersToArray,
   headersToObject,
+  toSendAtDate,
 } from "./utils.js";
 
 export function simpleAddress(address: string) {
@@ -157,6 +158,36 @@ export function expandRecipientMessage(message: EmailMessage, entry: RecipientEn
     html: message.html ? substituteRecipientVariables(message.html, entry.variables) : undefined,
     text: message.text ? substituteRecipientVariables(message.text, entry.variables) : undefined,
   };
+}
+
+export function sendAtDate(message: EmailMessage) {
+  return message.sendAt === undefined ? undefined : toSendAtDate(message.sendAt);
+}
+
+export function sendAtIso(message: EmailMessage) {
+  return sendAtDate(message)?.toISOString();
+}
+
+export function sendAtUnixSeconds(message: EmailMessage) {
+  const date = sendAtDate(message);
+  return date === undefined ? undefined : Math.floor(date.getTime() / 1000);
+}
+
+export function sendAtRfc2822(message: EmailMessage) {
+  // Mailgun documents o:deliverytime as RFC 2822, e.g. "Fri, 10 Jul 2026 12:30:00 +0000".
+  return sendAtDate(message)?.toUTCString().replace(/GMT$/, "+0000");
+}
+
+export function sendAtIsoUtcSeconds(message: EmailMessage) {
+  // SparkPost's start_time grammar is YYYY-MM-DDTHH:MM:SS±HH:MM — no milliseconds, no "Z".
+  const date = sendAtDate(message);
+  return date === undefined ? undefined : `${date.toISOString().slice(0, 19)}+00:00`;
+}
+
+export function sendAtUtcDateTime(message: EmailMessage) {
+  // Mailchimp Transactional's send_at grammar is "YYYY-MM-DD HH:MM:SS" in UTC.
+  const date = sendAtDate(message);
+  return date === undefined ? undefined : date.toISOString().slice(0, 19).replace("T", " ");
 }
 
 export function commonHeadersObject(message: EmailMessage) {

--- a/packages/email-sdk/src/postmark.ts
+++ b/packages/email-sdk/src/postmark.ts
@@ -9,6 +9,8 @@ import {
   isRetryableStatus,
   readErrorBody,
   assertMaxItems,
+  assertSupportedMessageFields,
+  SUPPORTED_MESSAGE_FIELDS,
 } from "./utils.js";
 
 export type PostmarkProviderOptions = {
@@ -67,6 +69,7 @@ export function postmark(options: PostmarkProviderOptions): EmailProvider<{ base
 }
 
 async function toPostmarkPayload(message: EmailMessage, messageStream?: string) {
+  assertSupportedMessageFields("postmark", message, SUPPORTED_MESSAGE_FIELDS.postmark);
   const tag = firstPostmarkTag(message.tags);
 
   return {

--- a/packages/email-sdk/src/resend.ts
+++ b/packages/email-sdk/src/resend.ts
@@ -1,4 +1,5 @@
 import { EmailProviderError } from "./errors.js";
+import { sendAtIso } from "./payloads.js";
 import type { EmailAttachment, EmailMessage, EmailProvider } from "./types.js";
 import {
   attachmentToBase64,
@@ -76,6 +77,7 @@ async function toResendPayload(message: EmailMessage) {
     headers: headersToObject(message.headers),
     attachments: await Promise.all((message.attachments ?? []).map(toResendAttachment)),
     tags: message.tags,
+    scheduled_at: sendAtIso(message),
   };
 }
 

--- a/packages/email-sdk/src/sendgrid.ts
+++ b/packages/email-sdk/src/sendgrid.ts
@@ -5,6 +5,7 @@ import {
   commonHeadersObject,
   optionalApiAddresses,
   recipientVariableEntries,
+  sendAtUnixSeconds,
   sendgridAttachments,
 } from "./payloads.js";
 import type { EmailMessage, EmailProvider } from "./types.js";
@@ -37,6 +38,7 @@ export function sendgrid(options: SendGridProviderOptions): EmailProvider<{ base
         ],
         attachments: await sendgridAttachments(message),
         categories: message.tags?.map((tag) => tag.value),
+        send_at: sendAtUnixSeconds(message),
       };
     },
     parseResponse(body, _message, response) {

--- a/packages/email-sdk/src/sparkpost.ts
+++ b/packages/email-sdk/src/sparkpost.ts
@@ -4,6 +4,7 @@ import {
   base64Attachments,
   formatAddresses,
   optionalStringAddresses,
+  sendAtIsoUtcSeconds,
 } from "./payloads.js";
 import type { EmailProvider } from "./types.js";
 import {
@@ -35,6 +36,7 @@ export function sparkpost(options: SparkPostProviderOptions): EmailProvider<{ ba
       return {
         options: {
           sandbox: options.sandbox,
+          start_time: sendAtIsoUtcSeconds(message),
         },
         recipients: formatAddresses(message.to).map((address) => ({ address })),
         content: {

--- a/packages/email-sdk/src/types.ts
+++ b/packages/email-sdk/src/types.ts
@@ -51,6 +51,7 @@ export type EmailMessage = {
   tags?: EmailTag[];
   metadata?: Record<string, string | number | boolean | null>;
   recipientVariables?: RecipientVariables;
+  sendAt?: Date | string;
   idempotencyKey?: string;
 };
 

--- a/packages/email-sdk/src/utils.ts
+++ b/packages/email-sdk/src/utils.ts
@@ -92,6 +92,25 @@ export function assertMessage(message: EmailMessage) {
       );
     }
   }
+
+  if (message.sendAt !== undefined) {
+    toSendAtDate(message.sendAt);
+  }
+}
+
+// Past sendAt values are intentionally allowed: providers either send immediately or reject
+// with their own scheduling-window errors, and clock skew makes a client-side cutoff unreliable.
+export function toSendAtDate(sendAt: NonNullable<EmailMessage["sendAt"]>): Date {
+  const date = sendAt instanceof Date ? sendAt : new Date(sendAt);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new EmailValidationError(
+      `Email message sendAt is not a valid date: "${String(sendAt)}".`,
+      { sendAt },
+    );
+  }
+
+  return date;
 }
 
 export function hasRecipientVariables(message: EmailMessage): boolean {
@@ -289,11 +308,22 @@ export async function attachmentToBytes(attachment: EmailAttachment) {
 }
 
 export type MessageFieldSupport = Partial<
-  Record<"cc" | "bcc" | "replyTo" | "headers" | "attachments" | "tags" | "metadata", boolean>
+  Record<
+    "cc" | "bcc" | "replyTo" | "headers" | "attachments" | "tags" | "metadata" | "sendAt",
+    boolean
+  >
 >;
 
 export const SUPPORTED_MESSAGE_FIELDS = {
-  resend: { cc: true, bcc: true, replyTo: true, headers: true, attachments: true, tags: true },
+  resend: {
+    cc: true,
+    bcc: true,
+    replyTo: true,
+    headers: true,
+    attachments: true,
+    tags: true,
+    sendAt: true,
+  },
   postmark: {
     cc: true,
     bcc: true,
@@ -311,6 +341,7 @@ export const SUPPORTED_MESSAGE_FIELDS = {
     attachments: true,
     tags: true,
     metadata: true,
+    sendAt: true,
   },
   cloudflare: { cc: true, bcc: true, replyTo: true, headers: true, attachments: true },
   unosend: { cc: true, bcc: true, replyTo: true, headers: true, attachments: true, tags: true },
@@ -323,8 +354,17 @@ export const SUPPORTED_MESSAGE_FIELDS = {
     attachments: true,
     tags: true,
     metadata: true,
+    sendAt: true,
   },
-  mailersend: { cc: true, bcc: true, replyTo: true, headers: true, attachments: true, tags: true },
+  mailersend: {
+    cc: true,
+    bcc: true,
+    replyTo: true,
+    headers: true,
+    attachments: true,
+    tags: true,
+    sendAt: true,
+  },
   brevo: {
     cc: true,
     bcc: true,
@@ -333,9 +373,25 @@ export const SUPPORTED_MESSAGE_FIELDS = {
     attachments: true,
     tags: true,
     metadata: true,
+    sendAt: true,
   },
-  mailchimp: { cc: true, bcc: true, headers: true, attachments: true, tags: true, metadata: true },
-  sparkpost: { replyTo: true, headers: true, attachments: true, tags: true, metadata: true },
+  mailchimp: {
+    cc: true,
+    bcc: true,
+    headers: true,
+    attachments: true,
+    tags: true,
+    metadata: true,
+    sendAt: true,
+  },
+  sparkpost: {
+    replyTo: true,
+    headers: true,
+    attachments: true,
+    tags: true,
+    metadata: true,
+    sendAt: true,
+  },
   iterable: { metadata: true },
   loops: { attachments: true, metadata: true },
   sequenzy: { replyTo: true, attachments: true, metadata: true },
@@ -380,6 +436,7 @@ export function assertSupportedMessageFields(
   if (message.attachments?.length && !supported.attachments) unsupported.push("attachments");
   if (message.tags?.length && !supported.tags) unsupported.push("tags");
   if (hasValues(message.metadata) && !supported.metadata) unsupported.push("metadata");
+  if (message.sendAt !== undefined && !supported.sendAt) unsupported.push("sendAt");
 
   if (unsupported.length > 0) {
     throw new EmailValidationError(


### PR DESCRIPTION
Closes #100

## What

Adds an optional `sendAt?: Date | string` to `EmailMessage` for provider-side scheduled sends. The SDK stays stateless — no queue or delay mechanism — each adapter translates `sendAt` into its provider's native scheduling parameter, and everything else fails fast through the existing field-support matrix.

## Native mappings

| Adapter | Provider parameter | Wire format |
| --- | --- | --- |
| Resend | `scheduled_at` | ISO 8601 |
| SendGrid | `send_at` | Unix timestamp (seconds) |
| Mailgun | `o:deliverytime` | RFC 2822 (`Fri, 10 Jul 2026 12:30:00 +0000`) |
| MailerSend | `send_at` | Unix timestamp (seconds) |
| Brevo | `scheduledAt` | ISO 8601 |
| Mailchimp Transactional | `send_at` (top level) | `YYYY-MM-DD HH:MM:SS` UTC |
| SparkPost | `options.start_time` | `YYYY-MM-DDTHH:MM:SS+00:00` |

MailerSend, SparkPost, and Mailchimp go beyond the issue's table — their APIs document native scheduling, so they are wired too. Iterable keeps its existing adapter-level `sendAt` option untouched; the message-level field is rejected there because the campaign-target format is a different contract.

## Unsupported adapters

All other adapters (Postmark, SES, Mailtrap, Cloudflare, Unosend, JetEmail, Lettermint, Loops, Plunk, Primitive, Sequenzy, Scaleway, ZeptoMail, MailPace, Iterable, SMTP) reject `sendAt` before any request with the standard `EmailValidationError` — `"<adapter> does not support these EmailMessage fields: sendAt."` — matching how `tags`/`metadata`/`headers` are handled today (reject, never silently drop). Postmark previously skipped the field-support assertion because it supported every field; it now runs it.

## Validation

- `sendAt` accepts a `Date` or any `new Date()`-parseable string; unparseable values throw `EmailValidationError` in `assertMessage` before any adapter runs. Docs recommend `Date` objects or offset-qualified ISO strings (`...Z` / `+02:00`) and warn that offset-less strings parse in the server's local timezone.
- No client-side scheduling-window or past-date check: providers apply their own limits (SendGrid/MailerSend/Brevo 72h, SparkPost/Mailgun ~3 days) and most treat past dates as "send now", so a client cutoff would just fight clock skew.

## Tests & docs

- Adapter tests assert each native mapping's exact payload field and format, Date vs string input, invalid-date rejection, and unsupported-adapter rejection (postmark, ses, mailtrap); core tests cover validation before the adapter runs and a fallback route where the backup adapter lacks scheduling support — the send fails with `all_providers_failed` instead of going out unscheduled.
- Docs: `field-support.mdx` gets a *Send at* column plus a scheduled-sends section, `reference/message.mdx` documents the field and its validation error, and the seven native adapter pages mention their parameter and provider limits.
- Changeset: minor bump for `@opencoredev/email-sdk`.

- Rebased on #125 (batch recipient variables): `sendAt` composes with `recipientVariables` — Mailgun/SendGrid native batch calls carry the scheduling parameter in the same request, the client-side per-recipient fallback inherits `sendAt` on every expanded send, and adapters without scheduling still reject the expanded sends before any request. New tests cover all three paths.

`bun run build`, `bun test` (116 pass), fumadocs `types:check`, and `oxlint` on touched files are all green.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

