### PR TITLE
Fix parallel package publish race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
           commit: "Version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+          EMAIL_SDK_RELEASE_PREBUILT: "1"
 
       - name: Annotate release in PostHog
         if: steps.changesets.outputs.published == 'true'

--- a/packages/convex-email/package.json
+++ b/packages/convex-email/package.json
@@ -83,7 +83,7 @@
     "build": "rm -rf dist && tsc -p tsconfig.json",
     "check-types": "tsc -p tsconfig.json --noEmit",
     "test": "bun test",
-    "prepack": "bun run build"
+    "prepack": "if [ \"${EMAIL_SDK_RELEASE_PREBUILT:-0}\" = \"1\" ]; then test -f dist/client/index.js; else bun run build; fi"
   },
   "devDependencies": {
     "@opencoredev/email-sdk": "workspace:*",


### PR DESCRIPTION
Prevents Convex Email from rebuilding during the Changesets publish step after `release:ci` has already produced and validated its tarball. This avoids racing Email SDK's concurrent prepack rebuild while preserving normal local `npm pack` behavior.

Validation:
- `bun run release:ci`
- prebuilt Convex pack succeeds with `packages/email-sdk/dist` removed
- normal Convex prepack rebuild succeeds when `dist` is absent