### PR TITLE
docs: humanize and rewrite the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ One TypeScript client for transactional email. Pick the providers you actually s
 npm install @opencoredev/email-sdk
 ```
 
-Server-side only (Node 20+ or Bun) — never expose provider API keys in client code.
+The SDK is server-side only and needs Node 20+ or Bun. Keep provider API keys out of client code.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 
 One TypeScript client for transactional email. Pick the providers you actually send through, add retries and fallback routes, catch unsupported fields before they are silently dropped, and keep every send observable.
 
-- 🔌 Adapters for 20+ providers behind one normalized message
-- 🔁 Retries within an adapter, plus fallback routes across adapters
-- 🛟 Fail-fast field-support checks before a provider drops data
-- 🔭 Observability hooks for logs, metrics, and traces
-- 🧪 Test adapters that never call real providers
-- ⌨️ CLI for adapter discovery, doctor checks, and dry-run sends
+- Adapters for 23 providers behind one normalized message
+- Retries within an adapter, plus fallback routes across adapters
+- Fail-fast field-support checks before a provider drops data
+- Observability hooks for logs, metrics, and traces
+- Test adapters that never call real providers
+- CLI for adapter discovery, doctor checks, and dry-run sends
 
 ## Install
 
@@ -45,7 +45,7 @@ await email.send({
 
 ## Adapters
 
-Resend, Postmark, SendGrid, Mailgun, Brevo, MailerSend, SparkPost, Mailchimp, Iterable, Loops, Plunk, Mailtrap, Cloudflare, Unosend, Scaleway, ZeptoMail, MailPace, Sequenzy, JetEmail, Primitive, SMTP, and a testing adapter — each imported from its own entry point. New here? Start with `resend` for the fastest first send.
+Resend, Postmark, SendGrid, AWS SES, Mailgun, Brevo, MailerSend, SparkPost, Mailchimp, Iterable, Loops, Plunk, Mailtrap, Cloudflare, Unosend, Scaleway, ZeptoMail, MailPace, Sequenzy, JetEmail, Lettermint, Primitive, SMTP, and a testing adapter, each imported from its own entry point. New here? Start with `resend` for the fastest first send.
 
 ## CLI
 

--- a/apps/fumadocs/content/docs/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs/adapters/brevo.mdx
@@ -4,7 +4,7 @@ description: Send through the Brevo transactional email API with full field supp
 icon: brevo
 ---
 
-The Brevo adapter calls the [Brevo transactional email API](https://developers.brevo.com/reference/sendtransacemail) over `fetch` — no extra dependency. It authenticates with Brevo's `api-key` header (not a Bearer token), supports every common field, and maps `metadata` to Brevo's `params` — the same values Brevo templates substitute.
+The Brevo adapter calls the [Brevo transactional email API](https://developers.brevo.com/reference/sendtransacemail) with plain `fetch`. It authenticates with Brevo's `api-key` header (not a Bearer token), supports every common field, and maps `metadata` to Brevo's `params`, the same values Brevo templates substitute.
 
 <ProviderBadge adapter="brevo" />
 
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Brevo maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata` (as `params`). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request.
+Brevo maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata` (as `params`). `replyTo` accepts a single address; two or more throw an `EmailValidationError` before any request.
 
 ```ts
 const result = await email.send({
@@ -58,7 +58,7 @@ const result = await email.send({
 console.log(result.id); // Brevo messageId, also exposed as result.messageId
 ```
 
-The response `id` is Brevo's `messageId` (falling back to `id`) — match it against events in Brevo's logs and webhooks.
+The response `id` is Brevo's `messageId` (falling back to `id`). Match it against events in Brevo's logs and webhooks.
 
 <Callout type="warn" title="Metadata becomes template params">
   `metadata` is sent as Brevo `params`, the values Brevo substitutes into templates. If you use
@@ -82,4 +82,4 @@ BREVO_API_KEY="xkeysib-..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — that is the only check that proves the key, sender verification, and recipient policy are ready.
+Drop `--dry-run` for one real send to confirm the key, sender verification, and recipient policy end to end.

--- a/apps/fumadocs/content/docs/adapters/cloudflare.mdx
+++ b/apps/fumadocs/content/docs/adapters/cloudflare.mdx
@@ -4,7 +4,7 @@ description: Send through Cloudflare's Email Sending REST API with plain-address
 icon: cloudflare
 ---
 
-The Cloudflare adapter calls Cloudflare's Email Sending REST API over `fetch` — no extra dependency and no Worker binding required. It is the natural pick when your sending domain already lives in Cloudflare; the trade-off is strict recipient rules: plain addresses only, 50 recipients max.
+The Cloudflare adapter calls Cloudflare's Email Sending REST API with plain `fetch`, so no Worker binding is required. It is the natural pick when your sending domain already lives in Cloudflare. The trade-off is strict recipient rules: plain addresses only, 50 recipients max.
 
 <ProviderBadge adapter="cloudflare" />
 
@@ -52,7 +52,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Cloudflare maps `cc`, `bcc`, one `replyTo`, `headers`, and `attachments` — no tags or metadata.
+Cloudflare maps `cc`, `bcc`, one `replyTo`, `headers`, and `attachments`. There are no tags or metadata.
 
 ```ts
 const result = await email.send({
@@ -70,7 +70,7 @@ console.log(result.accepted); // delivered + queued recipients
 Cloudflare does not return a message id; instead `result.accepted` lists delivered and queued recipients and `result.rejected` lists permanent bounces. Total recipients across `to`, `cc`, and `bcc` are capped at 50.
 
 <Callout type="warn" title="Plain recipient addresses only">
-  `to`, `cc`, and `bcc` must be bare addresses like `"user@example.com"` — a display name throws an
+  `to`, `cc`, and `bcc` must be bare addresses like `"user@example.com"`; a display name throws an
   `EmailValidationError` before any request is made. Only `from` and `replyTo` keep display names.
 </Callout>
 
@@ -92,4 +92,4 @@ npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — only Cloudflare can prove the domain and account are cleared to deliver.
+Drop `--dry-run` for one real send; only Cloudflare can prove the domain and account are cleared to deliver.

--- a/apps/fumadocs/content/docs/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs/adapters/field-support.mdx
@@ -1,10 +1,10 @@
 ---
 title: Field support
-description: Which EmailMessage fields each adapter maps — and which it rejects before the request.
+description: Which EmailMessage fields each adapter maps, and which it rejects before the request.
 icon: Table
 ---
 
-Email SDK keeps one message shape, but provider APIs do not expose the same features. Every adapter either **maps** a field or **rejects** it with an `EmailValidationError` before calling the provider — never a silent drop. This page is the authoritative matrix.
+Email SDK keeps one message shape, but provider APIs do not expose the same features. Every adapter either **maps** a field or **rejects** it with an `EmailValidationError` before calling the provider. There is no silent drop. This page is the authoritative matrix.
 
 **Reading the tables:** `Yes` = mapped, `No` = rejected before the request, `Values` = each tag's value is sent, `One tag` = the provider API represents a single tag and a second one fails fast.
 
@@ -18,7 +18,7 @@ The best fit when your app needs CC, BCC, reply-to, custom headers, tags, metada
 | Postmark                | Yes | Yes | Yes      | Yes     | Yes      | One tag | Yes         |
 | SendGrid                | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
 | Cloudflare              | Yes | Yes | Yes      | Yes     | No       | No      | Yes         |
-| Unosend                 | Yes | Yes | Yes      | Yes     | No       | Values  | Yes         |
+| Unosend                 | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         |
 | AWS SES                 | Yes | Yes | Yes      | Yes     | No       | Yes     | Yes         |
 | Mailgun                 | Yes | Yes | Yes      | Yes     | Yes      | Values  | Yes         |
 | MailerSend              | Yes | Yes | Yes      | Yes     | No       | Values  | Yes         |
@@ -34,7 +34,7 @@ Useful services whose public APIs cover less of the `EmailMessage` shape. The SD
 
 | Adapter   | CC  | BCC | Reply-To | Headers | Metadata | Tags   | Attachments |
 | --------- | --- | --- | -------- | ------- | -------- | ------ | ----------- |
-| SparkPost | No  | No  | Yes      | Yes     | Yes      | Values | Yes         |
+| SparkPost | No  | No  | Yes      | Yes     | Yes      | Yes    | Yes         |
 | Iterable  | No  | No  | No       | No      | Yes      | No     | No          |
 | Loops     | No  | No  | No       | No      | Yes      | No     | Yes         |
 | Primitive | No  | No  | No       | No      | No       | No     | Yes         |
@@ -58,7 +58,7 @@ A [fallback route](/docs/concepts/fallbacks-and-retries) is only safe when the b
 
 | Your messages use…                    | Compatible route examples                          |
 | ------------------------------------- | -------------------------------------------------- |
-| Addresses, subject, body, headers     | Almost anything — Resend + SMTP works              |
+| Addresses, subject, body, headers     | Almost anything; Resend + SMTP works               |
 | Attachments                           | Resend, Postmark, SendGrid, Mailgun, MailerSend…   |
 | Metadata for analytics or routing     | Postmark, SendGrid, Mailgun, Brevo, Mailtrap       |
 | Tags and metadata together            | SendGrid, Mailgun, Brevo, Mailtrap                 |
@@ -81,7 +81,7 @@ await email.send({
 });
 ```
 
-The same client with `tags` or `metadata` on the message would fail fast on the SMTP route instead of dropping those fields — which is exactly the point.
+The same client with `tags` or `metadata` on the message would fail fast on the SMTP route instead of dropping those fields. That failure is the feature: you find out about the incompatible route in development, not by discovering missing analytics data in the provider dashboard weeks later.
 
 Before adding a backup route, run through this checklist:
 
@@ -123,7 +123,7 @@ attachments: [{ filename: "receipt.pdf", path: "./receipt.pdf", contentType: "ap
   <Accordion title="Sequenzy — reserved metadata keys and one body field">
     Metadata maps to transactional `variables`, except reserved keys that map to provider fields:
     `sequenzySlug` (template slug), `sequenzyPreview`, and `subscriberExternalId` /
-    `sequenzySubscriberExternalId`. Sequenzy also has a single body field — when a message has both
+    `sequenzySubscriberExternalId`. Sequenzy also has a single body field: when a message has both
     `html` and `text`, the HTML body is sent and the text body stays available for other routes.
   </Accordion>
   <Accordion title="Iterable — template sends, one recipient">

--- a/apps/fumadocs/content/docs/adapters/index.mdx
+++ b/apps/fumadocs/content/docs/adapters/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Adapters
-description: 22 provider adapters and transports, each with explicit field support and fail-fast validation.
+description: 23 provider adapters and transports, each with explicit field support and fail-fast validation.
 icon: Cable
 ---
 
-Email SDK ships 22 adapters. Each is its own entry point — import only what you send through — and each follows the same contract: map the fields the provider supports, throw a validation error for fields it cannot represent. Nothing is silently dropped.
+Email SDK ships 23 adapters. Each is its own entry point, so you import only what you send through, and each follows the same contract: map the fields the provider supports, throw a validation error for fields it cannot represent. Nothing is silently dropped.
 
 <SponsorSpotlight />
 
@@ -18,10 +18,10 @@ Email SDK ships 22 adapters. Each is its own entry point — import only what yo
 | Mature transactional delivery controls  | Postmark, SendGrid, AWS SES, Mailgun, Unosend, or Brevo                      |
 | A backup route for production delivery  | A primary API adapter plus Postmark or SMTP                                  |
 | Product-triggered or template emails    | Iterable, Sequenzy, Loops, or Plunk                                          |
-| A cheap or self-managed transport       | SMTP (built in — no Nodemailer)                                              |
+| A cheap or self-managed transport       | SMTP (built in, no Nodemailer)                                               |
 | Heavy attachment use                    | Resend, Postmark, SendGrid, Mailgun, Unosend, MailerSend, Mailtrap, Sequenzy |
 
-Whatever you pick, choose fallback routes by [field support](/docs/adapters/field-support), not popularity — a fallback only helps if it can carry the same message.
+Whatever you pick, choose fallback routes by [field support](/docs/adapters/field-support), not popularity. A fallback only helps if it can carry the same message.
 
 ## One pattern for every provider
 
@@ -62,15 +62,15 @@ RESEND_API_KEY="re_..." npx email-sdk send \
 
 <Accordions type="single">
   <Accordion title="What the provider card labels mean">
-    - **Official** — the adapter ships in `@opencoredev/email-sdk`.
-    - **API tested** — a local check has successfully called the live provider API with a real key.
+    - **Official**: the adapter ships in `@opencoredev/email-sdk`.
+    - **API tested**: a local check has successfully called the live provider API with a real key.
       It does not prove delivery unless the adapter page says a send was performed.
-    - **Not API tested** — no live provider API check has been run yet.
-    - **Request tested** — repository tests cover request mapping, responses, and fail-fast
+    - **Not API tested**: no live provider API check has been run yet.
+    - **Request tested**: repository tests cover request mapping, responses, and fail-fast
       validation with injected fetch calls.
-    - **Built-in transport** — sends through Email SDK's own transport implementation instead of a
+    - **Built-in transport**: sends through Email SDK's own transport implementation instead of a
       provider HTTP API.
-    - **No provider API** — the adapter does not call a hosted provider API.
+    - **No provider API**: the adapter does not call a hosted provider API.
 
     Email SDK can catch unsupported fields before a request. It cannot make a provider account
     ready to send from an unverified domain.
@@ -80,7 +80,7 @@ RESEND_API_KEY="re_..." npx email-sdk send \
 
 ## Missing a provider?
 
-Don't fork the official package — wrap the provider in the [adapter contract](/docs/reference/adapter-contract) and publish it as a community package.
+Don't fork the official package. Wrap the provider in the [adapter contract](/docs/reference/adapter-contract) and publish it as a community package instead.
 
 <Cards>
   <Card

--- a/apps/fumadocs/content/docs/adapters/iterable.mdx
+++ b/apps/fumadocs/content/docs/adapters/iterable.mdx
@@ -4,7 +4,7 @@ description: Trigger an Iterable campaign template for one recipient, with messa
 icon: iterable
 ---
 
-The Iterable adapter calls [Iterable's target email API](https://api.iterable.com/api/docs) over `fetch` — no extra dependency. Instead of sending raw content, it triggers an existing campaign template for exactly one recipient and hands your message to the template as `dataFields`.
+The Iterable adapter calls [Iterable's target email API](https://api.iterable.com/api/docs) with plain `fetch`. It works differently from most adapters: instead of sending raw content, it triggers an existing campaign template for exactly one recipient and hands your message to the template as `dataFields`.
 
 <ProviderBadge adapter="iterable" />
 
@@ -45,11 +45,11 @@ export const email = createEmailClient({
     },
     dataFields: {
       description:
-        "Extra template fields — a static object or a function of the message. Merged in before the normalized fields, so subject/html/text/from win on conflicts.",
+        "Extra template fields, as a static object or a function of the message. Merged in before the normalized fields, so subject/html/text/from win on conflicts.",
       type: "Record<string, unknown> | (message) => Record<string, unknown>",
     },
     sendAt: {
-      description: "Schedule the send — UTC timestamp in Iterable's expected format.",
+      description: "Schedule the send. UTC timestamp in Iterable's expected format.",
       type: "string",
     },
     baseUrl: {
@@ -77,12 +77,12 @@ const result = await email.send({
   metadata: { userId: "user_123" },
 });
 
-console.log(result.raw); // Iterable returns no message id — inspect the raw response
+console.log(result.raw); // Iterable returns no message id; inspect the raw response
 ```
 
 <Callout type="warn" title="One recipient, template-only fields">
   Iterable target sends accept exactly one `to` recipient and no `cc`, `bcc`, `replyTo`, `headers`,
-  `attachments`, or `tags` — any of those throw an `EmailValidationError` before a request is made.
+  `attachments`, or `tags`. Any of those throw an `EmailValidationError` before a request is made.
   Check [field support](/docs/adapters/field-support) before routing fallbacks through Iterable.
 </Callout>
 

--- a/apps/fumadocs/content/docs/adapters/jetemail.mdx
+++ b/apps/fumadocs/content/docs/adapters/jetemail.mdx
@@ -1,10 +1,10 @@
 ---
 title: JetEmail
-description: Send through the JetEmail transactional API over fetch — CC, BCC, reply-to, custom headers, and base64 attachments, with idempotent retries.
+description: Send through the JetEmail transactional API with CC, BCC, reply-to, custom headers, base64 attachments, and idempotent retries.
 icon: jetemail
 ---
 
-The JetEmail adapter calls JetEmail's transactional `POST /email` endpoint over `fetch` — no extra dependency. JetEmail runs its own sending infrastructure (anycast IPs, managed reputation), and the adapter maps the normalized `EmailMessage` straight onto its REST payload.
+The JetEmail adapter calls JetEmail's transactional `POST /email` endpoint with plain `fetch`. JetEmail runs its own sending infrastructure (anycast IPs, managed reputation), and the adapter maps the normalized `EmailMessage` straight onto its REST payload.
 
 <ProviderBadge adapter="jetemail" />
 
@@ -63,7 +63,7 @@ console.log(result.id); // JetEmail message id, e.g. "19424fd2acd0004210"
 ```
 
 <Callout type="warn" title="From requires a display name">
-  JetEmail rejects a bare email in `from` — it requires the `"Name <email>"` form. The adapter
+  JetEmail rejects a bare email in `from`; it requires the `"Name <email>"` form. The adapter
   fails fast with an `EmailValidationError` when `from` has no display name, so pass
   `from: "Acme <hello@acme.com>"` or `from: { email: "hello@acme.com", name: "Acme" }`.
 </Callout>
@@ -98,4 +98,4 @@ JETEMAIL_API_KEY="transactional_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send — the only check that proves the API key and sender domain are ready.
+Drop `--dry-run` for one real smoke send to prove the API key and sender domain against the live API.

--- a/apps/fumadocs/content/docs/adapters/jetemail.mdx
+++ b/apps/fumadocs/content/docs/adapters/jetemail.mdx
@@ -98,4 +98,4 @@ JETEMAIL_API_KEY="transactional_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send to prove the API key and sender domain against the live API.
+Drop `--dry-run` to send for real. The dry run already enforces JetEmail's local rules (the display-name requirement on `from`, the 50-address caps), so what a live send actually tests is the `transactional_` key and whether your sending domain is verified on JetEmail's side.

--- a/apps/fumadocs/content/docs/adapters/lettermint.mdx
+++ b/apps/fumadocs/content/docs/adapters/lettermint.mdx
@@ -110,4 +110,4 @@ LETTERMINT_API_TOKEN="lm_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send to prove the API token and sending domain against the live API.
+Drop `--dry-run` to send for real. Route resolution only happens on Lettermint's end, so this doubles as your route check: a live send with `LETTERMINT_ROUTE` set proves that slug exists, and one without it proves your project's default route works.

--- a/apps/fumadocs/content/docs/adapters/lettermint.mdx
+++ b/apps/fumadocs/content/docs/adapters/lettermint.mdx
@@ -1,10 +1,10 @@
 ---
 title: Lettermint
-description: Send through Lettermint's European transactional email API over fetch — CC, BCC, reply-to, headers, metadata, tags, and base64 attachments, with idempotent retries and routes.
+description: Send through Lettermint's European transactional email API with CC, BCC, reply-to, headers, metadata, tags, base64 attachments, idempotent retries, and routes.
 icon: lettermint
 ---
 
-The Lettermint adapter calls Lettermint's `POST /v1/send` endpoint over `fetch` — no extra dependency. [Lettermint](https://lettermint.co/?ref=emailsdk) is a European transactional email service with a REST API, SMTP relay, routes, and built-in open/click tracking. The adapter maps the normalized `EmailMessage` straight onto its send payload and authenticates with the `x-lettermint-token` header.
+The Lettermint adapter calls Lettermint's `POST /v1/send` endpoint with plain `fetch`. [Lettermint](https://lettermint.co/?ref=emailsdk) is a European transactional email service with a REST API, SMTP relay, routes, and built-in open/click tracking. The adapter maps the normalized `EmailMessage` straight onto its send payload and authenticates with the `x-lettermint-token` header.
 
 <ProviderBadge adapter="lettermint" />
 
@@ -71,8 +71,9 @@ console.log(result.id); // Lettermint message_id
 </Callout>
 
 <Callout title="From a verified sending domain">
-  The sender domain in `from` must be verified for your Lettermint project, and a single message may
-  not exceed 50 recipients across `to`, `cc`, and `bcc` combined.
+  The sender domain in `from` must be verified for your Lettermint project. Lettermint also caps a
+  message at 50 recipients across `to`, `cc`, and `bcc` combined; the adapter does not pre-check
+  this, so an oversized send fails at the API.
 </Callout>
 
 ## Idempotent sends
@@ -109,4 +110,4 @@ LETTERMINT_API_TOKEN="lm_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send — the only check that proves the API token and sending domain are ready.
+Drop `--dry-run` for one real smoke send to prove the API token and sending domain against the live API.

--- a/apps/fumadocs/content/docs/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs/adapters/loops.mdx
@@ -4,7 +4,7 @@ description: Trigger a published Loops transactional email for one recipient, wi
 icon: loops
 ---
 
-The Loops adapter calls the [Loops transactional API](https://loops.so/docs/api-reference/send-transactional-email) over `fetch` — no extra dependency. It triggers a published transactional email by `transactionalId` for exactly one recipient and hands your message to the template as `dataVariables`.
+The Loops adapter calls the [Loops transactional API](https://loops.so/docs/api-reference/send-transactional-email) with plain `fetch`. It triggers a published transactional email by `transactionalId` for exactly one recipient and hands your message to the template as `dataVariables`.
 
 <ProviderBadge adapter="loops" />
 
@@ -34,7 +34,7 @@ export const email = createEmailClient({
       required: true,
     },
     transactionalId: {
-      description: "Published transactional email to render. Must be non-empty — the adapter throws at construction otherwise.",
+      description: "Published transactional email to render. Must be non-empty; the adapter throws at construction otherwise.",
       type: "string",
       required: true,
     },
@@ -52,7 +52,7 @@ export const email = createEmailClient({
 
 ## Send
 
-The Loops template renders the email. The adapter merges `subject`, `html`, `text`, `from`, and every `metadata` key into `dataVariables` — your template decides which of them appear. Exactly one `to` recipient is allowed per send.
+The Loops template renders the email. The adapter merges `subject`, `html`, `text`, `from`, and every `metadata` key into `dataVariables`; your template decides which of them appear. Exactly one `to` recipient is allowed per send.
 
 ```ts
 const result = await email.send({
@@ -72,8 +72,8 @@ console.log(result.id); // Loops id (or transactionalId) from the response
 Attachments are supported and sent as `{ filename, contentType, data }` with base64-encoded content.
 
 <Callout type="warn" title="Attachments need account enablement">
-  Loops only accepts transactional attachments on accounts where the capability has been enabled —
-  without it, sends with attachments fail at the API. Also note `cc`, `bcc`, `replyTo`, `headers`,
+  Loops only accepts transactional attachments on accounts where the capability has been enabled.
+  Without it, sends with attachments fail at the API. Also note `cc`, `bcc`, `replyTo`, `headers`,
   and `tags` throw an `EmailValidationError` before any request; see
   [field support](/docs/adapters/field-support).
 </Callout>

--- a/apps/fumadocs/content/docs/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailchimp.mdx
@@ -1,10 +1,10 @@
 ---
 title: Mailchimp Transactional
-description: Send through Mailchimp Transactional (Mandrill) with typed recipients, tags, and metadata — but no replyTo field.
+description: Send through Mailchimp Transactional (Mandrill) with typed recipients, tags, and metadata, but no replyTo field.
 icon: mailchimp
 ---
 
-The Mailchimp adapter calls the [Mailchimp Transactional API](https://mailchimp.com/developer/transactional/api/messages/send-new-message/) — the API formerly known as Mandrill — over `fetch`, no extra dependency. Unusually, the API key travels in the request body rather than a header, and recipients are a single typed list (`to`/`cc`/`bcc` entries) instead of separate arrays.
+The Mailchimp adapter calls the [Mailchimp Transactional API](https://mailchimp.com/developer/transactional/api/messages/send-new-message/), the API formerly known as Mandrill, with plain `fetch`. Unusually, the API key travels in the request body rather than a header, and recipients are a single typed list (`to`/`cc`/`bcc` entries) instead of separate arrays.
 
 <ProviderBadge adapter="mailchimp" />
 
@@ -57,10 +57,10 @@ const result = await email.send({
 console.log(result.id); // Mandrill _id of the first recipient result
 ```
 
-Mandrill responds with one result per recipient; the normalized `id` and `messageId` come from the first result's `_id`. Each result also carries a per-recipient status (`sent`, `queued`, `rejected`) — check `result.raw` during smoke tests if a send succeeds but mail does not arrive.
+Mandrill responds with one result per recipient; the normalized `id` and `messageId` come from the first result's `_id`. Each result also carries a per-recipient status (`sent`, `queued`, `rejected`). If a send succeeds but mail does not arrive, check `result.raw` during smoke tests, because a `rejected` status still counts as a successful API call.
 
 <Callout type="warn" title="No replyTo field">
-  This adapter does not support `replyTo` — setting it throws an `EmailValidationError` before
+  This adapter does not support `replyTo`; setting it throws an `EmailValidationError` before
   any request is made. Set a `Reply-To` header instead: `headers: { "Reply-To":
   "support@acme.com" }`. See [field support](/docs/adapters/field-support) for the full matrix.
 </Callout>
@@ -81,4 +81,4 @@ MAILCHIMP_API_KEY="md-..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — that is the only check that proves the key, domain verification, and recipient policy are ready.
+Drop `--dry-run` for one real send and check the per-recipient status in the output; Mandrill can accept the request and still reject the recipient.

--- a/apps/fumadocs/content/docs/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailersend.mdx
@@ -4,7 +4,7 @@ description: Send through the MailerSend Email API with cc/bcc, headers, tags, a
 icon: mailersend
 ---
 
-The MailerSend adapter calls the [MailerSend Email API](https://developers.mailersend.com/api/v1/email.html) over `fetch` — no extra dependency. Its quirk: MailerSend accepts exactly one reply-to address, and the message id comes back in the `x-message-id` response header rather than the body.
+The MailerSend adapter calls the [MailerSend Email API](https://developers.mailersend.com/api/v1/email.html) with plain `fetch`. Two quirks to know: MailerSend accepts exactly one reply-to address, and the message id comes back in the `x-message-id` response header rather than the body.
 
 <ProviderBadge adapter="mailersend" />
 
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-MailerSend maps `cc`, `bcc`, `headers`, `attachments` (an attachment's `contentId` becomes MailerSend's `id`), and `tags` (values only). `replyTo` accepts a single address — two or more throw an `EmailValidationError` before any request.
+MailerSend maps `cc`, `bcc`, `headers`, `attachments` (an attachment's `contentId` becomes MailerSend's `id`), and `tags` (values only). `replyTo` accepts a single address; two or more throw an `EmailValidationError` before any request.
 
 ```ts
 const result = await email.send({
@@ -57,7 +57,7 @@ const result = await email.send({
 console.log(result.id); // MailerSend message id from the x-message-id header
 ```
 
-The response `id` comes from the `x-message-id` response header, falling back to `message_id` or `id` in the body — use it to look the send up in MailerSend's activity log.
+The response `id` comes from the `x-message-id` response header, falling back to `message_id` or `id` in the body. Use it to look the send up in MailerSend's activity log.
 
 <Callout type="warn" title="No metadata field">
   MailerSend has no metadata concept, so `metadata` on a message throws an
@@ -82,4 +82,4 @@ MAILERSEND_API_KEY="mlsn..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — that is the only check that proves the token, domain verification, and plan limits are ready.
+Drop `--dry-run` for one real send. The token, domain verification, and plan limits only prove themselves against the live API.

--- a/apps/fumadocs/content/docs/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailgun.mdx
@@ -4,13 +4,13 @@ description: "Send through the Mailgun Messages API with domain-scoped multipart
 icon: mailgun
 ---
 
-The Mailgun adapter calls the [Mailgun Messages API](https://documentation.mailgun.com/docs/mailgun/api-reference/openapi-final/tag/Messages/) over `fetch` — no extra dependency. It is the one adapter that posts multipart form data instead of JSON, using Mailgun's prefixed field names: `h:` for headers, `v:` for metadata variables, `o:` for sending options. Every send is scoped to the `domain` you configure.
+The Mailgun adapter calls the [Mailgun Messages API](https://documentation.mailgun.com/docs/mailgun/api-reference/openapi-final/tag/Messages/) with plain `fetch`. It is the one adapter that posts multipart form data instead of JSON, using Mailgun's prefixed field names: `h:` for headers, `v:` for metadata variables, `o:` for sending options. Every send is scoped to the `domain` you configure.
 
 <ProviderBadge adapter="mailgun" />
 
 ## Configure
 
-Grab an API key from the [Mailgun dashboard](https://app.mailgun.com/settings/api_security) and note the sending domain it belongs to — both are required.
+Grab an API key from the [Mailgun dashboard](https://app.mailgun.com/settings/api_security) and note the sending domain it belongs to. Both are required.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -73,7 +73,7 @@ const result = await email.send({
 console.log(result.id); // Mailgun message id, also exposed as result.messageId
 ```
 
-The response `id` is Mailgun's queued message id from the response body — match it against delivery events in webhooks or the Mailgun logs.
+The response `id` is Mailgun's queued message id from the response body. Match it against delivery events in webhooks or the Mailgun logs.
 
 ## Verify from the CLI
 
@@ -93,4 +93,4 @@ MAILGUN_API_KEY="key-..." npx email-sdk send \
   --dry-run
 ```
 
-Credentials also work as flags: `--api-key`, `--domain`, and `--base-url` (or `MAILGUN_BASE_URL`) override the environment. Drop `--dry-run` for one real send — that is the only check that proves the domain's DNS and the account are ready.
+Credentials also work as flags: `--api-key`, `--domain`, and `--base-url` (or `MAILGUN_BASE_URL`) override the environment. Drop `--dry-run` for one real send to prove the domain's DNS records and the account are actually ready.

--- a/apps/fumadocs/content/docs/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailpace.mdx
@@ -1,10 +1,10 @@
 ---
 title: MailPace
-description: Send through the MailPace API — a deliberately minimal adapter for address fields and body content.
+description: Send through the MailPace API, a deliberately minimal adapter for address fields and body content.
 icon: mailpace
 ---
 
-The MailPace adapter calls the [MailPace send API](https://docs.mailpace.com/reference/send) over `fetch` — no extra dependency. It is the smallest adapter surface in the SDK: addresses, subject, and body only, with recipient lists serialized as comma-separated strings.
+The MailPace adapter calls the [MailPace send API](https://docs.mailpace.com/reference/send) with plain `fetch`. It has the smallest adapter surface in the SDK: addresses, subject, and body only, with recipient lists serialized as comma-separated strings.
 
 <ProviderBadge adapter="mailpace" />
 
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-MailPace maps `cc`, `bcc`, and `replyTo` alongside `html`/`text` (sent as `htmlbody`/`textbody`). That is the whole surface — a good fit for sign-in alerts, receipts, and other plain notifications.
+MailPace maps `cc`, `bcc`, and `replyTo` alongside `html`/`text` (sent as `htmlbody`/`textbody`). That is the whole surface, which makes it a good fit for sign-in alerts, receipts, and other plain notifications.
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs/adapters/mailtrap.mdx
@@ -4,7 +4,7 @@ description: Send through the Mailtrap Email Sending API with full field support
 icon: mailtrap
 ---
 
-The Mailtrap adapter calls the [Mailtrap Email Sending API](https://api-docs.mailtrap.io/) over `fetch` — no extra dependency. It supports every common transactional field, and Mailtrap's inspection tooling makes it a natural pick for staging environments.
+The Mailtrap adapter calls the [Mailtrap Email Sending API](https://api-docs.mailtrap.io/) with plain `fetch`. It supports every common transactional field, and Mailtrap's inspection tooling makes it a natural pick for staging environments.
 
 <ProviderBadge adapter="mailtrap" />
 
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Mailtrap maps `cc`, `bcc`, `headers`, `attachments`, `metadata`, and `tags` — with two limits: at most one tag (its value becomes the Mailtrap `category`) and at most one `replyTo`. `metadata` is sent as `custom_variables` with values stringified (`null` becomes `""`).
+Mailtrap maps `cc`, `bcc`, `headers`, `attachments`, `metadata`, and `tags`, with two limits: at most one tag (its value becomes the Mailtrap `category`) and at most one `replyTo`. `metadata` is sent as `custom_variables` with values stringified (`null` becomes `""`).
 
 ```ts
 const result = await email.send({
@@ -51,7 +51,7 @@ const result = await email.send({
   cc: "billing@acme.com",
   replyTo: "support@acme.com",
   subject: "Your receipt for order ord_123",
-  html: "<p>Thanks for your order — receipt attached.</p>",
+  html: "<p>Thanks for your order. Receipt attached.</p>",
   tags: [{ name: "type", value: "receipt" }],
   metadata: { orderId: "ord_123" },
   attachments: [
@@ -84,4 +84,4 @@ MAILTRAP_API_KEY="..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send — and confirm the token targets the intended Mailtrap project before pointing production at it.
+Drop `--dry-run` for one real smoke send, and confirm the token targets the intended Mailtrap project before pointing production at it.

--- a/apps/fumadocs/content/docs/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs/adapters/plunk.mdx
@@ -4,7 +4,7 @@ description: Send through the Plunk API with reply-to, headers, attachments, and
 icon: plunk
 ---
 
-The Plunk adapter calls the [Plunk send API](https://docs.useplunk.com) over `fetch` — no extra dependency. Plunk takes a single `body` field, so the adapter sends `html` when present and falls back to `text`.
+The Plunk adapter calls the [Plunk send API](https://docs.useplunk.com) with plain `fetch`. Plunk takes a single `body` field, so the adapter sends `html` when present and falls back to `text`.
 
 <ProviderBadge adapter="plunk" />
 
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Plunk supports `headers`, `attachments`, `metadata` (sent as Plunk `data`), and a single `replyTo` (sent as `reply`, email address only — a second reply-to throws an `EmailValidationError`).
+Plunk supports `headers`, `attachments`, `metadata` (sent as Plunk `data`), and a single `replyTo` (sent as `reply`, email address only; a second reply-to throws an `EmailValidationError`).
 
 ```ts
 const result = await email.send({

--- a/apps/fumadocs/content/docs/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs/adapters/postmark.mdx
@@ -4,7 +4,7 @@ description: Send through the Postmark Email API with message streams, metadata,
 icon: postmark
 ---
 
-The Postmark adapter calls the [Postmark Email API](https://postmarkapp.com/developer/api/email-api) over `fetch` — no extra dependency. Its distinctive feature is message streams: set `messageStream` once and every send routes through that Postmark stream.
+The Postmark adapter calls the [Postmark Email API](https://postmarkapp.com/developer/api/email-api) with plain `fetch`. Its distinctive feature is message streams: set `messageStream` once and every send routes through that Postmark stream.
 
 <ProviderBadge adapter="postmark" />
 
@@ -96,4 +96,4 @@ POSTMARK_SERVER_TOKEN="..." npx email-sdk send \
   --dry-run
 ```
 
-The token also accepts the `--server-token` flag. Drop `--dry-run` for one real send — that is the only check that proves the server token, sender signature, and message stream are ready.
+The token also accepts the `--server-token` flag. Drop `--dry-run` for one real send to confirm the server token, sender signature, and message stream actually work together.

--- a/apps/fumadocs/content/docs/adapters/primitive.mdx
+++ b/apps/fumadocs/content/docs/adapters/primitive.mdx
@@ -101,4 +101,4 @@ PRIMITIVE_API_KEY="prim_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send to prove the API key and outbound domain against the live API.
+Drop `--dry-run` to send for real. The single-recipient rule is checked locally, so the live send is really testing your `prim_` key and outbound domain. Check `accepted` and `rejected` in the response: Primitive queues delivery asynchronously, and those arrays tell you what it actually took.

--- a/apps/fumadocs/content/docs/adapters/primitive.mdx
+++ b/apps/fumadocs/content/docs/adapters/primitive.mdx
@@ -1,10 +1,10 @@
 ---
 title: Primitive
-description: Send through Primitive's email API for AI agents over fetch — base64 attachments and idempotent retries, with fail-fast validation for fields it cannot represent.
+description: Send through Primitive's email API for AI agents, with base64 attachments, idempotent retries, and fail-fast validation for fields it cannot represent.
 icon: primitive
 ---
 
-The Primitive adapter calls Primitive's `POST /v1/send-mail` endpoint over `fetch` — no extra dependency. [Primitive](https://www.primitive.dev) is email infrastructure for AI agents: a REST API for sending and receiving mail, with idempotency, typed errors, and an async delivery model. The adapter maps the normalized `EmailMessage` straight onto its send payload.
+The Primitive adapter calls Primitive's `POST /v1/send-mail` endpoint with plain `fetch`. [Primitive](https://www.primitive.dev) is email infrastructure for AI agents: a REST API for sending and receiving mail, with idempotency, typed errors, and an async delivery model. The adapter maps the normalized `EmailMessage` straight onto its send payload.
 
 <ProviderBadge adapter="primitive" />
 
@@ -101,4 +101,4 @@ PRIMITIVE_API_KEY="prim_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send — the only check that proves the API key and sender domain are ready.
+Drop `--dry-run` for one real smoke send to prove the API key and outbound domain against the live API.

--- a/apps/fumadocs/content/docs/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs/adapters/resend.mdx
@@ -4,7 +4,7 @@ description: Send through the Resend API with attachments, tags, and native idem
 icon: resend
 ---
 
-The Resend adapter calls the [Resend Email API](https://resend.com/docs/api-reference/emails/send-email) over `fetch` — no extra dependency. It is the default first adapter in these docs: short setup, broad field support, and it is the only adapter that forwards [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys) to the provider natively.
+The Resend adapter calls the [Resend Email API](https://resend.com/docs/api-reference/emails/send-email) with plain `fetch`. It is the default first adapter in these docs: setup is one API key, field support is broad, and it forwards [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys) to the provider as the `Idempotency-Key` header, so Resend itself deduplicates retried sends.
 
 <ProviderBadge adapter="resend" />
 
@@ -91,4 +91,4 @@ RESEND_API_KEY="re_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` to perform one real send from the environment that will send production email — that is the only check that proves the account, sender domain, and recipient policy are ready.
+Drop `--dry-run` to perform one real send from the environment that will send production email. Local validation cannot tell you whether the account, sender domain, and recipient policy are actually ready; one live send can.

--- a/apps/fumadocs/content/docs/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs/adapters/scaleway.mdx
@@ -4,7 +4,7 @@ description: Send through Scaleway Transactional Email with region-scoped endpoi
 icon: scaleway
 ---
 
-The Scaleway adapter calls the [Scaleway Transactional Email API](https://www.scaleway.com/en/developers/api/transactional-email/) over `fetch` — no extra dependency. Sends are region-scoped: the adapter targets `/regions/{region}/emails` and defaults to `fr-par`.
+The Scaleway adapter calls the [Scaleway Transactional Email API](https://www.scaleway.com/en/developers/api/transactional-email/) with plain `fetch`. Sends are region-scoped: the adapter targets `/regions/{region}/emails` and defaults to `fr-par`.
 
 <ProviderBadge adapter="scaleway" />
 
@@ -67,14 +67,14 @@ const result = await email.send({
   subject: "Your May invoice",
   html: "<p>Invoice INV-2041 is attached.</p>",
   attachments: [
-    { filename: "invoice.txt", content: "Invoice INV-2041 — 49.00 EUR", contentType: "text/plain" },
+    { filename: "invoice.txt", content: "Invoice INV-2041: 49.00 EUR", contentType: "text/plain" },
   ],
 });
 
 console.log(result.id); // Scaleway email id (`id` or `email_id` in the response)
 ```
 
-`replyTo` travels as a `Reply-To` entry in Scaleway's `additional_headers`. Setting both `replyTo` and a manual `Reply-To` header throws an `EmailValidationError` before any request — pick one.
+`replyTo` travels as a `Reply-To` entry in Scaleway's `additional_headers`. Setting both `replyTo` and a manual `Reply-To` header throws an `EmailValidationError` before any request, so pick one.
 
 <Callout type="warn" title="No tags or metadata">
   Scaleway has no tag or metadata concept, so either field throws an `EmailValidationError` before

--- a/apps/fumadocs/content/docs/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs/adapters/sendgrid.mdx
@@ -4,7 +4,7 @@ description: Send through the Twilio SendGrid Mail Send API with the fullest fie
 icon: sendgrid
 ---
 
-The SendGrid adapter calls the [Twilio SendGrid Mail Send API](https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send) over `fetch` — no extra dependency. It supports every `EmailMessage` field: recipients land in a `personalizations` entry, `metadata` becomes `custom_args`, and tags become `categories`.
+The SendGrid adapter calls the [Twilio SendGrid Mail Send API](https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send) with plain `fetch`. It supports every `EmailMessage` field: recipients land in a `personalizations` entry, `metadata` becomes `custom_args`, and tags become `categories`.
 
 <ProviderBadge adapter="sendgrid" />
 
@@ -76,4 +76,4 @@ SENDGRID_API_KEY="SG...." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — account review and sender verification can block delivery even when the payload validates, and only a live send proves they are done.
+Drop `--dry-run` for one real send. SendGrid account review and sender verification can block delivery even when the payload validates, and only a live send proves they are done.

--- a/apps/fumadocs/content/docs/adapters/sequenzy.mdx
+++ b/apps/fumadocs/content/docs/adapters/sequenzy.mdx
@@ -101,4 +101,4 @@ SEQUENZY_API_KEY="seq_live_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send to prove the API key and sender verification against the live API.
+Drop `--dry-run` to send for real. Sequenzy queues sends as jobs, so success comes back as a `jobId` rather than a message id. If you use template slugs, add `--metadata "sequenzySlug=..."` to the live send, since the slug lookup only happens on Sequenzy's servers.

--- a/apps/fumadocs/content/docs/adapters/sequenzy.mdx
+++ b/apps/fumadocs/content/docs/adapters/sequenzy.mdx
@@ -4,7 +4,7 @@ description: Send through the Sequenzy transactional API with metadata variables
 icon: sequenzy
 ---
 
-The Sequenzy adapter calls Sequenzy's transactional send endpoint over `fetch` — no extra dependency. Its distinctive feature: reserved `metadata` keys switch a send from direct content to a Sequenzy template slug, so the same message shape covers both modes.
+The Sequenzy adapter calls Sequenzy's transactional send endpoint with plain `fetch`. Its distinctive feature: reserved `metadata` keys switch a send from direct content to a Sequenzy template slug, so the same message shape covers both modes.
 
 <ProviderBadge adapter="sequenzy" />
 
@@ -42,7 +42,7 @@ export const email = createEmailClient({
 
 ## Send
 
-Sequenzy accepts up to 50 recipients and one `replyTo` per message. Flat `metadata` values become Sequenzy `variables`. Sequenzy has a single `body` field, so when a message carries both `html` and `text`, the adapter sends `html` — omit `html` to send plain text.
+Sequenzy accepts up to 50 recipients and one `replyTo` per message. Flat `metadata` values become Sequenzy `variables`. Sequenzy has a single `body` field, so when a message carries both `html` and `text`, the adapter sends `html`. Omit `html` to send plain text.
 
 ```ts
 const result = await email.send({
@@ -81,7 +81,7 @@ await email.send({
 
 <Callout type="warn" title="No cc, bcc, headers, or tags">
   Sequenzy rejects `cc`, `bcc`, `headers`, and `tags` with an `EmailValidationError` before any
-  request — as it does for more than 50 recipients or more than one `replyTo`. Check
+  request, as it does for more than 50 recipients or more than one `replyTo`. Check
   [field support](/docs/adapters/field-support) before using Sequenzy in a fallback route.
 </Callout>
 
@@ -101,4 +101,4 @@ SEQUENZY_API_KEY="seq_live_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real smoke send — the only check that proves the API key and sender verification are ready.
+Drop `--dry-run` for one real smoke send to prove the API key and sender verification against the live API.

--- a/apps/fumadocs/content/docs/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs/adapters/ses.mdx
@@ -1,10 +1,10 @@
 ---
 title: AWS SES
-description: Send through the SES v2 SendEmail API with built-in SigV4 signing — no AWS SDK dependency.
+description: Send through the SES v2 SendEmail API with built-in SigV4 signing and no AWS SDK dependency.
 icon: Cloud
 ---
 
-The SES adapter calls the [SES v2 SendEmail API](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html) over `fetch` and signs every request with AWS Signature V4 itself — your bundle never pulls in the AWS SDK. Pick a region, optionally a configuration set, and send.
+The SES adapter calls the [SES v2 SendEmail API](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html) with plain `fetch` and implements AWS Signature V4 signing itself, so your bundle does not pull in the AWS SDK. Pick a region, optionally a configuration set, and send.
 
 <ProviderBadge adapter="ses" />
 
@@ -112,4 +112,4 @@ npx email-sdk send \
   --dry-run
 ```
 
-`--session-token` and `--configuration-set` flags are also available. Drop `--dry-run` for one real send — that is the only check that proves the identity is verified and the account is out of the sandbox.
+`--session-token` and `--configuration-set` flags are also available. Drop `--dry-run` for one real send. It is the only way to prove the identity is verified and the account is out of the SES sandbox.

--- a/apps/fumadocs/content/docs/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs/adapters/smtp.mdx
@@ -1,10 +1,10 @@
 ---
 title: SMTP
-description: Send over raw SMTP with the built-in TCP/TLS transport — no Nodemailer, no HTTP API.
+description: Send over raw SMTP with the built-in TCP/TLS transport. No Nodemailer, no HTTP API.
 icon: smtp
 ---
 
-The SMTP adapter speaks the SMTP protocol directly over Node/Bun TCP and TLS sockets — no Nodemailer, no HTTP, no dependency. Point it at PurelyMail, a self-hosted server, or any provider's SMTP endpoint, and register it more than once under different names for multiple routes.
+The SMTP adapter speaks the SMTP protocol directly over Node/Bun TCP and TLS sockets. There is no Nodemailer and no HTTP API in the path. Point it at PurelyMail, a self-hosted server, or any provider's SMTP endpoint, and register it more than once under different names for multiple routes.
 
 <ProviderBadge adapter="smtp" />
 
@@ -71,7 +71,7 @@ export const email = createEmailClient({
       type: "{ replyTo?: string }",
     },
     name: {
-      description: "Adapter name override — register several SMTP servers side by side.",
+      description: "Adapter name override, for registering several SMTP servers side by side.",
       type: "string",
       default: '"smtp"',
     },
@@ -90,11 +90,11 @@ export const email = createEmailClient({
 
 ### TLS and auth semantics
 
-With `secure: true` the whole session is TLS. Otherwise the adapter connects in plaintext and upgrades with `STARTTLS` before authenticating whenever `requireTLS` is set or `auth` is present — credentials never travel unencrypted. Authenticating against a server that cannot do TLS requires an explicit `allowInsecureAuth: true`; without it the adapter throws instead of sending the password in the clear.
+With `secure: true` the whole session is TLS. Otherwise the adapter connects in plaintext and upgrades with `STARTTLS` before authenticating whenever `requireTLS` is set or `auth` is present, so credentials do not travel unencrypted. Authenticating against a server that cannot do TLS requires an explicit `allowInsecureAuth: true`; without it the adapter throws instead of sending the password in the clear.
 
 ## Send
 
-SMTP maps `cc`, `bcc`, `replyTo`, and `headers`. When a message has both `html` and `text`, the adapter builds a `multipart/alternative` MIME body. The generated `Message-ID` header is `<{idempotencyKey}@email-sdk.local>` when the message has an `idempotencyKey` (a random UUID otherwise), and an explicit `Message-ID` in `headers` overrides it — set one yourself if you need a specific domain for threading or deduplication.
+SMTP maps `cc`, `bcc`, `replyTo`, and `headers`. When a message has both `html` and `text`, the adapter builds a `multipart/alternative` MIME body. The generated `Message-ID` header is `<{idempotencyKey}@email-sdk.local>` when the message has an `idempotencyKey`, and a random UUID otherwise. An explicit `Message-ID` in `headers` overrides it; set one yourself if you need a specific domain for threading or deduplication.
 
 ```ts
 const result = await email.send({
@@ -111,11 +111,11 @@ console.log(result.accepted); // every recipient the server accepted
 console.log(result.id); // parsed from the server's "queued as ..." reply, else the idempotency key
 ```
 
-`rejected` is always empty — a refused recipient fails the SMTP conversation instead, and every transport error surfaces as a retryable `EmailProviderError`, so SMTP plays well with [retries and fallbacks](/docs/concepts/fallbacks-and-retries).
+`rejected` is always empty, because a refused recipient fails the SMTP conversation instead. Every transport error surfaces as a retryable `EmailProviderError`, so SMTP plays well with [retries and fallbacks](/docs/concepts/fallbacks-and-retries).
 
 <Callout type="warn" title="No attachments, tags, or metadata">
   The built-in transport does not build attachment MIME parts, and SMTP has no tag or metadata
-  concept — any of these fields throws an `EmailValidationError` before connecting. See the
+  concept. Any of these fields throws an `EmailValidationError` before connecting. See the
   [field support matrix](/docs/adapters/field-support).
 </Callout>
 
@@ -165,4 +165,4 @@ npx email-sdk send \
   --dry-run
 ```
 
-Each flag falls back to its env var: `--host`/`SMTP_HOST`, `--port`/`SMTP_PORT` (default 587), `--secure`/`SMTP_SECURE`, `--require-tls`/`SMTP_REQUIRE_TLS`, `--allow-insecure-auth`/`SMTP_ALLOW_INSECURE_AUTH`, `--user`/`SMTP_USER`, `--pass`/`SMTP_PASS`. Drop `--dry-run` for one real send — the only check that proves the host, TLS mode, and credentials actually deliver.
+Each flag falls back to its env var: `--host`/`SMTP_HOST`, `--port`/`SMTP_PORT` (default 587), `--secure`/`SMTP_SECURE`, `--require-tls`/`SMTP_REQUIRE_TLS`, `--allow-insecure-auth`/`SMTP_ALLOW_INSECURE_AUTH`, `--user`/`SMTP_USER`, `--pass`/`SMTP_PASS`. Drop `--dry-run` for one real send to prove the host, TLS mode, and credentials actually deliver.

--- a/apps/fumadocs/content/docs/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs/adapters/sparkpost.mdx
@@ -4,13 +4,13 @@ description: Send through the SparkPost Transmissions API with metadata, substit
 icon: sparkpost
 ---
 
-The SparkPost adapter calls the [SparkPost Transmissions API](https://developers.sparkpost.com/api/transmissions/) over `fetch` — no extra dependency. Two things set it apart: a `sandbox` option that routes sends through SparkPost's shared sandbox domain for testing, and tags become SparkPost `substitution_data` as `name: value` pairs instead of a flat list.
+The SparkPost adapter calls the [SparkPost Transmissions API](https://developers.sparkpost.com/api/transmissions/) with plain `fetch`. Two things set it apart: a `sandbox` option that routes sends through SparkPost's shared sandbox domain for testing, and tags become SparkPost `substitution_data` as `name: value` pairs instead of a flat list.
 
 <ProviderBadge adapter="sparkpost" />
 
 ## Configure
 
-Create an API key with Transmissions permission in the [SparkPost dashboard](https://app.sparkpost.com/account/api-keys). SparkPost expects the raw key in the `Authorization` header — the adapter sends it without a `Bearer` prefix.
+Create an API key with Transmissions permission in the [SparkPost dashboard](https://app.sparkpost.com/account/api-keys). SparkPost expects the raw key in the `Authorization` header, so the adapter sends it without a `Bearer` prefix.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -62,7 +62,7 @@ const result = await email.send({
 console.log(result.id); // SparkPost transmission id
 ```
 
-The response `id` is the transmission id from `results.id` (or `results.transmission_id`) — use it to query SparkPost's events API for delivery status.
+The response `id` is the transmission id from `results.id` (or `results.transmission_id`). Use it to query SparkPost's events API for delivery status.
 
 <Callout type="warn" title="No cc or bcc">
   This adapter sends one flat recipient list, so `cc` or `bcc` on a message throws an
@@ -86,4 +86,4 @@ SPARKPOST_API_KEY="..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — that is the only check that proves the key, sending domain, and recipient policy are ready.
+Drop `--dry-run` for one real send, or set `sandbox: true` in code first to exercise the API through SparkPost's shared sandbox domain before touching your own.

--- a/apps/fumadocs/content/docs/adapters/unosend.mdx
+++ b/apps/fumadocs/content/docs/adapters/unosend.mdx
@@ -81,4 +81,4 @@ UNOSEND_API_KEY="un_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send to prove the API key and sending domain against the live API.
+Drop `--dry-run` to send for real. Unosend has no extra credentials to get wrong, so a live send that prints an `id` means the key and the verified domain were the whole story. If it fails, the CLI surfaces Unosend's own error message from the response body.

--- a/apps/fumadocs/content/docs/adapters/unosend.mdx
+++ b/apps/fumadocs/content/docs/adapters/unosend.mdx
@@ -1,10 +1,10 @@
 ---
 title: Unosend
-description: Send through the Unosend REST API — a single Bearer-authenticated endpoint with CC, BCC, tags, and attachments.
+description: Send through the Unosend REST API, a single Bearer-authenticated endpoint with CC, BCC, tags, and attachments.
 icon: unosend
 ---
 
-The Unosend adapter calls the Unosend REST API over `fetch` — no extra dependency. It is one of the simplest providers to wire up: one Bearer-authenticated `/emails` endpoint, one API key, no other configuration.
+The Unosend adapter calls the Unosend REST API with plain `fetch`. It is one of the simplest providers to wire up: one Bearer-authenticated `/emails` endpoint, one API key, no other configuration.
 
 <ProviderBadge adapter="unosend" />
 
@@ -61,7 +61,7 @@ The adapter checks `success` in the response body and throws an `EmailProviderEr
 
 <Callout type="warn" title="No metadata, one reply-to">
   Unosend has no metadata field and accepts only one `replyTo` address. A message with `metadata`
-  or multiple reply-to addresses throws an `EmailValidationError` before any request is made — use
+  or multiple reply-to addresses throws an `EmailValidationError` before any request is made. Use
   `tags`, or pick a [metadata-capable adapter](/docs/adapters/field-support).
 </Callout>
 
@@ -81,4 +81,4 @@ UNOSEND_API_KEY="un_..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — that is the only check that proves the API key and sending domain are ready.
+Drop `--dry-run` for one real send to prove the API key and sending domain against the live API.

--- a/apps/fumadocs/content/docs/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs/adapters/zeptomail.mdx
@@ -4,7 +4,7 @@ description: Send through Zoho ZeptoMail with automatic send-mail token prefixin
 icon: zeptomail
 ---
 
-The ZeptoMail adapter calls the [Zoho ZeptoMail email API](https://www.zoho.com/zeptomail/help/api/email-sending.html) over `fetch` — no extra dependency. Paste your send mail token as-is: the adapter prepends Zoho's `Zoho-enczapikey ` authorization prefix automatically when it is missing.
+The ZeptoMail adapter calls the [Zoho ZeptoMail email API](https://www.zoho.com/zeptomail/help/api/email-sending.html) with plain `fetch`. Paste your send mail token as-is: the adapter prepends Zoho's `Zoho-enczapikey ` authorization prefix automatically when it is missing.
 
 <ProviderBadge adapter="zeptomail" />
 
@@ -80,4 +80,4 @@ ZEPTOMAIL_TOKEN="..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send — that is the check that proves the token, Mail Agent, and sender domain are ready.
+Drop `--dry-run` for one real send to prove the token, Mail Agent, and sender domain against the live API.

--- a/apps/fumadocs/content/docs/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs/adapters/zeptomail.mdx
@@ -80,4 +80,4 @@ ZEPTOMAIL_TOKEN="..." npx email-sdk send \
   --dry-run
 ```
 
-Drop `--dry-run` for one real send to prove the token, Mail Agent, and sender domain against the live API.
+Drop `--dry-run` to send for real. ZeptoMail scopes each token to one Mail Agent, so a valid token can still fail when the `from` domain is not verified under that agent. Only a live send confirms the token, the agent, and the sender domain all line up.

--- a/apps/fumadocs/content/docs/agents/skill.mdx
+++ b/apps/fumadocs/content/docs/agents/skill.mdx
@@ -18,11 +18,11 @@ Or copy the `skills/email-sdk/` directory into your repo's skills directory (`.c
 
 ### What it enforces
 
-- **Refresh docs first.** The skill is deliberately dynamic: before writing code, the agent reads the installed package's README, `package.json` exports, and TypeScript declarations — so it implements against the version actually installed, not stale training data.
-- **Correct imports and secrets.** Adapters come from their own entry points (`@opencoredev/email-sdk/resend`, `/smtp`, ...), credentials stay in environment variables, and no Nodemailer — the SDK includes its own SMTP transport.
+- **Refresh docs first.** The skill is deliberately dynamic: before writing code, the agent reads the installed package's README, `package.json` exports, and TypeScript declarations, so it implements against the version actually installed instead of stale training data.
+- **Correct imports and secrets.** Adapters come from their own entry points (`@opencoredev/email-sdk/resend`, `/smtp`, ...), credentials stay in environment variables, and no Nodemailer gets added, since the SDK includes its own SMTP transport.
 - **Compatible fallbacks.** Fallback routes only when the backup adapter supports the same fields, checked against [field support](/docs/adapters/field-support). Idempotency keys on externally visible sends that may retry.
 - **CLI smoke tests.** `email-sdk doctor` and `send --dry-run` before any live send, and no real external mail without your approval.
-- **Secret-safe observability.** [Hooks](/docs/concepts/hooks) and the [observability plugin](/docs/plugins/built-in/observability) for redacted events — never API keys, message bodies, or unnecessary recipient data in logs.
+- **Secret-safe observability.** [Hooks](/docs/concepts/hooks) and the [observability plugin](/docs/plugins/built-in/observability) for redacted events, keeping API keys, message bodies, and unnecessary recipient data out of logs.
 - **Narrow validation.** The smallest test or typecheck that covers the send path before declaring the work done.
 
 ### Prompt example
@@ -100,7 +100,7 @@ async function handleToolCall(name: string, input: unknown) {
 }
 ```
 
-`execute` goes through the full client pipeline — validation, [retries and fallbacks](/docs/concepts/fallbacks-and-retries), plugins, hooks — so an agent send behaves exactly like any other send in your app.
+`execute` goes through the full client pipeline (validation, [retries and fallbacks](/docs/concepts/fallbacks-and-retries), plugins, hooks), so an agent send behaves exactly like any other send in your app.
 
 <Callout type="warn" title="Gate agent sends">
   The tool description asks the model to confirm before sending, but the model decides whether to

--- a/apps/fumadocs/content/docs/authentication.mdx
+++ b/apps/fumadocs/content/docs/authentication.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-description: How Email SDK authenticates to every provider — there is no platform account, you supply each provider's own credential from an environment variable.
+description: How Email SDK authenticates to every provider. There is no platform account; you supply each provider's own credential from an environment variable.
 icon: KeyRound
 ---
 
@@ -66,7 +66,7 @@ is issued and lists every configuration field.
 ## SMTP
 
 SMTP is the one adapter that does not take an API key. It connects to a mail server
-with a host, port, and username/password — the SDK ships its own SMTP transport, so
+with a host, port, and username/password. The SDK ships its own SMTP transport, so
 you do **not** add Nodemailer.
 
 ```ts title="lib/email.ts"
@@ -87,16 +87,17 @@ export const email = createEmailClient({
 
 ## Optional configuration
 
-Beyond credentials, every adapter accepts the same optional fields:
+Beyond credentials, the HTTP-based adapters accept two shared optional fields:
 
-- `baseUrl` — override the provider's API origin (for a proxy or region endpoint).
-- `headers` — extra HTTP headers sent with every request.
-- `fetch` — a custom `fetch` implementation for tests or special runtimes.
+- `baseUrl` overrides the provider's API origin, for a proxy or region endpoint.
+- `fetch` injects a custom `fetch` implementation for tests or special runtimes.
+
+A few adapters (Resend, Postmark, JetEmail, Lettermint, Primitive) also take a `headers` option for extra HTTP request headers. SMTP is socket-based and has its own options (`host`, `port`, `secure`, `tls`, and so on) instead of these. Each adapter page lists its exact option set.
 
 ## Multiple providers and fallbacks
 
 Pass several configured adapters to route across them. Only configure a fallback
-between adapters that support the same fields — see
+between adapters that support the same fields; see
 [Field support](/docs/adapters/field-support).
 
 ```ts title="lib/email.ts"
@@ -128,7 +129,7 @@ export const email = createEmailClient({
 
 - Scope each provider key to sending only, where the provider supports it.
 - Rotate or revoke credentials in the provider's own dashboard, then update the
-  environment variable — Email SDK holds no session or token state of its own.
+  environment variable. Email SDK holds no session or token state of its own.
 - Use [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys)
   for externally visible sends that may be retried.
 

--- a/apps/fumadocs/content/docs/authentication.mdx
+++ b/apps/fumadocs/content/docs/authentication.mdx
@@ -114,6 +114,7 @@ export const email = createEmailClient({
       region: process.env.AWS_REGION!,
     }),
   ],
+  fallback: ["ses"],
   retry: { retries: 1 },
 });
 ```

--- a/apps/fumadocs/content/docs/components/convex-email.mdx
+++ b/apps/fumadocs/content/docs/components/convex-email.mdx
@@ -4,7 +4,7 @@ description: Queue email from Convex mutations with durable retries, fallback ad
 icon: Component
 ---
 
-`@opencoredev/convex-email` packages [Email SDK](/docs) as a Convex component. Mutations enqueue email into Convex tables; the component sends it outside the request path with retries and [fallback adapters](/docs/concepts/fallbacks-and-retries), and every send has queryable status and event history.
+`@opencoredev/convex-email` packages [Email SDK](/docs) as a Convex component. Mutations enqueue email into Convex tables, and the component sends it outside the request path with retries and [fallback adapters](/docs/concepts/fallbacks-and-retries). Every send keeps a queryable status and event history.
 
 ```ts
 // In any mutation:
@@ -27,7 +27,7 @@ Use it when email should behave like app state: queued, retried, observable, and
 
 <PackageInstallTabs packageName="@opencoredev/convex-email @opencoredev/email-sdk" />
 
-`@opencoredev/email-sdk` is a peer dependency; the component reuses its adapters and message shape.
+`@opencoredev/email-sdk` is a peer dependency because the component reuses its adapters and message shape.
 
 </Step>
 <Step>
@@ -145,7 +145,7 @@ export const sendWelcomeEmail = mutation({
 
 `send` enqueues the message and returns the email's document id. If an email with the same `idempotencyKey` already exists, the existing id is returned and nothing new is enqueued.
 
-Messages take the standard [EmailMessage fields](/docs/reference/message); per-send args can also override `adapter`, `fallbackAdapters`, `maxAttempts`, `retryBaseMs`, and add `sendMetadata`.
+Messages take the standard [EmailMessage fields](/docs/reference/message). On top of those, per-send args can override `adapter`, `fallbackAdapters`, `maxAttempts`, and `retryBaseMs`, or add `sendMetadata`.
 
 </Step>
 </Steps>
@@ -165,7 +165,7 @@ adapters: [
 
 Override fields follow the credential: `apiKeyEnv`, `serverTokenEnv` (Postmark), `tokenEnv` (ZeptoMail), `domainEnv` (Mailgun), `accountIdEnv` (Cloudflare), `projectIdEnv`/`secretKeyEnv`/`regionEnv` (Scaleway), `accessKeyIdEnv`/`secretAccessKeyEnv` (SES), `hostEnv`/`portEnv`/`userEnv`/`passEnv` (SMTP). Non-serializable Email SDK options (custom `fetch`, SMTP `tls`, function-valued Iterable `dataFields`) are intentionally not part of component config.
 
-`name` sets the routing name used in `defaultAdapter` and `fallbackAdapters`; it defaults to the kind. Pick fallbacks that support the fields you send. [Field support](/docs/adapters/field-support) applies unchanged here.
+`name` sets the routing name used in `defaultAdapter` and `fallbackAdapters`, and defaults to the kind. Pick fallbacks that support the fields you send. [Field support](/docs/adapters/field-support) applies unchanged here.
 
 ## Status and events
 
@@ -267,7 +267,7 @@ await email.setConfig(ctx, {
 
 The fail-before-enqueue rule is deliberate: enabling `testMode` without `sandboxTo` rejects sends instead of guessing, so a misconfigured staging deploy can never email real users.
 
-`exposeApi()` publishes `send`, `sendBatch`, `status`, `listEvents`, and `cancel` as Convex functions. It omits `setConfig`/`getConfig` by default; pass `{ includeConfigApi: true }` only from a module behind your own auth checks.
+`exposeApi()` publishes `send`, `sendBatch`, `status`, `listEvents`, and `cancel` as Convex functions. By default it leaves out `setConfig` and `getConfig`. If you need those, pass `{ includeConfigApi: true }`, and only from a module behind your own auth checks.
 
 ## Webhooks
 
@@ -290,7 +290,7 @@ email.registerRoutes(http, {
 export default http;
 ```
 
-This creates `POST /email/webhooks/resend`. The `verify` callback receives `{ provider, request, body, headers }` and must return `true` to accept; anything else gets a 401.
+This creates `POST /email/webhooks/resend`. The `verify` callback receives `{ provider, request, body, headers }` and must return `true` to accept the delivery. Anything else gets a 401.
 
 <Callout type="warn" title="Always verify in production">
   The route is public on your Convex deployment. Omitting `verify` is for local development only;

--- a/apps/fumadocs/content/docs/components/convex-email.mdx
+++ b/apps/fumadocs/content/docs/components/convex-email.mdx
@@ -16,7 +16,7 @@ const emailId = await email.send(ctx, {
 });
 ```
 
-Use it when email should behave like app state: queued, retried, observable, and portable across the [20 supported providers](/docs/adapters). For a Resend-only app that wants the official integration, use `@convex-dev/resend` instead — this component earns its place when provider portability, fallback routing, status history, or test-safe multi-provider operations matter.
+Use it when email should behave like app state: queued, retried, observable, and portable across the component's [20 supported provider kinds](/docs/adapters). For a Resend-only app that wants the official integration, use `@convex-dev/resend` instead. This component earns its place when provider portability, fallback routing, status history, or test-safe multi-provider operations matter.
 
 ## Setup
 
@@ -27,7 +27,7 @@ Use it when email should behave like app state: queued, retried, observable, and
 
 <PackageInstallTabs packageName="@opencoredev/convex-email @opencoredev/email-sdk" />
 
-`@opencoredev/email-sdk` is a peer dependency — the component reuses its adapters and message shape.
+`@opencoredev/email-sdk` is a peer dependency; the component reuses its adapters and message shape.
 
 </Step>
 <Step>
@@ -154,7 +154,7 @@ Messages take the standard [EmailMessage fields](/docs/reference/message); per-s
 
 Every Email SDK adapter has a config kind, plus `memory` for tests: `resend`, `postmark`, `sendgrid`, `ses`, `smtp`, `brevo`, `cloudflare`, `iterable`, `loops`, `mailchimp`, `mailersend`, `mailgun`, `mailpace`, `mailtrap`, `plunk`, `scaleway`, `sequenzy`, `sparkpost`, `unosend`, `zeptomail`.
 
-Each kind reads its standard env vars by default (`RESEND_API_KEY`, `POSTMARK_SERVER_TOKEN`, `SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/`SMTP_PASS`, ... — the same names the [CLI](/docs/reference/cli) uses). Override the env-var *name* per config when you need several accounts of one provider:
+Each kind reads its standard env vars by default (`RESEND_API_KEY`, `POSTMARK_SERVER_TOKEN`, `SMTP_HOST`/`SMTP_PORT`/`SMTP_USER`/`SMTP_PASS`, the same names the [CLI](/docs/reference/cli) uses). Override the env-var *name* per config when you need several accounts of one provider:
 
 ```ts
 adapters: [
@@ -163,9 +163,9 @@ adapters: [
 ]
 ```
 
-Override fields follow the credential: `apiKeyEnv`, `serverTokenEnv` (Postmark), `tokenEnv` (ZeptoMail), `domainEnv` (Mailgun), `accountIdEnv` (Cloudflare), `projectIdEnv`/`secretKeyEnv`/`regionEnv` (Scaleway), `accessKeyIdEnv`/`secretAccessKeyEnv` (SES), `hostEnv`/`portEnv`/`userEnv`/`passEnv` (SMTP). Non-serializable Email SDK options — custom `fetch`, SMTP `tls`, function-valued Iterable `dataFields` — are intentionally not part of component config.
+Override fields follow the credential: `apiKeyEnv`, `serverTokenEnv` (Postmark), `tokenEnv` (ZeptoMail), `domainEnv` (Mailgun), `accountIdEnv` (Cloudflare), `projectIdEnv`/`secretKeyEnv`/`regionEnv` (Scaleway), `accessKeyIdEnv`/`secretAccessKeyEnv` (SES), `hostEnv`/`portEnv`/`userEnv`/`passEnv` (SMTP). Non-serializable Email SDK options (custom `fetch`, SMTP `tls`, function-valued Iterable `dataFields`) are intentionally not part of component config.
 
-`name` sets the routing name used in `defaultAdapter` and `fallbackAdapters`; it defaults to the kind. Pick fallbacks that support the fields you send — [field support](/docs/adapters/field-support) applies unchanged here.
+`name` sets the routing name used in `defaultAdapter` and `fallbackAdapters`; it defaults to the kind. Pick fallbacks that support the fields you send. [Field support](/docs/adapters/field-support) applies unchanged here.
 
 ## Status and events
 
@@ -216,7 +216,7 @@ const ids = await email.sendBatch(ctx, [
 ]);
 ```
 
-Larger arrays throw before enqueueing anything — split them in your app so Convex mutation limits stay predictable.
+Larger arrays throw before enqueueing anything. Split them in your app so Convex mutation limits stay predictable.
 
 ## Configuration
 
@@ -267,7 +267,7 @@ await email.setConfig(ctx, {
 
 The fail-before-enqueue rule is deliberate: enabling `testMode` without `sandboxTo` rejects sends instead of guessing, so a misconfigured staging deploy can never email real users.
 
-`exposeApi()` publishes `send`, `sendBatch`, `status`, `listEvents`, and `cancel` as Convex functions — it omits `setConfig`/`getConfig` by default. Pass `{ includeConfigApi: true }` only from a module behind your own auth checks.
+`exposeApi()` publishes `send`, `sendBatch`, `status`, `listEvents`, and `cancel` as Convex functions. It omits `setConfig`/`getConfig` by default; pass `{ includeConfigApi: true }` only from a module behind your own auth checks.
 
 ## Webhooks
 
@@ -293,7 +293,7 @@ export default http;
 This creates `POST /email/webhooks/resend`. The `verify` callback receives `{ provider, request, body, headers }` and must return `true` to accept; anything else gets a 401.
 
 <Callout type="warn" title="Always verify in production">
-  The route is public on your Convex deployment. Omitting `verify` is for local development only —
+  The route is public on your Convex deployment. Omitting `verify` is for local development only;
   production routes must check the provider's signature or a shared secret.
 </Callout>
 
@@ -315,9 +315,9 @@ URL fetching is restricted to public HTTPS hosts: `http:`, localhost, internal h
 
 A built-in cron sweeps every 5 minutes:
 
-- **Queue recovery** — processes due emails whose scheduled run was missed.
-- **Stale `processing` recovery** — an email stuck in `processing` past its timeout is retried only if it has an `idempotencyKey`. Without one the component fails it closed, because the provider request may already have delivered.
-- **Cleanup** — when `cleanupAfterDays` is set, prunes expired terminal emails, webhook delivery records, and event history.
+- **Queue recovery** processes due emails whose scheduled run was missed.
+- **Stale `processing` recovery** retries an email stuck in `processing` past its timeout, but only if it has an `idempotencyKey`. Without one the component fails it closed, because the provider request may already have delivered.
+- **Cleanup** prunes expired terminal emails, webhook delivery records, and event history when `cleanupAfterDays` is set.
 
 This is the practical reason to set `idempotencyKey` on transactional sends: it makes recovery safe and deduplicates repeated enqueues.
 
@@ -347,7 +347,7 @@ registerConvexEmail(t); // mounts the component as "convexEmail"
 
 ## Scope
 
-Convex Email Ops is transactional email operations — queueing, retries, fallback routing, idempotency, webhook records, queryable status. It is not a campaign builder, contact database, template editor, analytics dashboard, or inbound processor. Provider accounts still decide whether a send lands: domain verification, sandbox rules, rate limits, and suppression lists live with the provider.
+Convex Email Ops is transactional email operations: queueing, retries, fallback routing, idempotency, webhook records, queryable status. It is not a campaign builder, contact database, template editor, analytics dashboard, or inbound processor. Provider accounts still decide whether a send lands: domain verification, sandbox rules, rate limits, and suppression lists live with the provider.
 
 ## Next
 
@@ -360,7 +360,7 @@ Convex Email Ops is transactional email operations — queueing, retries, fallba
   <Card
     title="Fallbacks and retries"
     href="/docs/concepts/fallbacks-and-retries"
-    description="How Email SDK classifies errors and orders routes — the same model this component queues."
+    description="How Email SDK classifies errors and orders routes, the same model this component queues."
   />
   <Card
     title="All adapters"

--- a/apps/fumadocs/content/docs/concepts/adapter-model.mdx
+++ b/apps/fumadocs/content/docs/concepts/adapter-model.mdx
@@ -4,7 +4,7 @@ description: How adapters register routing names, map messages to provider APIs,
 icon: Plug
 ---
 
-An adapter is a module that knows how to send one normalized `EmailMessage` through one service or transport. The client holds a registry of adapters keyed by routing name; everything else — defaults, fallbacks, per-send overrides — is built on those names.
+An adapter is a module that knows how to send one normalized `EmailMessage` through one service or transport. The client holds a registry of adapters keyed by routing name. Everything else (defaults, fallbacks, per-send overrides) is built on those names.
 
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -16,7 +16,7 @@ const email = createEmailClient({
     resend({ apiKey: process.env.RESEND_API_KEY! }),
     postmark({ serverToken: process.env.POSTMARK_SERVER_TOKEN! }),
   ],
-  // defaultAdapter is optional — it falls back to the first adapter ("resend" here)
+  // defaultAdapter is optional; it falls back to the first adapter ("resend" here)
 });
 ```
 
@@ -27,14 +27,14 @@ Each adapter import is a separate entry point (`@opencoredev/email-sdk/resend`, 
 Every adapter does three things:
 
 1. **Maps** supported `EmailMessage` fields to the provider's API payload.
-2. **Rejects** unsupported fields with an `EmailValidationError` before any request — never silently drops data. See [field support](/docs/adapters/field-support).
+2. **Rejects** unsupported fields with an `EmailValidationError` before any request, instead of silently dropping data. See [field support](/docs/adapters/field-support).
 3. **Normalizes** the result into `{ provider, id?, messageId?, accepted?, rejected?, raw? }` and provider failures into typed [errors](/docs/reference/errors) with retryability info.
 
 The full interface for building your own is in the [adapter contract reference](/docs/reference/adapter-contract).
 
 ## Routing names
 
-Adapter factories register fixed routing names — `resend`, `postmark`, `sendgrid`, `cloudflare`, `unosend`, `ses`, `mailgun`, `mailersend`, `brevo`, `mailchimp`, `sparkpost`, `iterable`, `loops`, `sequenzy`, `plunk`, `mailtrap`, `scaleway`, `zeptomail`, `mailpace`, and `smtp` (the SMTP factory accepts a `name` option for running several SMTP routes side by side).
+Adapter factories register fixed routing names: `resend`, `postmark`, `sendgrid`, `cloudflare`, `unosend`, `ses`, `mailgun`, `mailersend`, `brevo`, `mailchimp`, `sparkpost`, `iterable`, `loops`, `sequenzy`, `jetemail`, `lettermint`, `primitive`, `plunk`, `mailtrap`, `scaleway`, `zeptomail`, `mailpace`, and `smtp`. The SMTP factory also accepts a `name` option for running several SMTP routes side by side.
 
 Those names are what you pass everywhere a route is selected:
 
@@ -50,7 +50,7 @@ const transactional = email.withAdapter("postmark");
 await transactional.send(message);
 ```
 
-Selecting a name that is not registered throws `EmailProviderNotFoundError` — routes are explicit, never guessed.
+Selecting a name that is not registered throws `EmailProviderNotFoundError`. The client never guesses a route.
 
 ## Escape hatches
 
@@ -65,7 +65,7 @@ The [memory test adapter](/docs/guides/test-email-behavior) uses the same hatch 
 
 ## Naming aliases
 
-`adapter` and `provider` mean the same thing throughout the API. `providers`, `defaultProvider`, `fallbackProviders`, `email.provider()`, and `email.withProvider()` are aliases kept for compatibility — new code should prefer the `adapter` spellings.
+`adapter` and `provider` mean the same thing throughout the API. `providers`, `defaultProvider`, `fallbackProviders`, `email.provider()`, and `email.withProvider()` are aliases kept for compatibility. New code should prefer the `adapter` spellings.
 
 ## Next
 

--- a/apps/fumadocs/content/docs/concepts/fallbacks-and-retries.mdx
+++ b/apps/fumadocs/content/docs/concepts/fallbacks-and-retries.mdx
@@ -1,10 +1,10 @@
 ---
 title: Fallbacks and retries
-description: Retry transient provider errors with backoff, then fail over to a compatible backup adapter — two layers, one send call.
+description: Retry transient provider errors with backoff, then fail over to a compatible backup adapter. Two layers, one send call.
 icon: Repeat2
 ---
 
-A failing send gets two distinct layers of recovery. **Retries** re-attempt the *same* adapter when an error looks transient (rate limit, timeout, 5xx). **Fallback** moves to the *next* adapter only after the current one has finally failed. Both are off by default — `retries` is `0` and `fallback` is empty.
+A failing send gets two distinct layers of recovery. **Retries** re-attempt the *same* adapter when an error looks transient (rate limit, timeout, 5xx). **Fallback** moves to the *next* adapter only after the current one has finally failed. Both are off by default: `retries` is `0` and `fallback` is empty.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -33,11 +33,11 @@ resend  attempt 3 → 429               retries exhausted → onError("resend")
 smtp    attempt 1 → accepted          response.provider === "smtp"
 ```
 
-**The retry budget resets for each adapter on the route.** The fallback adapter gets its own `retries: 2`, so the worst case for this client is six provider attempts — size your retry budget with the whole route in mind.
+**The retry budget resets for each adapter on the route.** The fallback adapter gets its own `retries: 2`, so the worst case for this client is six provider attempts. Size the retry budget with the whole route in mind.
 
 <Callout type="warn" title="Fallback routes must be field-compatible">
-  A backup adapter only helps if it supports every `EmailMessage` field your messages actually use
-  — adapters reject unsupported fields instead of silently dropping them, so an incompatible
+  A backup adapter only helps if it supports every `EmailMessage` field your messages actually
+  use. Adapters reject unsupported fields instead of silently dropping them, so an incompatible
   fallback fails too. Pick routes from the [field support matrix](/docs/adapters/field-support).
 </Callout>
 
@@ -77,7 +77,7 @@ The default `shouldRetry` is `isRetryableEmailError`: it retries only errors the
 | HTTP `5xx` | Provider-side failure |
 | Network errors | `ECONNRESET`-style failures, `fetch failed`, timeouts |
 
-Everything else — `401`, `422`, validation errors, bugs in your code — fails immediately. To change the policy, supply your own `shouldRetry` or `delay`:
+Everything else (`401`, `422`, validation errors, bugs in your code) fails immediately. To change the policy, supply your own `shouldRetry` or `delay`:
 
 ```ts
 const email = createEmailClient({
@@ -99,7 +99,7 @@ For each send, the SDK builds a route from the selected adapter followed by the 
 
 The selected adapter comes from the per-send `adapter` option or the client's `defaultAdapter` (the first registered adapter unless you set it). Fallbacks come from the per-send `fallbackAdapters` option or the client-level `fallback` list. A route name that is not registered throws `EmailProviderNotFoundError` when the route reaches it.
 
-Fallback is not limited to retryable errors. Retryability decides whether the *same* adapter gets another attempt; fallback fires on *any* final adapter failure — including a non-retryable `401` on the first attempt.
+Fallback is not limited to retryable errors. Retryability decides whether the *same* adapter gets another attempt; fallback fires on *any* final adapter failure, including a non-retryable `401` on the first attempt.
 
 ## Per-send overrides
 
@@ -149,11 +149,11 @@ await email.send(message, {
 
 The key (from `send` options, falling back to `message.idempotencyKey`) is passed to the adapter on every attempt. What happens next depends on the adapter:
 
-- **Resend** is the only adapter that transmits it natively, as the `Idempotency-Key` HTTP header — the provider itself deduplicates repeated sends.
+- **Resend, JetEmail, Lettermint, and Primitive** transmit it as the `Idempotency-Key` HTTP header, so the provider itself deduplicates repeated sends.
 - **SMTP** uses `message.idempotencyKey` as the `Message-ID` header value, so downstream mail systems can recognize duplicates.
 - Every other adapter ignores it on the wire.
 
-Even where the provider ignores the key, set one anyway: it gives your own pipeline — queues, workers, hook-based logging — a stable identity, so application-level retries and re-enqueues stay safe to deduplicate.
+Even where the provider ignores the key, set one anyway. It gives your own pipeline (queues, workers, hook-based logging) a stable identity, so application-level retries and re-enqueues stay safe to deduplicate.
 
 ## Testing the route
 
@@ -180,7 +180,7 @@ expect(response.provider).toBe("backup");
 expect(backup.raw.sent).toHaveLength(1);
 ```
 
-Test with the same message shape production sends — that is what proves the routes are compatible.
+Test with the same message shape production sends. That is what proves the routes are compatible.
 
 ## Next
 

--- a/apps/fumadocs/content/docs/concepts/hooks.mdx
+++ b/apps/fumadocs/content/docs/concepts/hooks.mdx
@@ -1,10 +1,10 @@
 ---
 title: Hooks
-description: Observe every send attempt — retries, fallback routing, failures — without ever changing the message or the result.
+description: Observe every send attempt (retries, fallback routing, failures) without changing the message or the result.
 icon: Activity
 ---
 
-Hooks are read-only observers of the send pipeline: logs, metrics, traces. They fire for **every adapter attempt**, they cannot change the message, and a throwing hook never breaks a send. To *transform* messages, use [plugin middleware](/docs/plugins/writing-plugins) instead — that distinction is the whole design.
+Hooks are read-only observers of the send pipeline: logs, metrics, traces. They fire for **every adapter attempt**, they cannot change the message, and a throwing hook does not break a send. To *transform* messages, use [plugin middleware](/docs/plugins/writing-plugins) instead. Keeping observation and transformation separate is deliberate: you can add logging anywhere without worrying about breaking delivery.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -32,7 +32,7 @@ const email = createEmailClient({
 await email.send(message, { metadata: { route: "checkout.receipt" } });
 ```
 
-The `metadata` here is send-scope: it flows to every hook event for correlation but is never merged into the message — unlike `message.metadata`, which adapters map to the wire.
+The `metadata` here is send-scope: it flows to every hook event for correlation but is not merged into the message. That makes it different from `message.metadata`, which adapters map to the wire.
 
 ## The four events
 
@@ -66,20 +66,20 @@ Each event adds its own fields:
 | `beforeSend` | Before every attempt, on every adapter | — |
 | `afterSend` | Once, on the attempt that succeeded | `response` (normalized, `provider` always set) |
 | `onRetry` | When the same adapter will be retried, before the backoff sleep | `error`, `nextAttempt`, `delayMs` |
-| `onError` | Once per adapter, after its final failure — before [fallback](/docs/concepts/fallbacks-and-retries) continues | `error` |
+| `onError` | Once per adapter, after its final failure, before [fallback](/docs/concepts/fallbacks-and-retries) continues | `error` |
 
 So a send with `retries: 2` and one fallback adapter can fire `beforeSend` up to six times, `onRetry` up to four, `onError` up to twice, and `afterSend` at most once.
 
 ## Hooks observe, middleware transforms
 
-Hooks are deliberately powerless. When you need to *change* a send — add default headers, stamp idempotency keys, rewrite recipients — that is plugin middleware, a separate mechanism with different rules:
+Hooks are deliberately powerless. When you need to *change* a send (add default headers, stamp idempotency keys, rewrite recipients), that is plugin middleware, a separate mechanism with different rules:
 
 | | Hooks | Plugin middleware `beforeSend` |
 | --- | --- | --- |
 | Registered via | Client `hooks` option or `plugin.hooks` | Plugins only (`plugin.middleware`) |
 | Runs | Per attempt, per adapter | Once per send, before validation and routing |
-| Knows the adapter | Yes (`provider` on every event) | No — it runs before the route is resolved |
-| Can change the send | Never | Yes — returns `{ message?, options? }` |
+| Knows the adapter | Yes (`provider` on every event) | No, it runs before the route is resolved |
+| Can change the send | Never | Yes, by returning `{ message?, options? }` |
 | If it throws | Swallowed, send unaffected | Send fails |
 
 ```ts title="A transform belongs in middleware, not a hook"
@@ -99,7 +99,7 @@ const brandPlugin = {
 
 ## Guarantees
 
-- **Failures are swallowed.** A hook that throws (or rejects) is ignored — observability must never mask a send result. The flip side: never put delivery-critical logic in a hook.
+- **Failures are swallowed.** A hook that throws (or rejects) is ignored, because observability must not mask a send result. The flip side: don't put delivery-critical logic in a hook, since its errors disappear.
 - **Hooks are awaited in order.** Async hooks run sequentially: plugin hooks first, then client hooks. Slow hooks slow down sends, so keep them fast or fire-and-forget internally.
 - **Hooks see the final message.** Middleware transforms run first, so `event.message` is what the adapter actually receives.
 
@@ -107,8 +107,8 @@ const brandPlugin = {
 
 Hand-rolled `console.log` hooks leak recipients and bodies into logs sooner or later. Two built-in plugins cover the common cases:
 
-- [`observabilityPlugin`](/docs/plugins/built-in/observability) emits `email.sent` / `email.retry` / `email.error` events with a redacted message shape — counts and flags, no bodies or recipients. Use it for production logging, metrics, and tracing.
-- [`capturePlugin`](/docs/plugins/built-in/capture) records every hook event to an inspectable store — use it to assert send behavior in [tests](/docs/guides/test-email-behavior).
+- [`observabilityPlugin`](/docs/plugins/built-in/observability) emits `email.sent` / `email.retry` / `email.error` events with a redacted message shape: counts and flags, no bodies or recipients. Use it for production logging, metrics, and tracing.
+- [`capturePlugin`](/docs/plugins/built-in/capture) records every hook event to an inspectable store. Use it to assert send behavior in [tests](/docs/guides/test-email-behavior).
 
 ## Next
 

--- a/apps/fumadocs/content/docs/getting-started/install.mdx
+++ b/apps/fumadocs/content/docs/getting-started/install.mdx
@@ -17,7 +17,7 @@ import { resend } from "@opencoredev/email-sdk/resend";
 
 <Callout type="warn" title="Package name vs. command name">
   The package is `@opencoredev/email-sdk`; the installed binary is `email-sdk`. The unscoped
-  `email-sdk` package on npm is an unrelated project — never `npm install email-sdk`.
+  `email-sdk` package on npm is an unrelated project, so don't `npm install email-sdk`.
 </Callout>
 
 ## Run the CLI
@@ -40,8 +40,8 @@ import { resend } from "@opencoredev/email-sdk/resend";
     bunx --bun --package @opencoredev/email-sdk email-sdk adapters
     ```
 
-    There is no safe no-install form for plain `npx` — the unscoped `email-sdk` package is
-    unrelated — so npm users should install first.
+    There is no safe no-install form for plain `npx`, because the unscoped `email-sdk` package
+    is unrelated. npm users should install first.
 
   </Tab>
 </Tabs>
@@ -61,6 +61,6 @@ RESEND_API_KEY="re_..." npx email-sdk doctor --adapter resend
 
 ## Keep credentials server-side
 
-Provider API keys belong in environment variables (or CLI flags for one-off commands) — never in browser bundles or client-side code. The SDK is a server library by design.
+Provider API keys belong in environment variables, or CLI flags for one-off commands. They have no business in browser bundles or client-side code; the SDK is a server library by design.
 
 Ready to send? Continue with the [quickstart](/docs/getting-started/quickstart).

--- a/apps/fumadocs/content/docs/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs/getting-started/quickstart.mdx
@@ -20,7 +20,7 @@ The SDK and CLI run server-side on Node 20+ and Bun 1.1+. See [Install](/docs/ge
 
 ### Create a client
 
-These docs use Resend first — shortest setup, broad field support. Any [adapter](/docs/adapters) works the same way; only the factory and credentials change.
+These docs use Resend first because it has the shortest setup and broad field support. Any [adapter](/docs/adapters) works the same way; only the factory and credentials change.
 
 Set `RESEND_API_KEY`, then:
 
@@ -46,11 +46,11 @@ const result = await email.send({
   text: "Your account is ready.",
 });
 
-console.log(result.provider); // "resend" — the adapter that handled the send
+console.log(result.provider); // "resend", the adapter that handled the send
 console.log(result.id); // provider message id, when the API returns one
 ```
 
-`send` resolves with a normalized [response](/docs/reference/client#response): `provider` tells you which adapter actually delivered, `id`/`messageId` carry the provider's message id, and `raw` keeps the untouched provider payload.
+`send` resolves with a normalized [response](/docs/reference/client#response). `provider` tells you which adapter actually delivered, `id` and `messageId` carry the provider's message id, and `raw` keeps the untouched provider payload.
 
 </Step>
 <Step>
@@ -80,7 +80,7 @@ npx email-sdk send \
 
 ### Add a fallback route
 
-A second adapter keeps simple transactional email flowing when the primary fails. SMTP is built in (no Nodemailer) and pairs well with API providers for plain text/HTML messages:
+A second adapter keeps simple transactional email flowing when the primary fails. SMTP is built into the SDK (no Nodemailer) and pairs well with API providers for plain text/HTML messages:
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -100,11 +100,11 @@ export const email = createEmailClient({
 });
 ```
 
-Your application code does not change — `email.send(...)` now tries Resend, then SMTP.
+Your application code does not change. `email.send(...)` now tries Resend, then SMTP.
 
 <Callout type="warn" title="Fallbacks must match your message shape">
   A fallback only helps if the backup adapter supports the fields you send. SMTP cannot carry
-  tags, metadata, or attachments — sends using those fields throw instead of silently dropping
+  tags, metadata, or attachments, so sends using those fields throw instead of silently dropping
   data. Check [field support](/docs/adapters/field-support) when picking backup routes.
 </Callout>
 
@@ -127,7 +127,7 @@ Your application code does not change — `email.send(...)` now tries Resend, th
   <Card
     title="All adapters"
     href="/docs/adapters"
-    description="20 providers with per-adapter setup, options, and CLI smoke tests."
+    description="23 providers with per-adapter setup, options, and CLI smoke tests."
   />
   <Card
     title="Test email behavior"

--- a/apps/fumadocs/content/docs/guides/authoring/create-adapter.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/create-adapter.mdx
@@ -1,6 +1,6 @@
 ---
 title: Create an adapter
-description: Implement the EmailProvider contract for a new provider — payload mapping, fail-fast field validation, retryable error mapping, and tests with injected fetch.
+description: Implement the EmailProvider contract for a new provider, covering payload mapping, fail-fast field validation, retryable error mapping, and tests with injected fetch.
 icon: Cable
 ---
 
@@ -55,14 +55,14 @@ export function acmeMail(options: AcmeMailOptions): EmailProvider<{ baseUrl: str
 }
 ```
 
-The response shape is `{ provider, id?, messageId?, accepted?, rejected?, raw? }`. Always set `provider` and keep the untouched API body in `raw`. The `context` also carries `idempotencyKey` and `attempt` — forward the key when the provider supports it (Resend sends it as an `Idempotency-Key` header).
+The response shape is `{ provider, id?, messageId?, accepted?, rejected?, raw? }`. Always set `provider` and keep the untouched API body in `raw`. The `context` also carries `idempotencyKey` and `attempt`. Forward the key when the provider supports it; the Resend, JetEmail, Lettermint, and Primitive adapters all send it as an `Idempotency-Key` header.
 
 </Step>
 <Step>
 
 ### Reject unsupported fields before the request
 
-Acme Mail's API accepts addresses, subject, body, and tags — no headers, attachments, or metadata. Do not drop those fields: throw an `EmailValidationError` listing them, matching the SDK's own adapters. This is what makes the adapter safe to use as a [fallback route](/docs/adapters/field-support).
+Acme Mail's API accepts addresses, subject, body, and tags, but no headers, attachments, or metadata. Do not drop those fields: throw an `EmailValidationError` listing them, matching the SDK's own adapters. This is what makes the adapter safe to use as a [fallback route](/docs/adapters/field-support).
 
 ```ts title="acme-mail.ts"
 import { EmailValidationError } from "@opencoredev/email-sdk";
@@ -88,7 +88,7 @@ function hasEntries(value: object | unknown[] | undefined) {
 }
 ```
 
-Core validation (missing `from`, no recipient, neither `html` nor `text`) already ran before your adapter is called — only check what is specific to your provider.
+Core validation (missing `from`, no recipient, neither `html` nor `text`) already ran before your adapter is called. Only check what is specific to your provider.
 
 </Step>
 <Step>
@@ -130,7 +130,7 @@ function formatList(addresses: EmailMessage["cc"]) {
 
 ### Map errors with retryability
 
-Throw `EmailProviderError` with `status`, the parsed body in `details`, and an honest `retryable` flag. The client's retry loop and `isRetryableEmailError` are driven by that flag — the SDK's adapters treat 408, 409, 425, 429, and 5xx as retryable:
+Throw `EmailProviderError` with `status`, the parsed body in `details`, and an honest `retryable` flag. The client's retry loop and `isRetryableEmailError` are driven by that flag. The SDK's adapters treat 408, 409, 425, 429, and 5xx as retryable:
 
 ```ts title="acme-mail.ts"
 async function toAcmeError(response: Response) {
@@ -150,7 +150,7 @@ async function toAcmeError(response: Response) {
 }
 ```
 
-Network failures thrown by `fetch` need no handling — the client wraps them as retryable provider errors automatically.
+Network failures thrown by `fetch` need no handling; the client wraps them as retryable provider errors automatically.
 
 </Step>
 <Step>
@@ -241,7 +241,7 @@ test("rejects unsupported fields before any request", async () => {
 });
 ```
 
-Run `bun test` — three green tests and zero network calls.
+Run `bun test`: three green tests and zero network calls.
 
 </Step>
 </Steps>
@@ -251,7 +251,7 @@ Run `bun test` — three green tests and zero network calls.
 - One stable adapter `name`; document it as the routing name.
 - `provider`, `id` or `messageId`, and `raw` on every response.
 - `context.signal` forwarded into provider requests; `context.idempotencyKey` forwarded when supported.
-- Unsupported fields throw `EmailValidationError` — never dropped.
+- Unsupported fields throw `EmailValidationError` instead of being dropped.
 - Provider failures throw `EmailProviderError` with `status` and an honest `retryable`.
 - Injected `fetch` accepted and documented.
 

--- a/apps/fumadocs/content/docs/guides/authoring/create-first-plugin.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/create-first-plugin.mdx
@@ -1,10 +1,10 @@
 ---
 title: Create your first plugin
-description: Build an audit-log plugin end to end — middleware that records every send and a typed client extension that exposes the log.
+description: Build an audit-log plugin end to end, with middleware that records every send and a typed client extension that exposes the log.
 icon: PackagePlus
 ---
 
-This guide builds a real plugin from scratch: an audit log that records the outcome of every send and exposes the entries through a typed `email.auditLog` property. Along the way you use the two plugin capabilities that matter most — `middleware` for the send pipeline and `extendClient` for typed client extensions.
+This guide builds a real plugin from scratch: an audit log that records the outcome of every send and exposes the entries through a typed `email.auditLog` property. Along the way you use the two plugin capabilities that matter most, `middleware` for the send pipeline and `extendClient` for typed client extensions.
 
 A plugin is a plain object: `{ id, adapters?, hooks?, middleware?, extendClient? }`. The full lifecycle is in [writing plugins](/docs/plugins/writing-plugins); exact types in the [plugin API](/docs/plugins/api).
 
@@ -13,7 +13,7 @@ A plugin is a plain object: `{ id, adapters?, hooks?, middleware?, extendClient?
 
 ### Define the entry shape and factory
 
-Type the extension first. `EmailPlugin<TExtension>` is generic over what `extendClient` returns — that is what makes `email.auditLog` fully typed later.
+Type the extension first. `EmailPlugin<TExtension>` is generic over what `extendClient` returns, which is what makes `email.auditLog` fully typed later.
 
 ```ts title="audit-log-plugin.ts"
 import type { EmailPlugin } from "@opencoredev/email-sdk";
@@ -41,7 +41,7 @@ export function auditLogPlugin(): EmailPlugin<{ auditLog: AuditLog }> {
 }
 ```
 
-Keep recipients and bodies out of the entry shape — an audit log should answer "did the receipt for order 42 go out, through which route?" without becoming a PII store. Put correlation data in send-scope `metadata` instead.
+Keep recipients and bodies out of the entry shape. An audit log should answer "did the receipt for order 42 go out, through which route?" without becoming a PII store. Put correlation data in send-scope `metadata` instead.
 
 </Step>
 <Step>
@@ -74,14 +74,14 @@ Middleware runs on the send pipeline. `afterSend` fires once per successful deli
     ],
 ```
 
-Exceptions thrown from `afterSend` and `onError` are swallowed — observers can never break a send. If you want a plugin that *blocks* sends (policy checks, allow-lists), throw from middleware `beforeSend`, which runs before validation and may also transform the message.
+Exceptions thrown from `afterSend` and `onError` are swallowed, so observers cannot break a send. If you want a plugin that *blocks* sends (policy checks, allow-lists), throw from middleware `beforeSend`, which runs before validation and may also transform the message.
 
 </Step>
 <Step>
 
 ### Expose the log with extendClient
 
-`extendClient` returns properties merged onto the client. The keys must not collide with built-in client members (`send`, `adapters`, ...) or another plugin's extension — collisions throw an `EmailValidationError` at `createEmailClient` time.
+`extendClient` returns properties merged onto the client. The keys must not collide with built-in client members (`send`, `adapters`, ...) or another plugin's extension; collisions throw an `EmailValidationError` at `createEmailClient` time.
 
 ```ts title="audit-log-plugin.ts"
     extendClient() {
@@ -124,7 +124,7 @@ console.log(email.auditLog.entries);
 // [{ at: ..., status: "sent", provider: "resend", attempt: 1, messageId: "..." }]
 ```
 
-`email.auditLog` is typed — TypeScript infers the intersection of all plugin extensions from the `plugins` array, so `email.auditLog.entries[0]?.status` autocompletes.
+`email.auditLog` is typed. TypeScript infers the intersection of all plugin extensions from the `plugins` array, so `email.auditLog.entries[0]?.status` autocompletes.
 
 </Step>
 <Step>
@@ -180,7 +180,7 @@ test("records failures", async () => {
 - One stable `id` per plugin; make it configurable if users may mount two instances.
 - `middleware.beforeSend` for anything that blocks or transforms; `afterSend`, `onError`, and [hooks](/docs/concepts/hooks) for observation only.
 - Keep `extendClient` surfaces small, and never reuse built-in client member names.
-- Each factory call should own its state — two clients with two `auditLogPlugin()` instances must not share entries.
+- Each factory call should own its state: two clients with two `auditLogPlugin()` instances must not share entries.
 
 ## Next
 

--- a/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/publish-community-adapter.mdx
@@ -4,7 +4,7 @@ description: Ship a third-party provider adapter as its own npm package and list
 icon: BadgeCheck
 ---
 
-This guide takes an adapter you have built — see [Create an adapter](/docs/guides/authoring/create-adapter) — to a published npm package with a listing in the [community registry](/docs/plugins/community). Community adapters stay third-party: you own the package and the provider relationship; the registry makes it discoverable.
+This guide takes an adapter you have built (see [Create an adapter](/docs/guides/authoring/create-adapter)) to a published npm package with a listing in the [community registry](/docs/plugins/community). Community adapters stay third-party: you own the package and the provider relationship; the registry makes it discoverable.
 
 | Surface           | Who owns it                     | Where it lives                                 |
 | ----------------- | ------------------------------- | ---------------------------------------------- |
@@ -12,7 +12,7 @@ This guide takes an adapter you have built — see [Create an adapter](/docs/gui
 | Community adapter | You                             | Your npm package, e.g. `email-sdk-acme-mail`   |
 | Registry listing  | Email SDK docs, by pull request | `apps/fumadocs/content/community/plugins.json` |
 
-Do not add community adapters to the SDK source, CLI, or exports — that path is for providers the project has agreed to maintain as official.
+Do not add community adapters to the SDK source, CLI, or exports. That path is for providers the project has agreed to maintain as official.
 
 <Steps>
 <Step>
@@ -56,7 +56,7 @@ export { acmeMailPlugin } from "./plugin";
 export type { AcmeMailOptions } from "./acme-mail";
 ```
 
-Declare `@opencoredev/email-sdk` as a **peer dependency** — a regular dependency can give apps two copies of the core types, and the registry's CI audit rejects packages without the peer dependency:
+Declare `@opencoredev/email-sdk` as a **peer dependency**. A regular dependency can give apps two copies of the core types, and the registry's CI audit rejects packages without the peer dependency:
 
 ```json title="package.json"
 {
@@ -82,7 +82,7 @@ Keep the package boring: no `preinstall`/`install`/`postinstall` scripts, no bin
 
 ### Document field support in the README
 
-Field support determines whether your adapter is safe as a [fallback route](/docs/adapters/field-support), so the README must state how each `EmailMessage` field behaves — mapped, or rejected with an error:
+Field support determines whether your adapter is safe as a [fallback route](/docs/adapters/field-support), so the README must state how each `EmailMessage` field behaves: mapped, or rejected with an error.
 
 | Field            | Support | Notes                                     |
 | ---------------- | ------- | ----------------------------------------- |
@@ -124,7 +124,7 @@ test("registers the adapter via the plugin", () => {
 
 ### Publish to npm
 
-Publish from your own repository. Enable npm provenance or trusted publishing — it is required if you ever want the listing upgraded to `verified`.
+Publish from your own repository. Enable npm provenance or trusted publishing; it is required if you ever want the listing upgraded to `verified`.
 
 </Step>
 <Step>
@@ -170,7 +170,7 @@ CI runs the same check. For `verified` and `official` entries it additionally au
 | `verified`  | One published version passed the verification audit; requires `verifiedVersion` plus `verification` metadata in the entry. |
 | `official`  | Maintained by OpenCore or shipped in this repository. Not for third-party packages.       |
 
-Verification applies to a single version. After a new release, the entry keeps the old `verifiedVersion` until someone reviews the new one — never mark a listing `verified` ahead of an actual review.
+Verification applies to a single version. After a new release, the entry keeps the old `verifiedVersion` until someone reviews the new one. Never mark a listing `verified` ahead of an actual review.
 
 ## Next
 

--- a/apps/fumadocs/content/docs/guides/authoring/publish-community-plugin.mdx
+++ b/apps/fumadocs/content/docs/guides/authoring/publish-community-plugin.mdx
@@ -4,9 +4,9 @@ description: Package an Email SDK plugin for npm and list it in the community re
 icon: PackageCheck
 ---
 
-This guide publishes a plugin — built in [Create your first plugin](/docs/guides/authoring/create-first-plugin) — as an npm package and lists it in the [community registry](/docs/plugins/community). The registry is a static JSON file in the docs repo; there is no hosted plugin service.
+This guide publishes a plugin (built in [Create your first plugin](/docs/guides/authoring/create-first-plugin)) as an npm package and lists it in the [community registry](/docs/plugins/community). The registry is a static JSON file in the docs repo; there is no hosted plugin service.
 
-If your package adds a new email provider, follow [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) instead — same process, plus field-support documentation.
+If your package adds a new email provider, follow [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) instead. It is the same process plus field-support documentation.
 
 <Steps>
 <Step>
@@ -126,7 +126,7 @@ Publish to npm from your own repository, then add an entry to `apps/fumadocs/con
 }
 ```
 
-Every field except `pluginId` is required; `href` and `repo` must be `https` URLs, and name, package, and plugin id must be unique across the registry. Start with `status: "community"` — `verified` requires a per-version review with `verifiedVersion` and `verification` metadata in the entry.
+Every field except `pluginId` is required; `href` and `repo` must be `https` URLs, and name, package, and plugin id must be unique across the registry. Start with `status: "community"`; `verified` requires a per-version review with `verifiedVersion` and `verification` metadata in the entry.
 
 </Step>
 <Step>

--- a/apps/fumadocs/content/docs/guides/index.mdx
+++ b/apps/fumadocs/content/docs/guides/index.mdx
@@ -17,7 +17,7 @@ Guides walk one task end to end: a goal, the steps, and a verification at the en
   <Card
     title="Test email behavior"
     href="/docs/guides/test-email-behavior"
-    description="Assert sends, fallbacks, and retries in unit tests with the memory adapter and capture plugin — no provider account."
+    description="Assert sends, fallbacks, and retries in unit tests with the memory adapter and capture plugin. No provider account needed."
   />
 </Cards>
 
@@ -42,6 +42,6 @@ Guides walk one task end to end: a goal, the steps, and a verification at the en
   <Card
     title="Publish a community adapter"
     href="/docs/guides/authoring/publish-community-adapter"
-    description="Ship a third-party provider adapter as its own package — naming, field-support docs, and the registry PR."
+    description="Ship a third-party provider adapter as its own package: naming, field-support docs, and the registry PR."
   />
 </Cards>

--- a/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
+++ b/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
@@ -1,12 +1,12 @@
 ---
 title: Production send pipeline
-description: Build one production-ready email client — retries, a compatible fallback route, shared defaults, idempotency keys, observability, tests, and CLI verification.
+description: Build one production-ready email client with retries, a compatible fallback route, shared defaults, idempotency keys, observability, tests, and CLI verification.
 icon: Workflow
 ---
 
 This guide grows one `lib/email.ts` from a single adapter into a production send pipeline: retries on transient failures, a fallback route for outages, org-wide defaults, idempotency keys, secret-safe observability, a test that proves the routing, and CLI checks before the first live send.
 
-It assumes you have finished the [quickstart](/docs/getting-started/quickstart). Every step keeps your application code unchanged — `email.send(...)` stays the only call sites know about.
+It assumes you have finished the [quickstart](/docs/getting-started/quickstart). Every step keeps your application code unchanged; `email.send(...)` stays the only call sites know about.
 
 <Steps>
 <Step>
@@ -38,14 +38,14 @@ export const email = createEmailClient({
 });
 ```
 
-Only [retryable errors](/docs/reference/errors) are retried — HTTP 408, 409, 425, 429, 5xx, and network failures. Validation errors and hard rejections fail immediately. The default backoff is `min(100 * 2^(attempt - 1), 2000)` milliseconds — 100ms doubling per attempt, capped at 2s; see [fallbacks and retries](/docs/concepts/fallbacks-and-retries) for the full retry config, including custom `delay` and `shouldRetry`.
+Only [retryable errors](/docs/reference/errors) are retried: HTTP 408, 409, 425, 429, 5xx, and network failures. Validation errors and hard rejections fail immediately. The default backoff is `min(100 * 2^(attempt - 1), 2000)` milliseconds, doubling from 100ms and capped at 2s. See [fallbacks and retries](/docs/concepts/fallbacks-and-retries) for the full retry config, including custom `delay` and `shouldRetry`.
 
 </Step>
 <Step>
 
 ### Add a compatible fallback route
 
-Retries handle blips; a fallback adapter handles an outage. Pick a backup that supports every field your messages use — check [field support](/docs/adapters/field-support) first. Postmark pairs well with Resend here: both carry CC, BCC, reply-to, headers, attachments, and tags.
+Retries handle blips; a fallback adapter handles an outage. Pick a backup that supports every field your messages use, checking [field support](/docs/adapters/field-support) first. Postmark pairs well with Resend here: both carry CC, BCC, reply-to, headers, attachments, and tags.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -62,7 +62,7 @@ export const email = createEmailClient({
 });
 ```
 
-Each send now tries Resend (with retries), then Postmark (with retries). A send that includes a field the backup rejects — say `metadata` on the Resend side, or a second tag on Postmark — throws an `EmailValidationError` instead of silently dropping data.
+Each send now tries Resend (with retries), then Postmark (with retries). A send that includes a field a route rejects, say `metadata` on the Resend side or a second tag on Postmark, throws an `EmailValidationError` instead of silently dropping data.
 
 </Step>
 <Step>
@@ -91,14 +91,14 @@ export const email = createEmailClient({
 });
 ```
 
-Message values always win: a send that sets its own `replyTo` keeps it. `sendMetadata` attaches context for hooks and observability without touching the message — use it instead of message `metadata` when a route (like Resend) cannot carry provider metadata.
+Message values always win: a send that sets its own `replyTo` keeps it. `sendMetadata` attaches context for hooks and observability without touching the message. Use it instead of message `metadata` when a route (like Resend) cannot carry provider metadata.
 
 </Step>
 <Step>
 
 ### Add idempotency keys to externally visible sends
 
-Retries and fallbacks mean one logical send can become several provider requests. Give every send a user could notice twice — receipts, password resets, invoices — a stable key derived from your domain:
+Retries and fallbacks mean one logical send can become several provider requests. Give every send a user could notice twice (receipts, password resets, invoices) a stable key derived from your domain:
 
 ```ts
 await email.send(
@@ -112,14 +112,14 @@ await email.send(
 );
 ```
 
-The key reaches every adapter attempt through the provider context. Resend enforces it natively via its `Idempotency-Key` header; custom adapters can use it for their own dedupe logic. `defaultsPlugin` can add an `idempotencyKeyPrefix` to namespace keys per environment.
+The key reaches every adapter attempt through the provider context. Resend, JetEmail, Lettermint, and Primitive forward it as an `Idempotency-Key` header so the provider deduplicates; custom adapters can use it for their own dedupe logic. `defaultsPlugin` can add an `idempotencyKeyPrefix` to namespace keys per environment.
 
 </Step>
 <Step>
 
 ### Wire up observability
 
-The [observability plugin](/docs/plugins/built-in/observability) emits `email.sent`, `email.retry`, and `email.error` events with a redacted message — counts, tag names, and the subject, never bodies or recipients. The complete client:
+The [observability plugin](/docs/plugins/built-in/observability) emits `email.sent`, `email.retry`, and `email.error` events with a redacted message: counts, tag names, and the subject, without bodies or recipients. The complete client:
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -153,7 +153,7 @@ export const email = createEmailClient({
 });
 ```
 
-A spike of `email.retry` followed by `email.sent` on `postmark` tells you the fallback route earned its keep. Observer exceptions are swallowed — monitoring can never break a send.
+A spike of `email.retry` followed by `email.sent` on `postmark` tells you the fallback route earned its keep. Observer exceptions are swallowed, so monitoring cannot break a send.
 
 </Step>
 <Step>
@@ -193,7 +193,7 @@ test("falls back to the backup route when the primary fails", async () => {
 });
 ```
 
-Run it with `bun test`. Use the message shape production actually sends — that is what catches a fallback route that cannot carry one of your fields.
+Run it with `bun test`. Use the message shape production actually sends; that is what catches a fallback route that cannot carry one of your fields.
 
 </Step>
 <Step>
@@ -217,7 +217,7 @@ npx email-sdk send \
   --dry-run
 ```
 
-`--dry-run` validates message shape and adapter field support without a provider request. Drop the flag — once per route, from the environment that will send production email — for the only check that proves the account, sender domain, and recipient policy are ready.
+`--dry-run` validates message shape and adapter field support without a provider request. Then drop the flag once per route, from the environment that will send production email. That live send is the only check that proves the account, sender domain, and recipient policy are ready.
 
 </Step>
 </Steps>

--- a/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
+++ b/apps/fumadocs/content/docs/guides/production-send-pipeline.mdx
@@ -6,14 +6,14 @@ icon: Workflow
 
 This guide grows one `lib/email.ts` from a single adapter into a production send pipeline: retries on transient failures, a fallback route for outages, org-wide defaults, idempotency keys, secret-safe observability, a test that proves the routing, and CLI checks before the first live send.
 
-It assumes you have finished the [quickstart](/docs/getting-started/quickstart). Every step keeps your application code unchanged; `email.send(...)` stays the only call sites know about.
+It assumes you have finished the [quickstart](/docs/getting-started/quickstart). None of the steps touch your application code, since `email.send(...)` stays the only call sites know about.
 
 <Steps>
 <Step>
 
 ### Start with the primary adapter
 
-One shared client, one adapter. These docs use Resend; any [adapter](/docs/adapters) slots in the same way.
+One shared client, one adapter. These docs use Resend, but any [adapter](/docs/adapters) slots in the same way.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -45,7 +45,7 @@ Only [retryable errors](/docs/reference/errors) are retried: HTTP 408, 409, 425,
 
 ### Add a compatible fallback route
 
-Retries handle blips; a fallback adapter handles an outage. Pick a backup that supports every field your messages use, checking [field support](/docs/adapters/field-support) first. Postmark pairs well with Resend here: both carry CC, BCC, reply-to, headers, attachments, and tags.
+Retries cover blips. For a real outage you want a fallback adapter. Pick a backup that supports every field your messages use, checking [field support](/docs/adapters/field-support) first. Postmark pairs well with Resend here: both carry CC, BCC, reply-to, headers, attachments, and tags.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -112,7 +112,7 @@ await email.send(
 );
 ```
 
-The key reaches every adapter attempt through the provider context. Resend, JetEmail, Lettermint, and Primitive forward it as an `Idempotency-Key` header so the provider deduplicates; custom adapters can use it for their own dedupe logic. `defaultsPlugin` can add an `idempotencyKeyPrefix` to namespace keys per environment.
+The key reaches every adapter attempt through the provider context. Resend, JetEmail, Lettermint, and Primitive forward it as an `Idempotency-Key` header so the provider deduplicates. Custom adapters get the same key and can build their own dedupe logic on it. `defaultsPlugin` can add an `idempotencyKeyPrefix` to namespace keys per environment.
 
 </Step>
 <Step>
@@ -193,7 +193,7 @@ test("falls back to the backup route when the primary fails", async () => {
 });
 ```
 
-Run it with `bun test`. Use the message shape production actually sends; that is what catches a fallback route that cannot carry one of your fields.
+Run it with `bun test`. Use the message shape production actually sends, because that is what catches a fallback route that cannot carry one of your fields.
 
 </Step>
 <Step>

--- a/apps/fumadocs/content/docs/guides/test-email-behavior.mdx
+++ b/apps/fumadocs/content/docs/guides/test-email-behavior.mdx
@@ -1,10 +1,10 @@
 ---
 title: Test email behavior
-description: Assert sends, fallback routing, and retries in unit tests with the memory adapter, failing adapter, and capture plugin — no provider account needed.
+description: Assert sends, fallback routing, and retries in unit tests with the memory adapter, failing adapter, and capture plugin. No provider account needed.
 icon: FlaskConical
 ---
 
-This guide tests email behavior without network calls: prove a send happened with the right fields, prove the fallback route engages when the primary fails, and prove retries fire. Everything runs in plain unit tests — the examples use `bun:test`, but any runner works.
+This guide tests email behavior without network calls: prove a send happened with the right fields, prove the fallback route engages when the primary fails, and prove retries fire. Everything runs in plain unit tests. The examples use `bun:test`, but any runner works.
 
 Two tools cover it all, both free of provider credentials:
 
@@ -40,7 +40,7 @@ test("sends the welcome email", async () => {
 });
 ```
 
-This also catches plugin transforms — mount a [defaults plugin](/docs/plugins/built-in/defaults) on the test client and assert the merged headers or reply-to landed on `message`.
+This also catches plugin transforms. Mount a [defaults plugin](/docs/plugins/built-in/defaults) on the test client and assert the merged headers or reply-to landed on `message`.
 
 </Step>
 <Step>
@@ -80,7 +80,7 @@ Use the same message fields production sends. A backup adapter that cannot carry
 
 ### Assert retry events with the capture plugin
 
-The capture plugin extends the client with `email.capture.events`. To see a `retry` event, you need an adapter that fails with a retryable error and then succeeds — a five-line inline adapter does it:
+The capture plugin extends the client with `email.capture.events`. To see a `retry` event, you need an adapter that fails with a retryable error and then succeeds. A short inline adapter does it:
 
 ```ts title="retry.test.ts"
 import { expect, test } from "bun:test";
@@ -127,7 +127,7 @@ test("retries once on a transient failure", async () => {
 });
 ```
 
-`delay: () => 0` keeps the backoff out of your test runtime. `failingProvider` throws a plain `Error` (not retryable), so it tests fallback, not retries — retry tests need an error with `retryable: true`.
+`delay: () => 0` keeps the backoff out of your test runtime. `failingProvider` throws a plain `Error` (not retryable), so it tests fallback, not retries. Retry tests need an error with `retryable: true`.
 
 </Step>
 <Step>
@@ -168,7 +168,7 @@ const email = createEmailClient({
 bun test
 ```
 
-No environment variables, no network. If a test makes a real HTTP call, an adapter slipped in — test clients should only register `memoryProvider`, `failingProvider`, or inline test adapters.
+No environment variables, no network. If a test makes a real HTTP call, an adapter slipped in; test clients should only register `memoryProvider`, `failingProvider`, or inline test adapters.
 
 </Step>
 </Steps>

--- a/apps/fumadocs/content/docs/index.mdx
+++ b/apps/fumadocs/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Email SDK
-description: One typed send() for 20 email providers — explicit routing, retries, fallbacks, and zero dependencies.
+description: One typed send() for 23 email providers, with explicit routing, retries, and fallbacks. Zero runtime dependencies.
 icon: Mail
 ---
 
-Email SDK is a zero-dependency TypeScript library for transactional email. You write one typed message; configured adapters decide how it reaches Resend, Postmark, SendGrid, AWS SES, Mailgun, SMTP, or any of [20 providers](/docs/adapters). Switching providers — or surviving an outage with a fallback route — never touches your application code.
+Email SDK is a zero-dependency TypeScript library for transactional email. You write one typed message, and the adapters you configured decide how it reaches Resend, Postmark, SendGrid, AWS SES, Mailgun, SMTP, or any of [23 providers](/docs/adapters). Switching providers, or surviving an outage with a fallback route, is a config change. Your application code stays the same.
 
 ```ts
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -24,12 +24,13 @@ await email.send({
 
 ## Why Email SDK
 
-- **One message shape, 20 providers.** Import only the adapter you use — each one is a separate entry point, and the core has zero runtime dependencies.
-- **No silent data loss.** Providers differ: Resend has no metadata, SMTP has no tags. Adapters either map a field or throw before the request — never drop it. See [field support](/docs/adapters/field-support).
-- **Retries and fallback routes, made explicit.** Exponential backoff inside an adapter, then explicit fallback adapters after it finally fails. [How routing works](/docs/concepts/fallbacks-and-retries).
-- **Observable without leaking PII.** [Hooks](/docs/concepts/hooks) and the [observability plugin](/docs/plugins/built-in/observability) emit redacted events — counts and tag names, never bodies or recipients.
-- **Testable for free.** [Memory and failing adapters](/docs/guides/test-email-behavior) plus the [capture plugin](/docs/plugins/built-in/capture) assert send behavior without a real provider.
-- **A CLI for the boring parts.** `email-sdk doctor` checks your environment, `--dry-run` validates a message against an adapter, and `send` runs a real smoke test. [CLI reference](/docs/reference/cli).
+Provider SDKs are easy to adopt and hard to leave. Each has its own message shape, its own error format, and its own opinion about retries. Email SDK puts one client in front of all of them. Every adapter is a separate entry point, so your bundle only contains the providers you actually send through, and the core has no runtime dependencies.
+
+Providers genuinely differ. Resend has no metadata field, SMTP has no tags, Iterable takes exactly one recipient. When a message uses a field the selected adapter cannot carry, the adapter throws before making the request instead of quietly dropping the field. The [field support matrix](/docs/adapters/field-support) shows what each provider maps.
+
+Failure handling has two explicit layers: exponential backoff inside an adapter for transient errors, then fallback adapters once the current one has failed for good. [How routing works](/docs/concepts/fallbacks-and-retries) covers both, including why a fallback route only helps when it can carry the same fields.
+
+The rest is operational plumbing you would otherwise write yourself. [Hooks](/docs/concepts/hooks) and the [observability plugin](/docs/plugins/built-in/observability) emit redacted events (counts and tag names, not bodies or recipients). [Memory and failing adapters](/docs/guides/test-email-behavior) plus the [capture plugin](/docs/plugins/built-in/capture) let unit tests assert send behavior without a provider account. The CLI covers setup checks: `email-sdk doctor` inspects your environment, `send --dry-run` validates a message against an adapter, and `send` runs a real smoke test. See the [CLI reference](/docs/reference/cli).
 
 ## Start here
 
@@ -42,7 +43,7 @@ await email.send({
   <Card
     title="Choose an adapter"
     href="/docs/adapters"
-    description="Browse all 20 providers and pick primary and backup routes."
+    description="Browse all 23 providers and pick primary and backup routes."
   />
   <Card
     title="Production send pipeline"
@@ -83,7 +84,7 @@ await email.send({
 
 ## What it is not
 
-Email SDK is not a campaign tool, queue, template engine, or hosted analytics product. It is the layer apps keep rebuilding — adapter setup, one consistent send call, typed errors, compatibility checks, and fallback routes explicit enough to debug at 3 a.m.
+Email SDK is not a campaign tool, a queue, a template engine, or a hosted analytics product. It is the layer apps keep rebuilding by hand: adapter setup, one consistent send call, typed errors, compatibility checks, and fallback routes explicit enough to debug at 3 a.m.
 
 <Callout title="Local checks are not deliverability">
   The SDK validates message shape and field support before every request, but live delivery still

--- a/apps/fumadocs/content/docs/plugins/api.mdx
+++ b/apps/fumadocs/content/docs/plugins/api.mdx
@@ -103,7 +103,7 @@ type EmailBeforeSendEvent = { message: EmailMessage; options?: SendOptions };
 type EmailBeforeSendResult = { message?: EmailMessage; options?: SendOptions };
 ```
 
-No `provider` field — routing has not happened yet. Returning a result transforms the send: `message` **replaces** the message wholesale, `options` **shallow-merges** over the current send options. Return nothing to observe or to throw for policy. Middleware runs in plugin order, each seeing the previous one's result.
+There is no `provider` field because routing has not happened yet. Returning a result transforms the send: `message` **replaces** the message wholesale, `options` **shallow-merges** over the current send options. Return nothing to observe or to throw for policy. Middleware runs in plugin order, each seeing the previous one's result.
 
 ### afterSend and onError
 
@@ -127,7 +127,7 @@ type EmailErrorEvent = {
 };
 ```
 
-After `onError`, [fallback adapters](/docs/concepts/fallbacks-and-retries) may still run — it signals a failed route, not necessarily a failed send.
+After `onError`, [fallback adapters](/docs/concepts/fallbacks-and-retries) may still run. It signals a failed route, not necessarily a failed send.
 
 ## Typed client extensions
 
@@ -151,7 +151,7 @@ Helper types behind the inference:
     },
     "EmailPluginClientExtensions<TPlugins>": {
       description:
-        "Intersection of all extensions in a readonly plugins tuple — the type argument of the returned EmailClient.",
+        "Intersection of all extensions in a readonly plugins tuple; the type argument of the returned EmailClient.",
       type: "object",
     },
   }}

--- a/apps/fumadocs/content/docs/plugins/built-in/capture.mdx
+++ b/apps/fumadocs/content/docs/plugins/built-in/capture.mdx
@@ -1,10 +1,10 @@
 ---
 title: Capture plugin
-description: Record every send, retry, response, and error in tests — and assert on them through a typed client.capture store.
+description: Record every send, retry, response, and error in tests, and assert on them through a typed client.capture store.
 icon: ClipboardCheck
 ---
 
-`capturePlugin` records send lifecycle events into a store and exposes it as `client.capture` — a typed property added through the plugin extension system. Pair it with the [memory adapter](/docs/guides/test-email-behavior) to assert exactly what the SDK tried to do, without a network call.
+`capturePlugin` records send lifecycle events into a store and exposes it as `client.capture`, a typed property added through the plugin extension system. Pair it with the [memory adapter](/docs/guides/test-email-behavior) to assert exactly what the SDK tried to do, without a network call.
 
 ```ts title="email.test.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -28,7 +28,7 @@ expect(sent?.provider).toBe("memory");
 expect(email.capture.events.map((event) => event.type)).toEqual(["beforeSend", "afterSend"]);
 ```
 
-`email.capture` is fully typed — `capturePlugin()` is an `EmailPlugin<{ capture: EmailCaptureStore }>`, so the extension flows into the client type with no casts.
+`email.capture` is fully typed. `capturePlugin()` is an `EmailPlugin<{ capture: EmailCaptureStore }>`, so the extension flows into the client type with no casts.
 
 ## What gets captured
 
@@ -39,7 +39,7 @@ expect(email.capture.events.map((event) => event.type)).toEqual(["beforeSend", "
 | `retry`      | The SDK schedules another attempt on the same adapter. | `provider`, `attempt`, `nextAttempt`, `delayMs`, `error` |
 | `error`      | An adapter route fails after exhausting its retries.   | `provider`, `attempt`, `error`                 |
 
-Unlike the [observability plugin](/docs/plugins/built-in/observability), captured events hold the **full, unredacted message** — they are meant for test assertions, not production logs.
+Unlike the [observability plugin](/docs/plugins/built-in/observability), captured events hold the **full, unredacted message**. They are meant for test assertions, not production logs.
 
 Reset between tests with `email.capture.clear()`.
 
@@ -87,7 +87,7 @@ Multiple instances need distinct `id`s (duplicate plugin ids throw) **and** dist
 
 ## Share a store
 
-`createEmailCaptureStore()` creates a store you can hold a reference to directly — useful when the client is built inside a factory and your test only sees the store:
+`createEmailCaptureStore()` creates a store you can hold a reference to directly. This is useful when the client is built inside a factory and your test only sees the store:
 
 ```ts
 import { capturePlugin, createEmailCaptureStore } from "@opencoredev/email-sdk/plugins/capture";
@@ -101,4 +101,4 @@ expect(store.events).toHaveLength(2);
 
 ## Capture vs memory adapter
 
-They answer different questions: `memoryProvider()` replaces the network so nothing real sends, while `capturePlugin()` records what the pipeline did — including retries and errors the adapter alone cannot show. Most tests use both. See [Test email behavior](/docs/guides/test-email-behavior) for the full testing setup.
+They answer different questions: `memoryProvider()` replaces the network so nothing real sends, while `capturePlugin()` records what the pipeline did, including retries and errors the adapter alone cannot show. Most tests use both. See [Test email behavior](/docs/guides/test-email-behavior) for the full testing setup.

--- a/apps/fumadocs/content/docs/plugins/built-in/defaults.mdx
+++ b/apps/fumadocs/content/docs/plugins/built-in/defaults.mdx
@@ -1,6 +1,6 @@
 ---
 title: Defaults plugin
-description: Merge org-wide headers, tags, reply-to, and idempotency key prefixes into every send — with message values winning.
+description: Merge org-wide headers, tags, reply-to, and idempotency key prefixes into every send, with message values winning.
 icon: Settings
 ---
 
@@ -23,7 +23,7 @@ export const email = createEmailClient({
   ],
 });
 
-// Every send now carries the header, the env tag, and the reply-to —
+// Every send now carries the header, the env tag, and the reply-to
 // without repeating them in application code:
 await email.send({
   from: "Acme <hello@acme.com>",
@@ -82,16 +82,16 @@ Each option has an exact, predictable rule:
 | `headers`              | Merged by name; a message header with the same name **wins** over the default.                                            |
 | `metadata`             | Merged by key; message metadata **wins**.                                                                                 |
 | `sendMetadata`         | Merged into `options.metadata`; per-send metadata **wins**.                                                                |
-| `tags`                 | Concatenated — defaults first, then message tags. Nothing is replaced.                                                    |
+| `tags`                 | Concatenated: defaults first, then message tags. Nothing is replaced.                                                     |
 | `replyTo`              | Applied only when the message has no `replyTo` at all.                                                                    |
 | `idempotencyKey`       | Applied only when neither the message nor send options carry a key.                                                       |
-| `idempotencyKeyPrefix` | Prepended to whichever key ends up applying — unless the key already starts with the prefix, so re-runs never double-prefix. |
+| `idempotencyKeyPrefix` | Prepended to whichever key ends up applying, unless the key already starts with the prefix, so re-runs never double-prefix. |
 
 So with the client above, a message that sets `headers: { "X-Entity-Ref": "checkout" }` sends `checkout` (message wins), while its `tags` gain the `env` tag in front of its own.
 
 <Callout type="warn" title="Defaults are validated like any other field">
   Defaults merge before adapter validation. If a default adds a field the selected route cannot
-  represent — tags on SMTP, for example — the send throws an `EmailValidationError` before any
+  represent (tags on SMTP, for example), the send throws an `EmailValidationError` before any
   request. Check [field support](/docs/adapters/field-support) when adding default tags or
   metadata to a client with fallback routes.
 </Callout>

--- a/apps/fumadocs/content/docs/plugins/built-in/observability.mdx
+++ b/apps/fumadocs/content/docs/plugins/built-in/observability.mdx
@@ -1,10 +1,10 @@
 ---
 title: Observability plugin
-description: Emit redacted sent/retry/error events to your logger, metrics, and tracer — counts and tag names, never recipients or bodies.
+description: Emit redacted sent/retry/error events to your logger, metrics, and tracer. Counts and tag names only, no recipients or bodies.
 icon: Activity
 ---
 
-`observabilityPlugin` turns the send pipeline into structured events you can wire to any logger, metrics client, or tracer. Events are redacted by default: they carry counts, flags, and tag names — never recipient addresses, bodies, attachment content, or metadata values — so they are safe to ship to a log aggregator as-is.
+`observabilityPlugin` turns the send pipeline into structured events you can wire to any logger, metrics client, or tracer. Events are redacted by default. They carry counts, flags, and tag names, and omit recipient addresses, bodies, attachment content, and metadata values, so they are safe to ship to a log aggregator as-is.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -55,7 +55,7 @@ export const email = createEmailClient({
   }}
 />
 
-`log`, `metric`, and `trace` are not filtered by event type — **all three receive every event** (dispatched via `Promise.allSettled`). Route inside each callback if you only want errors in one sink. Callback failures are swallowed so a broken logger never masks a provider failure.
+`log`, `metric`, and `trace` are not filtered by event type: **all three receive every event**, dispatched via `Promise.allSettled`. Route inside each callback if you only want errors in one sink. Callback failures are swallowed so a broken logger cannot mask a provider failure.
 
 ## Events
 
@@ -85,7 +85,7 @@ Tag *names* and metadata *keys* are included; their values are not.
 
 ## Custom redaction
 
-Pass `redactMessage` when your team needs a different summary — for example, a template name from metadata:
+Pass `redactMessage` when your team needs a different summary, for example a template name from metadata:
 
 ```ts
 observabilityPlugin({
@@ -102,9 +102,9 @@ observabilityPlugin({
 ```
 
 <Callout type="warn" title="You own redaction once you override it">
-  A custom `redactMessage` replaces the default entirely. Whatever it returns goes to every sink —
-  keep recipient lists, bodies, and secrets out unless your logging pipeline is built to protect
-  them.
+  A custom `redactMessage` replaces the default entirely. Whatever it returns goes to every sink,
+  so keep recipient lists, bodies, and secrets out unless your logging pipeline is built to
+  protect them.
 </Callout>
 
 ## Next

--- a/apps/fumadocs/content/docs/plugins/community.mdx
+++ b/apps/fumadocs/content/docs/plugins/community.mdx
@@ -1,6 +1,6 @@
 ---
 title: Community plugins and adapters
-description: Browse third-party Email SDK packages — and get your own adapter or plugin listed by pull request.
+description: Browse third-party Email SDK packages, and get your own adapter or plugin listed by pull request.
 icon: Users
 ---
 
@@ -16,7 +16,7 @@ Third-party adapters and plugins are npm packages listed in a static registry ma
 | Plugin  | Reusable send behavior, policy, or helpers.      | `plugins: [requireMetadata("key")]` |
 | Hybrid  | Both a provider and behavior in one package.     | `plugins: [providerWithDefaults()]` |
 
-Adapter packages are mounted through `plugins` too — the plugin wrapper registers the provider in one call. See [Writing plugins](/docs/plugins/writing-plugins#register-adapters).
+Adapter packages are mounted through `plugins` too; the plugin wrapper registers the provider in one call. See [Writing plugins](/docs/plugins/writing-plugins#register-adapters).
 
 ## Labels
 
@@ -26,10 +26,10 @@ Adapter packages are mounted through `plugins` too — the plugin wrapper regist
 | Verified  | Passed the registry's static checks for a specific package version.       |
 | Official  | Maintained by OpenCore or in this repository.                             |
 
-Verified is not a security review — the exact checks and the entry schema are documented in the [community registry reference](/docs/reference/community-registry).
+Verified is not a security review. The exact checks and the entry schema are documented in the [community registry reference](/docs/reference/community-registry).
 
 ## List your package
 
-1. Build and publish to npm — follow [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) for provider packages or [Publish a community plugin](/docs/guides/authoring/publish-community-plugin) for behavior packages.
+1. Build and publish to npm. Follow [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) for provider packages or [Publish a community plugin](/docs/guides/authoring/publish-community-plugin) for behavior packages.
 2. Open a pull request adding an entry to `apps/fumadocs/content/community/plugins.json` (shape in the [registry reference](/docs/reference/community-registry)).
 3. Want feedback first? Open the `Community package listing` issue template with your package and source links.

--- a/apps/fumadocs/content/docs/plugins/index.mdx
+++ b/apps/fumadocs/content/docs/plugins/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Plugins
-description: Package reusable send behavior — adapters, hooks, middleware, and typed client extensions — into one plugins array.
+description: Package reusable send behavior (adapters, hooks, middleware, and typed client extensions) into one plugins array.
 icon: Plug
 ---
 
-A plugin bundles send-pipeline behavior into one reusable unit you mount with `plugins: [...]`. One plugin can register adapters, transform messages before validation, observe every attempt, and add typed helpers to the client — so shared policy lives in one place instead of being copied around every `createEmailClient` call.
+A plugin bundles send-pipeline behavior into one reusable unit you mount with `plugins: [...]`. One plugin can register adapters, transform messages before validation, observe every attempt, and add typed helpers to the client. Shared policy lives in one place instead of being copied around every `createEmailClient` call.
 
 ```ts title="lib/email.ts"
 import { createEmailClient } from "@opencoredev/email-sdk";
@@ -27,9 +27,9 @@ A plugin is a plain object with an `id` and any combination of four capabilities
 
 | Capability | Field          | What it does                                                                                                                          |
 | ---------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| Add routes | `adapters`     | Registers providers into the client, same as the `adapters` option — how community provider packages ship one-call setup.              |
+| Add routes | `adapters`     | Registers providers into the client, same as the `adapters` option. This is how community provider packages ship one-call setup.       |
 | Transform  | `middleware`   | `beforeSend` runs once per send, before validation, and can replace the message or options. `afterSend` / `onError` observe outcomes.  |
-| Observe    | `hooks`        | The same [hooks](/docs/concepts/hooks) as the client option — per-attempt, observe-only, failures swallowed.                            |
+| Observe    | `hooks`        | The same [hooks](/docs/concepts/hooks) as the client option: per-attempt, observe-only, failures swallowed.                             |
 | Extend     | `extendClient` | Adds typed properties to the returned client, like `email.capture` from the capture plugin.                                            |
 
 Middleware is the capability only plugins have: client-level `hooks` can watch a send, but only plugin middleware can change it.
@@ -50,7 +50,7 @@ Plugins register in array order, and the order is deterministic:
 
 1. Direct `adapters` register first, then each plugin's adapters in plugin order.
 2. Middleware and hooks run in plugin order; plugin hooks run before client `hooks`.
-3. Duplicate plugin ids and duplicate adapter names throw an `EmailValidationError` — mount two instances of the same plugin with distinct `id`s (and distinct extension keys, e.g. `capturePlugin({ id: "capture:audit", clientKey: "auditCapture" })`).
+3. Duplicate plugin ids and duplicate adapter names throw an `EmailValidationError`. Mount two instances of the same plugin with distinct `id`s and distinct extension keys, e.g. `capturePlugin({ id: "capture:audit", clientKey: "auditCapture" })`.
 
 The full rules, event shapes, and error cases are in the [plugin API reference](/docs/plugins/api).
 

--- a/apps/fumadocs/content/docs/plugins/writing-plugins.mdx
+++ b/apps/fumadocs/content/docs/plugins/writing-plugins.mdx
@@ -1,10 +1,10 @@
 ---
 title: Writing plugins
-description: Build an EmailPlugin — choose hooks or middleware, register adapters, and add typed client extensions.
+description: Build an EmailPlugin. Choose hooks or middleware, register adapters, and add typed client extensions.
 icon: PackagePlus
 ---
 
-A plugin is a plain object: a stable `id` plus any combination of `adapters`, `hooks`, `middleware`, and `extendClient`. No base class, no registration ceremony — export a factory function that returns the object.
+A plugin is a plain object: a stable `id` plus any combination of `adapters`, `hooks`, `middleware`, and `extendClient`. There is no base class and no registration ceremony. Export a factory function that returns the object.
 
 ```ts
 import type { EmailPlugin } from "@opencoredev/email-sdk";
@@ -32,7 +32,7 @@ Both watch the send pipeline; only middleware can change it. Pick by intent:
 | You want to…                              | Use                     | Why                                                                                  |
 | ----------------------------------------- | ----------------------- | ------------------------------------------------------------------------------------ |
 | Add defaults or rewrite the message       | `middleware.beforeSend` | Runs once per send, before validation; its return value replaces message/options.    |
-| Block a send (policy, guardrails)         | `middleware.beforeSend` | Thrown errors propagate and stop the send — hooks errors are swallowed.              |
+| Block a send (policy, guardrails)         | `middleware.beforeSend` | Thrown errors propagate and stop the send; hook errors are swallowed.                |
 | Log, count, or trace attempts             | `hooks`                 | Per-attempt events including `onRetry`; failures never mask the send.                |
 | React to the final outcome                | `middleware.afterSend` / `onError` | Fire on success and on per-route failure; observe-only, errors swallowed. |
 
@@ -55,7 +55,7 @@ export function requireMetadata(key: string): EmailPlugin {
 
 `beforeSend` can also transform: return `{ message?, options? }` and the pipeline continues with your values. The returned `message` replaces the message wholesale; returned `options` shallow-merge over the current send options. The [defaults plugin](/docs/plugins/built-in/defaults) is exactly this pattern.
 
-Plugin `hooks` use the same shape as the client `hooks` option and run before client hooks — see [Hooks](/docs/concepts/hooks) for the event fields.
+Plugin `hooks` use the same shape as the client `hooks` option and run before client hooks. See [Hooks](/docs/concepts/hooks) for the event fields.
 
 ## Register adapters
 
@@ -78,7 +78,7 @@ const email = createEmailClient({
 });
 ```
 
-For dynamic registration, `adapters` can be a function receiving an `EmailPluginContext` — inspect already-registered routes via `ctx.adapters`, read `ctx.defaultAdapter`, and call `ctx.addAdapter()`:
+For dynamic registration, `adapters` can be a function receiving an `EmailPluginContext`: inspect already-registered routes via `ctx.adapters`, read `ctx.defaultAdapter`, and call `ctx.addAdapter()`.
 
 ```ts
 export function regionalMail(options: RegionOptions): EmailPlugin {
@@ -94,11 +94,11 @@ export function regionalMail(options: RegionOptions): EmailPlugin {
 }
 ```
 
-Two rules, both enforced with an `EmailValidationError`: adapter factories must be **synchronous** (`createEmailClient` is sync — returning a Promise throws), and duplicate adapter names throw. Building the adapter itself is its own topic: [Create an adapter](/docs/guides/authoring/create-adapter).
+Two rules, both enforced with an `EmailValidationError`: adapter factories must be **synchronous** (`createEmailClient` is sync, so returning a Promise throws), and duplicate adapter names throw. Building the adapter itself is its own topic: [Create an adapter](/docs/guides/authoring/create-adapter).
 
 ## Extend the client
 
-`extendClient` returns properties merged onto the client. Type the plugin as `EmailPlugin<TExtension>` and the extension flows into the client type — `createEmailClient` infers the intersection of all plugin extensions, so callers get autocomplete with no casts:
+`extendClient` returns properties merged onto the client. Type the plugin as `EmailPlugin<TExtension>` and the extension flows into the client type. `createEmailClient` infers the intersection of all plugin extensions, so callers get autocomplete with no casts:
 
 ```ts
 export function routeNamesPlugin(): EmailPlugin<{ routeNames: string[] }> {
@@ -115,10 +115,10 @@ const email = createEmailClient({
   plugins: [routeNamesPlugin()],
 });
 
-email.routeNames; // string[] — typed, no cast
+email.routeNames; // string[], typed, no cast
 ```
 
-Extensions run after the client is built. A key that already exists on the client — built-ins like `send` or `adapters`, or a key claimed by an earlier plugin — throws: `Email plugin "<id>" tried to extend the client with reserved key "<key>".` Keep extensions small: a store, a helper, a few readonly values. The [capture plugin](/docs/plugins/built-in/capture) shows the pattern, including a configurable typed key.
+Extensions run after the client is built. A key that already exists on the client (built-ins like `send` or `adapters`, or a key claimed by an earlier plugin) throws: `Email plugin "<id>" tried to extend the client with reserved key "<key>".` Keep extensions small: a store, a helper, a few readonly values. The [capture plugin](/docs/plugins/built-in/capture) shows the pattern, including a configurable typed key.
 
 ## Registration rules
 

--- a/apps/fumadocs/content/docs/reference/adapter-contract.mdx
+++ b/apps/fumadocs/content/docs/reference/adapter-contract.mdx
@@ -101,11 +101,11 @@ Throw `EmailProviderError` for provider failures and classify retryability so th
 - Set `retryable: true` for transient failures. The SDK's own adapters use `isRetryableStatus`: `408`, `409`, `425`, `429`, and any `5xx`.
 - Put the parsed error body in `details`.
 
-Anything else you throw is normalized by the client via `toProviderError`: plain `Error`s become non-retryable `EmailProviderError`s — except network-style failures (`ECONNRESET`-family codes, `fetch failed`, timeouts), which are marked retryable. `AbortError` is never retried. See the [errors reference](/docs/reference/errors) for the full taxonomy.
+Anything else you throw is normalized by the client via `toProviderError`: plain `Error`s become non-retryable `EmailProviderError`s, except network-style failures (`ECONNRESET`-family codes, `fetch failed`, timeouts), which are marked retryable. `AbortError` is never retried. See the [errors reference](/docs/reference/errors) for the full taxonomy.
 
 ## Fail fast on unsupported fields
 
-Adapters must reject message fields the provider cannot represent — before any request, never a silent drop. Built-in adapters throw `EmailValidationError` with this exact shape:
+Adapters must reject message fields the provider cannot represent before any request, rather than dropping them silently. Built-in adapters throw `EmailValidationError` with this exact shape:
 
 ```txt
 <adapter> does not support these EmailMessage fields: tags, metadata.
@@ -115,10 +115,10 @@ Do the same in custom adapters: check `cc`, `bcc`, `replyTo`, `headers`, `attach
 
 ## Internal helpers
 
-The built-in adapters share two internal modules in the SDK repository — useful as reference, or directly if you contribute an adapter upstream (they are not public package exports):
+The built-in adapters share two internal modules in the SDK repository. They are useful as reference, or directly if you contribute an adapter upstream (they are not public package exports):
 
-- `src/http.ts` — `jsonProvider({ name, baseUrl, endpoint, headers, buildPayload, parseResponse? })` wraps the whole JSON-API pattern: fetch with `context.signal`, error-body parsing, `EmailProviderError` with `isRetryableStatus`, and response normalization.
-- `src/payloads.ts` — address and attachment mapping helpers (`apiAddresses`, `stringAddresses`, `base64Attachments`, `commonHeadersObject`, …) used across the 20 adapters.
+- `src/http.ts`: `jsonProvider({ name, baseUrl, endpoint, headers, buildPayload, parseResponse? })` wraps the whole JSON-API pattern: fetch with `context.signal`, error-body parsing, `EmailProviderError` with `isRetryableStatus`, and response normalization.
+- `src/payloads.ts`: address and attachment mapping helpers (`apiAddresses`, `stringAddresses`, `base64Attachments`, `commonHeadersObject`, and so on) shared across the built-in adapters.
 
 Community packages should copy these patterns rather than import them.
 
@@ -137,6 +137,6 @@ export function acmeMailPlugin(options: AcmeMailOptions): EmailPlugin {
 }
 ```
 
-`adapters` must be synchronous — an array, or a function of the plugin context that returns one. A plugin that returns a Promise throws `EmailValidationError` at client creation, as do duplicate plugin ids and duplicate adapter names.
+`adapters` must be synchronous: an array, or a function of the plugin context that returns one. A plugin that returns a Promise throws `EmailValidationError` at client creation, as do duplicate plugin ids and duplicate adapter names.
 
 Export both the plain adapter factory and the plugin from your package root, then follow [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) to list it in the [community registry](/docs/reference/community-registry).

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -87,6 +87,9 @@ Prints one line per adapter: routing name, required environment variables, and a
 | `sparkpost` | `SPARKPOST_API_KEY` | — |
 | `loops` | `LOOPS_API_KEY`, `LOOPS_TRANSACTIONAL_ID` | — |
 | `sequenzy` | `SEQUENZY_API_KEY` | `SEQUENZY_BASE_URL` |
+| `jetemail` | `JETEMAIL_API_KEY` | `JETEMAIL_BASE_URL` |
+| `lettermint` | `LETTERMINT_API_TOKEN` | `LETTERMINT_BASE_URL`, `LETTERMINT_ROUTE` |
+| `primitive` | `PRIMITIVE_API_KEY` | `PRIMITIVE_BASE_URL` |
 | `plunk` | `PLUNK_API_KEY` | — |
 | `mailtrap` | `MAILTRAP_API_KEY` | — |
 | `scaleway` | `SCALEWAY_SECRET_KEY`, `SCALEWAY_PROJECT_ID` | `SCALEWAY_REGION` |
@@ -216,12 +219,13 @@ Every credential environment variable has a flag override; flags win over the en
 
 | Adapter | Flags |
 | --- | --- |
-| `resend`, `sendgrid`, `unosend`, `mailersend`, `brevo`, `mailchimp`, `sparkpost`, `sequenzy`, `plunk`, `mailtrap`, `mailpace`, `loops` | `--api-key`, plus `--transactional-id` (Loops) and `--base-url` (Unosend, Sequenzy) |
+| `resend`, `sendgrid`, `unosend`, `mailersend`, `brevo`, `mailchimp`, `sparkpost`, `sequenzy`, `jetemail`, `primitive`, `plunk`, `mailtrap`, `mailpace`, `loops` | `--api-key`, plus `--transactional-id` (Loops) and `--base-url` (Unosend, Sequenzy, JetEmail, Primitive) |
 | `postmark` | `--server-token`, `--message-stream` |
 | `cloudflare` | `--api-token`, `--account-id`, `--base-url` |
 | `iterable` | `--api-key`, `--campaign-id`, `--base-url`, `--send-at`, `--allow-repeat-marketing-sends` |
 | `ses` | `--access-key-id`, `--secret-access-key`, `--region`, `--session-token`, `--configuration-set`, `--base-url` |
 | `mailgun` | `--api-key`, `--domain`, `--base-url` |
+| `lettermint` | `--api-token`, `--base-url`, `--route` |
 | `scaleway` | `--secret-key`, `--project-id`, `--region` |
 | `zeptomail` | `--token` |
 | `smtp` | `--host`, `--port`, `--secure`, `--require-tls`, `--allow-insecure-auth`, `--user`, `--pass` |

--- a/apps/fumadocs/content/docs/reference/cli.mdx
+++ b/apps/fumadocs/content/docs/reference/cli.mdx
@@ -1,10 +1,10 @@
 ---
 title: CLI
-description: The complete email-sdk command manual — adapters, doctor, send, dry runs, credential flags, and exit codes.
+description: The complete email-sdk command manual, covering adapters, doctor, send, dry runs, credential flags, and exit codes.
 icon: Terminal
 ---
 
-The `email-sdk` CLI ships inside `@opencoredev/email-sdk`. Use it to list adapters, check credentials with `doctor`, validate a message with `--dry-run`, and run a real smoke send — no app code required.
+The `email-sdk` CLI ships inside `@opencoredev/email-sdk`. Use it to list adapters, check credentials with `doctor`, validate a message with `--dry-run`, and run a real smoke send, all without writing app code.
 
 ## Run it
 
@@ -39,7 +39,7 @@ Any other command fails with `Unknown command "x".` and exit code 1.
 ### Flag syntax
 
 - `--flag value` and `--flag=value` are equivalent; a flag without a value is treated as `true`.
-- `--header`, `--tag`, `--metadata`, and `--attachment` (alias `--attach`) are repeatable — pass them once per value.
+- `--header`, `--tag`, `--metadata`, and `--attachment` (alias `--attach`) are repeatable; pass them once per value.
 - Repeating any other flag keeps the last value.
 - `--to`, `--cc`, `--bcc`, and `--reply-to` accept comma-separated address lists.
 
@@ -61,7 +61,7 @@ npx email-sdk version --json
 # { "name": "@opencoredev/email-sdk", "version": "0.6.1" }
 ```
 
-Reads the metadata of the package actually installed on your machine — check it before comparing behavior against the docs.
+Reads the metadata of the package actually installed on your machine. Check it before comparing behavior against the docs.
 
 ## adapters
 
@@ -111,7 +111,7 @@ RESEND_API_KEY="re_..." npx email-sdk doctor --adapter resend
 # resend looks configured.
 ```
 
-Checks that each required variable is set — or supplied via its [credential flag](#credential-flags). On failure it prints the missing names and exits 1:
+Checks that each required variable is set, or supplied via its [credential flag](#credential-flags). On failure it prints the missing names and exits 1:
 
 ```txt
 Missing environment for resend: RESEND_API_KEY
@@ -188,7 +188,7 @@ npx email-sdk send \
 }
 ```
 
-Attachment content is redacted in dry-run output — only `filename`, `path`, `contentType`, `contentId`, and `disposition` are echoed.
+Attachment content is redacted in dry-run output; only `filename`, `path`, `contentType`, `contentId`, and `disposition` are echoed.
 
 ### Send from a JSON file
 
@@ -230,7 +230,7 @@ Every credential environment variable has a flag override; flags win over the en
 
 | Code | When |
 | --- | --- |
-| `0` | Command succeeded — including a passing `doctor` and a valid `--dry-run`. |
+| `0` | Command succeeded, including a passing `doctor` and a valid `--dry-run`. |
 | `1` | Anything else: unknown command, missing flag or environment, validation failure, missing `doctor` credentials, provider error. |
 
 Errors print their message to stderr; success output is JSON (or plain text for `help`, `doctor`, `version`, and `adapters` without `--json`) on stdout, so the CLI pipes cleanly into `jq` and scripts.

--- a/apps/fumadocs/content/docs/reference/client.mdx
+++ b/apps/fumadocs/content/docs/reference/client.mdx
@@ -1,6 +1,6 @@
 ---
 title: Client
-description: API reference for createEmailClient — client options, send and sendBatch, adapter helpers, and the normalized response.
+description: API reference for createEmailClient, covering client options, send and sendBatch, adapter helpers, and the normalized response.
 icon: Braces
 ---
 
@@ -65,7 +65,7 @@ Construction fails fast with an `EmailValidationError` for a duplicate adapter r
 send(message: EmailMessage, options?: SendOptions): Promise<EmailProviderResponse>
 ```
 
-Validates the [message](/docs/reference/message), builds the route `[adapter, ...fallbackAdapters]` (duplicates removed), retries each adapter per the retry config, and resolves with the first successful [response](#response). One failed route rethrows the adapter's error as-is; multiple failed routes throw `EmailSdkError` with code `all_providers_failed` — see [errors](/docs/reference/errors).
+Validates the [message](/docs/reference/message), builds the route `[adapter, ...fallbackAdapters]` (duplicates removed), retries each adapter per the retry config, and resolves with the first successful [response](#response). One failed route rethrows the adapter's error as-is; multiple failed routes throw `EmailSdkError` with code `all_providers_failed`. See [errors](/docs/reference/errors).
 
 ```ts
 const result = await email.send(message, {
@@ -108,7 +108,7 @@ const result = await email.send(message, {
   }}
 />
 
-`provider` and `fallbackProviders` are accepted [aliases](#aliases). Send-options `metadata` is unrelated to `message.metadata` — the message field goes to the provider, the send option only flows to [hooks](/docs/concepts/hooks).
+`provider` and `fallbackProviders` are accepted [aliases](#aliases). Send-options `metadata` is unrelated to `message.metadata`: the message field goes to the provider, the send option only flows to [hooks](/docs/concepts/hooks).
 
 ## `email.sendBatch(messages, options?)`
 
@@ -116,7 +116,7 @@ const result = await email.send(message, {
 sendBatch(messages: SendBatchItem[], options?: SendOptions): Promise<SendBatchResult[]>
 ```
 
-Sends sequentially, one message at a time in array order, and always resolves with one result per item — a failed item never throws or stops the batch:
+Sends sequentially, one message at a time in array order, and always resolves with one result per item. A failed item does not throw or stop the batch:
 
 ```ts
 type SendBatchResult =
@@ -151,7 +151,7 @@ Returns the registered adapter or throws `EmailProviderNotFoundError`. Useful fo
 withAdapter(name: string): Pick<EmailClient, "send" | "sendBatch">
 ```
 
-Returns a client pinned to one route — `send` and `sendBatch` behave as if `{ adapter: name }` were passed every time. The name is checked immediately: an unregistered name throws `EmailProviderNotFoundError` at `withAdapter` time, not at send time.
+Returns a client pinned to one route: `send` and `sendBatch` behave as if `{ adapter: name }` were passed every time. The name is checked immediately, so an unregistered name throws `EmailProviderNotFoundError` at `withAdapter` time, not at send time.
 
 ```ts
 const transactional = email.withAdapter("postmark");
@@ -175,7 +175,7 @@ await transactional.send(message);
 
 ## Response
 
-Every successful send resolves with a normalized `EmailProviderResponse`. `provider` is always set — it names the adapter that actually delivered, which matters when a fallback route handled the send.
+Every successful send resolves with a normalized `EmailProviderResponse`. `provider` is always set. It names the adapter that actually delivered, which matters when a fallback route handled the send.
 
 <TypeTable
   type={{
@@ -209,4 +209,4 @@ Every successful send resolves with a normalized `EmailProviderResponse`. `provi
 
 ## Aliases
 
-`adapter` and `provider` mean the same thing everywhere: `providers`, `defaultProvider`, `fallbackProviders`, `email.provider(name)`, `email.providers`, and `email.withProvider(name)` are compatibility aliases for their `adapter` spellings. Prefer `adapter` in new code — see [naming aliases](/docs/concepts/adapter-model#naming-aliases).
+`adapter` and `provider` mean the same thing everywhere: `providers`, `defaultProvider`, `fallbackProviders`, `email.provider(name)`, `email.providers`, and `email.withProvider(name)` are compatibility aliases for their `adapter` spellings. Prefer `adapter` in new code. See [naming aliases](/docs/concepts/adapter-model#naming-aliases).

--- a/apps/fumadocs/content/docs/reference/community-registry.mdx
+++ b/apps/fumadocs/content/docs/reference/community-registry.mdx
@@ -4,7 +4,7 @@ description: The plugins.json entry schema, status labels, and the validation th
 icon: ShieldCheck
 ---
 
-The community registry is one static JSON file — `apps/fumadocs/content/community/plugins.json` in the [SDK repository](https://github.com/opencoredev/email-sdk) — listing third-party adapters, plugins, and hybrid packages. The docs site renders it on the [community page](/docs/plugins/community); changes land by pull request and are validated by a script in CI.
+The community registry is one static JSON file, `apps/fumadocs/content/community/plugins.json` in the [SDK repository](https://github.com/opencoredev/email-sdk), listing third-party adapters, plugins, and hybrid packages. The docs site renders it on the [community page](/docs/plugins/community); changes land by pull request and are validated by a script in CI.
 
 To list a package, build it first: [Publish a community adapter](/docs/guides/authoring/publish-community-adapter) or [Publish a community plugin](/docs/guides/authoring/publish-community-plugin).
 
@@ -117,7 +117,7 @@ That runs `scripts/validate-community-registry.ts`, which enforces the schema ab
 
 ### The npm audit in CI
 
-With `--network` (or automatically when `CI=true` — the same script runs in CI via `bun run release:ci`), verified and official entries get a deeper audit. The script downloads the published npm tarball for `verifiedVersion` and fails the build if the package:
+With `--network` (or automatically when `CI=true`; the same script runs in CI via `bun run release:ci`), verified and official entries get a deeper audit. The script downloads the published npm tarball for `verifiedVersion` and fails the build if the package:
 
 1. Has a `repository` that does not match the entry's `repo`.
 2. Defines `preinstall`, `install`, or `postinstall` scripts.

--- a/apps/fumadocs/content/docs/reference/errors.mdx
+++ b/apps/fumadocs/content/docs/reference/errors.mdx
@@ -53,12 +53,12 @@ All four classes carry the same fields (plus the standard `Error` `message` and 
 | Class | Code | Thrown when |
 | --- | --- | --- |
 | `EmailValidationError` | `validation_error` | The message fails [validation](/docs/reference/message#validation), an adapter rejects [unsupported fields](/docs/adapters/field-support), or client config is invalid (duplicate adapter/plugin, no adapters). Never retryable. |
-| `EmailProviderNotFoundError` | `provider_not_found` | A routing name is not registered — `Email provider "x" is not registered.` Never retryable. |
+| `EmailProviderNotFoundError` | `provider_not_found` | A routing name is not registered: `Email provider "x" is not registered.` Never retryable. |
 | `EmailProviderError` | `provider_error` | A provider request fails: non-2xx response or network error. `status` and `details` carry the provider's answer. |
 | `EmailSdkError` | `all_providers_failed` | Two or more routes were attempted and all failed. `details` holds one error per adapter, in route order. |
 | `EmailSdkError` | `retry_loop_exited` | Internal guard for an impossible retry-loop exit. Treat as a bug if seen. |
 
-When only **one** route was attempted, its error is rethrown as-is — `all_providers_failed` only appears after a multi-adapter route exhausts every option. Errors adapters throw that are not already `EmailProviderError` are wrapped into one, keeping the original as `cause` (or in `details` for non-`Error` values).
+When only **one** route was attempted, its error is rethrown as-is; `all_providers_failed` only appears after a multi-adapter route exhausts every option. Errors adapters throw that are not already `EmailProviderError` are wrapped into one, keeping the original as `cause` (or in `details` for non-`Error` values).
 
 ## What counts as retryable
 
@@ -67,7 +67,7 @@ When only **one** route was attempted, its error is rethrown as-is — `all_prov
 - HTTP `408`, `409`, `425`, `429`, and any `5xx`
 - Network failures: `ECONNRESET`-family error codes, `fetch failed`, socket and timeout errors
 
-Everything else is non-retryable: `4xx` like `401`/`422`, validation errors, unknown routing names, and aborted requests (`AbortError`). This classification drives the default retry policy — see [fallbacks and retries](/docs/concepts/fallbacks-and-retries#what-retries-by-default).
+Everything else is non-retryable: `4xx` like `401`/`422`, validation errors, unknown routing names, and aborted requests (`AbortError`). This classification drives the default retry policy; see [fallbacks and retries](/docs/concepts/fallbacks-and-retries#what-retries-by-default).
 
 ## `isRetryableEmailError(error)`
 
@@ -92,14 +92,14 @@ try {
   await email.send(message);
 } catch (error) {
   if (error instanceof EmailValidationError) {
-    // Bad message shape or unsupported field — fix the code path, do not retry.
+    // Bad message shape or unsupported field: fix the code path, do not retry.
     throw error;
   }
 
   if (error instanceof EmailProviderError) {
     console.error(`${error.provider} failed`, error.status, error.details);
     if (error.retryable) {
-      await queue.retryLater(message); // transient — re-enqueue
+      await queue.retryLater(message); // transient: re-enqueue
       return;
     }
     throw error; // 401/422-style failure: needs a config or account fix
@@ -114,4 +114,4 @@ try {
 }
 ```
 
-Inside a send, you rarely handle retries yourself — configure the client's [`retry` and `fallback`](/docs/concepts/fallbacks-and-retries) options and let the SDK exhaust them before anything reaches your `catch`.
+Inside a send, you rarely handle retries yourself. Configure the client's [`retry` and `fallback`](/docs/concepts/fallbacks-and-retries) options and let the SDK exhaust them before anything reaches your `catch`.

--- a/apps/fumadocs/content/docs/reference/message.mdx
+++ b/apps/fumadocs/content/docs/reference/message.mdx
@@ -1,6 +1,6 @@
 ---
 title: Message
-description: The EmailMessage shape field by field — addresses, headers, attachments, tags vs metadata, and the exact validation rules.
+description: The EmailMessage shape field by field, covering addresses, headers, attachments, tags vs metadata, and the exact validation rules.
 icon: Mail
 ---
 
@@ -88,7 +88,7 @@ type EmailMessage = {
 
 ## Addresses
 
-`EmailAddress` is a plain string — including the `Name <email>` form — or an object with a display name:
+`EmailAddress` is a plain string (including the `Name <email>` form) or an object with a display name:
 
 ```ts
 from: "Acme <hello@acme.com>",
@@ -123,7 +123,7 @@ type EmailAttachment = {
 
 Every attachment needs `content` **or** `path`:
 
-- `content` attaches in-memory data. String content is treated as raw (`contentEncoding: "raw"`) and Base64-encoded for providers that need it — set `contentEncoding: "base64"` when the string is already Base64 so it is not double-encoded.
+- `content` attaches in-memory data. String content is treated as raw (`contentEncoding: "raw"`) and Base64-encoded for providers that need it. Set `contentEncoding: "base64"` when the string is already Base64 so it is not double-encoded.
 - `path` makes the SDK read a local file at send time.
 
 For inline images, set `contentId` and reference it from the HTML body with `cid:`, plus `disposition: "inline"`:
@@ -144,14 +144,14 @@ await email.send({
 
 Both attach data to a send on the provider side, but they are different provider concepts:
 
-- **`tags`** are `{ name, value }` labels for categorizing sends — provider dashboards and analytics group by them. Some providers carry only each tag's value, and Postmark and Mailtrap accept a single tag.
+- **`tags`** are `{ name, value }` labels for categorizing sends; provider dashboards and analytics group by them. Some providers carry only each tag's value, and Postmark, Mailtrap, and Lettermint accept a single tag.
 - **`metadata`** is free-form key-value data (`string | number | boolean | null` values) the provider stores with the message and echoes in webhooks and events.
 
-Support differs per provider — Resend has tags but no metadata, Iterable has metadata but no tags. Check the [field support matrix](/docs/adapters/field-support) before relying on either, especially for fallback routes.
+Support differs per provider. Resend has tags but no metadata; Iterable has metadata but no tags. Check the [field support matrix](/docs/adapters/field-support) before relying on either, especially for fallback routes.
 
 ## Idempotency key
 
-`idempotencyKey` gives the send a stable identity across retries. The send-options key wins when both are set; the message field is the fallback. Only Resend transmits it natively — see [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys) for per-adapter behavior.
+`idempotencyKey` gives the send a stable identity across retries. The send-options key wins when both are set; the message field is the fallback. Resend, JetEmail, Lettermint, and Primitive transmit it to the provider as an `Idempotency-Key` header, and SMTP uses it as the `Message-ID`. See [idempotency keys](/docs/concepts/fallbacks-and-retries#idempotency-keys) for per-adapter behavior.
 
 ## Validation
 
@@ -171,4 +171,4 @@ Adapters add a second fail-fast layer for fields their provider cannot represent
 smtp does not support these EmailMessage fields: tags, metadata.
 ```
 
-That error fires before any request — fields are rejected, never silently dropped. The per-adapter availability of `cc`, `bcc`, `replyTo`, `headers`, `attachments`, `tags`, and `metadata` is the [field support matrix](/docs/adapters/field-support).
+That error fires before any request: fields are rejected rather than silently dropped. The per-adapter availability of `cc`, `bcc`, `replyTo`, `headers`, `attachments`, `tags`, and `metadata` is the [field support matrix](/docs/adapters/field-support).

--- a/packages/email-sdk/README.md
+++ b/packages/email-sdk/README.md
@@ -1,6 +1,6 @@
 # Email SDK
 
-A lightweight TypeScript SDK for transactional email send pipelines. Use one typed client, pick the adapters your app actually sends through, validate provider compatibility before data is silently dropped, add retries and fallback routes, and use plugins for defaults, observability, capture, or community providers.
+A lightweight TypeScript SDK for transactional email send pipelines. One typed client, adapters for the providers your app actually sends through, compatibility validation before data is silently dropped, retries and fallback routes, and plugins for defaults, observability, capture, or community providers.
 
 Docs: https://email-sdk.dev/docs
 
@@ -89,6 +89,7 @@ Available adapter entry points:
 | `@opencoredev/email-sdk/loops`      | Loops                            |
 | `@opencoredev/email-sdk/sequenzy`   | Sequenzy                         |
 | `@opencoredev/email-sdk/jetemail`   | JetEmail                         |
+| `@opencoredev/email-sdk/lettermint` | Lettermint                       |
 | `@opencoredev/email-sdk/primitive`  | Primitive                        |
 | `@opencoredev/email-sdk/plunk`      | Plunk                            |
 | `@opencoredev/email-sdk/mailtrap`   | Mailtrap                         |


### PR DESCRIPTION
Closes #105

## What this does

A full pass over every current docs page (`apps/fumadocs/content/docs/**`) and both READMEs, with two goals: make the docs read like a maintainer wrote them, and fix everything the docs get wrong about the code. All claims were verified against `packages/email-sdk/src` (types.ts, core.ts, utils.ts, every adapter, cli.ts) and `packages/convex-email`. Routes, slugs, meta.json, versioned doc archives, the blog, and generated files are untouched.

## Factual errors corrected

- **Adapter counts were stale everywhere.** The landing page said "20 providers", the adapters index said "22 adapters", the adapter-contract reference said "the 20 adapters". The package exports 23 adapters; every count now says 23.
- **"Resend is the only adapter that transmits idempotency keys natively" was false on three pages** (fallbacks-and-retries, message reference, production pipeline, create-adapter guide). JetEmail, Lettermint, and Primitive also forward `Idempotency-Key`; all four are now listed, along with SMTP's `Message-ID` behavior.
- **The routing-name list in the adapter model omitted `jetemail`, `lettermint`, and `primitive`.**
- **The auth page claimed every adapter accepts `baseUrl`/`headers`/`fetch`.** Only five adapters take `headers`, and SMTP takes none of the three; the section now says which adapters take what.
- **Field-support matrix:** Unosend and SparkPost were marked as sending tag *values only*, but both preserve full name/value pairs.
- **Both READMEs were missing Lettermint from their adapter lists, and the root README also dropped AWS SES.** The message reference now names Lettermint among single-tag providers, and the Lettermint page clarifies its 50-recipient cap is provider-side, not adapter-checked.
- The Convex page now says the component supports 20 provider *kinds* (it does not wrap jetemail/lettermint/primitive yet), instead of implying it covers every SDK adapter.

## Slop removed

- The identical template opener ("calls the X API over `fetch` — no extra dependency") and closer ("Drop `--dry-run` for one real send — that is the only check that proves…") stamped across all 23 adapter pages. Each page keeps a uniform one-line opener (endpoint plus `fetch`), puts the provider's actual quirks in the sentence right after it, and closes with what a live send specifically proves for that provider.
- Em-dash chains (several per paragraph, sitewide), "never X" tailing negations ("routes are explicit, never guessed"), bold-lead marketing bullets on the landing page, and stock fragments like "that distinction is the whole design".
- Where a punchy fragment carried real information, it was rewritten as a full sentence with the reasoning kept (e.g. why fail-fast field validation beats silent drops).

## Review fixes

Follow-up commit addressing adversarial-review findings:

- **CLI reference tables were missing `jetemail`, `lettermint`, and `primitive`** in both the adapters/env table and the credential-flags table, which also made the auto-detection order wrong. Both tables now match `cli.ts` row for row (jetemail/lettermint/primitive sit between `sequenzy` and `plunk` in detection order; Lettermint gets its own flags row for `--api-token`/`--base-url`/`--route`).
- The authentication page's fallback example registered Resend and SES but never set `fallback: ["ses"]`, leaving SES as dead code. Fixed.
- Six adapter pages (jetemail, lettermint, primitive, sequenzy, unosend, zeptomail) shared a near-identical "one real smoke send to prove X and Y" closer. Each is now specific to the provider: route resolution for Lettermint, `accepted`/`rejected` and async delivery for Primitive, `jobId` and slug lookup for Sequenzy, Mail Agent scoping for ZeptoMail, and so on.
- README line 26 still had an em-dash + "never" construction; rewritten plainly.
- A cadence pass on `components/convex-email.mdx` and `guides/production-send-pipeline.mdx`, where several sentences were the old em-dash constructions with a semicolon swapped in. The most conspicuous ones were restructured into genuinely different sentences.

## Merge with main + new feature docs

Main moved a lot under this branch (#126 delivery status tracking, #125 recipient variables, #127 scheduled sends, #121 fumadocs README, #120/#122 AGENTS.md, #129 Homebrew). The merge keeps main's feature facts and this PR's prose:

- **field-support.mdx**: kept the corrected tag columns (Unosend/SparkPost = full name/value) and took main's new *Send at* column; the whole matrix re-verified cell-for-cell against `SUPPORTED_MESSAGE_FIELDS` in `utils.ts`.
- **Feature docs rewritten into the overhaul voice** (facts unchanged): the recipient-variables and scheduled-sends sections in `reference/message.mdx`, the batch sections on the Mailgun/SendGrid pages, the `sendAt` sentences on all seven scheduling adapters, and the delivery-tracking + `setConfig`-replace sections on the Convex page (severity/Type-gated bounce mapping and sticky semantics verified against `lib.ts`/`worker.ts`).
- **New features got findable homes**: cross-links from the quickstart and landing page, `sendBulk` documented in the adapter contract, `all_recipients_failed` added to the errors page, per-recipient idempotency-key suffixing noted in fallbacks-and-retries, and the per-recipient `afterSend`/`onError` firing exception noted on the hooks page. The Iterable page now distinguishes its adapter-config `sendAt` from the rejected message-level field.

## Greptile P2 fixes

- **Tag semantics**: the field-support legend and the message reference now say which one-tag provider keeps what — Postmark sends a joined `name:value` string, Mailtrap and Lettermint forward only the value (verified against all three adapter sources).
- **OG cache window** (`apps/fumadocs/README.md`): already accurate on main as merged — the table, "How it works", and "Publishing cadence" all state the `/og/blog/*` `max-age=86400` (~1 day) window separately from the ~60s blog pages. No change needed.

## Telemetry pre-integration

Both READMEs already carry the telemetry disclosure section from the telemetry branch, rewritten in this PR's voice with identical facts (collected properties including recipient-variables/scheduling usage and delivery path, redaction rules, `~/.config/email-sdk/telemetry.json`, `EMAIL_SDK_TELEMETRY=0` / `DO_NOT_TRACK=1` / `telemetry: false` / `NODE_ENV=test` opt-outs), so the post-merge rebase for that PR is near-clean. `privacy.tsx` is untouched here and merges cleanly from that branch. README feature lists now mention batch personalization and scheduled sends.

## Validation

- `bun run types:check` in `apps/fumadocs` (fumadocs-mdx + tsc): passes.
- `bun run build` in `apps/fumadocs`: exit 0, all doc routes prerender.
- Field-support matrix re-derived from `SUPPORTED_MESSAGE_FIELDS` in `utils.ts`; CLI tables re-checked against `cli.ts` after the review fixes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
