### PR TITLE
docs(site): archive v1.0.0 docs

### DIFF
--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/brevo.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/brevo.mdx
@@ -1,0 +1,93 @@
+---
+title: Brevo
+description: Send through the Brevo transactional email API with full field support and metadata mapped to template params.
+icon: brevo
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | Yes | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Brevo adapter calls the [Brevo transactional email API](https://developers.brevo.com/reference/sendtransacemail) with plain `fetch`. It authenticates with Brevo's `api-key` header (not a Bearer token), supports every common field, and maps `metadata` to Brevo's `params`, the same values Brevo templates substitute.
+
+<ProviderBadge adapter="brevo" />
+
+## Configure
+
+Create an API key under [SMTP & API in the Brevo dashboard](https://app.brevo.com/settings/keys/api) and verify the sender or domain you use in `from`.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { brevo } from "@opencoredev/email-sdk/brevo";
+
+export const email = createEmailClient({
+  adapters: [brevo({ apiKey: process.env.BREVO_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Brevo API key, sent as the api-key request header.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.brevo.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Brevo maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata` (as `params`). `replyTo` accepts a single address; two or more throw an `EmailValidationError` before any request. `sendAt` maps to Brevo's `scheduledAt` (ISO 8601), so scheduling happens on Brevo's side. Brevo accepts at most 72 hours in the future.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  replyTo: "support@acme.com",
+  subject: "You're invited to the Acme workspace",
+  html: "<p>Ada invited you to join the Acme workspace.</p>",
+  metadata: { workspaceId: "ws_123" },
+  tags: [{ name: "type", value: "invite" }],
+});
+
+console.log(result.id); // Brevo messageId
+```
+
+The response `id` is Brevo's `messageId` (falling back to the provider's `id` field). Match it against events in Brevo's logs and webhooks.
+
+<Callout type="warn" title="Metadata becomes template params">
+  `metadata` is sent as Brevo `params`, the values Brevo substitutes into templates. If you use
+  Brevo template syntax in your content, pick metadata keys that don't collide with template
+  placeholders.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+BREVO_API_KEY="xkeysib-..." npx email-sdk doctor --adapter brevo
+```
+
+```bash
+BREVO_API_KEY="xkeysib-..." npx email-sdk send \
+  --adapter brevo \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Brevo smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real send to confirm the key, sender verification, and recipient policy end to end.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/capability-groups.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/capability-groups.mdx
@@ -1,0 +1,50 @@
+---
+title: Delivery capabilities
+sidebarTitle: Capabilities
+description: Decide when an adapter can preserve repeated headers, idempotency, scheduled delivery, or personalized fanout.
+---
+
+Field support answers whether an adapter can represent a message field. Capabilities answer how delivery behaves when retries, duplicate risk, timing, or recipient fanout matter.
+
+## Choose by delivery requirement
+
+- Preserve repeated header names with adapters whose `repeatedHeaders` capability is `true`; duplicate names survive instead of failing validation.
+- Use provider-side idempotency when `idempotency` is `native`; `message_id` means SMTP derives a stable `Message-ID`, but the SMTP server still decides deduplication.
+- Use provider-side scheduled delivery when `scheduling` is `true`; `sendAt` is translated to the provider, and the SDK never waits or queues.
+- Use one native personalized request when `personalized` is `native`; every other built-in adapter expands personalized delivery into deterministic sequential one-recipient sends.
+
+<AdapterCapabilitySupport />
+
+Every fallback candidate must preserve the message's fields and required delivery capabilities. No built-in adapter silently ignores an unsupported capability.
+
+## Scheduling is not a queue
+
+Use `sendAt` for a simple future send when the selected provider supports the required time window. Use a durable scheduler or workflow when you need provider independence, long horizons, cancellation, rescheduling, persisted state, or recovery after process failure.
+
+A cron job is only a polling implementation. If an application uses one, store due jobs in a database, claim them with a lease or transaction, and pass a stable idempotency key to `email.send`. Do not keep timers or a cron loop inside Email SDK.
+
+## Idempotency does not make fallback exactly once
+
+One key cannot guarantee exactly-once delivery across different providers. When a provider returns `delivery: "unknown"`, v1 stops fallback by default because a second provider may create a duplicate.
+
+```ts title="src/email.ts"
+const email = createEmailClient({
+  adapters: [primary, backup],
+  fallback: {
+    adapters: ["backup"],
+    onUnknownDelivery: "stop",
+  },
+});
+```
+
+## Validate the complete route
+
+Validate before a durable queue accepts the job:
+
+```ts title="src/jobs/enqueue-email.ts"
+await email.validate(message, {
+  fallback: { adapters: ["backup"] },
+});
+```
+
+Use [Field support](/docs/adapters/field-support) for address, attachment, tag, metadata, and scheduling field compatibility, and [Production pipeline](/docs/guides/production-send-pipeline) for queueing and recovery boundaries.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/cloudflare.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/cloudflare.mdx
@@ -1,0 +1,103 @@
+---
+title: Cloudflare Email Sending
+description: Send through Cloudflare's Email Sending REST API with plain-address recipients and a 50-recipient cap.
+icon: cloudflare
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Cloudflare adapter calls Cloudflare's Email Sending REST API with plain `fetch`, so no Worker binding is required. It is the natural pick when your sending domain already lives in Cloudflare. The trade-off is strict recipient rules: plain addresses only, 50 recipients max.
+
+<ProviderBadge adapter="cloudflare" />
+
+## Configure
+
+Enable Email Sending for your account and domain, then create an [API token](https://dash.cloudflare.com/profile/api-tokens) with Email Sending permission. You also need your account ID.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { cloudflare } from "@opencoredev/email-sdk/cloudflare";
+
+export const email = createEmailClient({
+  adapters: [
+    cloudflare({
+      apiToken: process.env.CLOUDFLARE_API_TOKEN!,
+      accountId: process.env.CLOUDFLARE_ACCOUNT_ID!,
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    apiToken: {
+      description: "Cloudflare API token with Email Sending permission.",
+      type: "string",
+      required: true,
+    },
+    accountId: {
+      description: "Cloudflare account ID used in the send endpoint path.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.cloudflare.com/client/v4"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Cloudflare maps `cc`, `bcc`, one `replyTo`, `headers`, and `attachments`. There are no tags or metadata.
+
+```ts
+const result = await email.send({
+  from: "Acme Alerts <alerts@acme.com>",
+  to: "oncall@example.com",
+  cc: "ops@example.com",
+  subject: "Disk usage above 90% on db-1",
+  text: "db-1 crossed the 90% disk threshold at 14:02 UTC.",
+  headers: [{ name: "X-Alert-ID", value: "alrt_8841" }],
+});
+
+console.log(result.accepted); // delivered + queued recipients
+```
+
+Cloudflare does not return a message id; instead `result.accepted` lists delivered and queued recipients and `result.rejected` lists permanent bounces. Total recipients across `to`, `cc`, and `bcc` are capped at 50.
+
+<Callout type="warn" title="Plain recipient addresses only">
+  `to`, `cc`, and `bcc` must be bare addresses like `"user@example.com"`; a display name throws an
+  `EmailValidationError` before any request is made. Only `from` and `replyTo` keep display names.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+CLOUDFLARE_API_TOKEN="..." CLOUDFLARE_ACCOUNT_ID="..." npx email-sdk doctor --adapter cloudflare
+```
+
+```bash
+npx email-sdk send \
+  --adapter cloudflare \
+  --api-token "$CLOUDFLARE_API_TOKEN" \
+  --account-id "$CLOUDFLARE_ACCOUNT_ID" \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Cloudflare smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real send; only Cloudflare can prove the domain and account are cleared to deliver.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/field-support.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/field-support.mdx
@@ -1,0 +1,49 @@
+---
+title: Field support
+description: Source-derived support for normalized message fields across all built-in adapters.
+---
+
+Use this page to eliminate incompatible routes before sending. A primary adapter and every fallback must support every normalized field your message uses; Email SDK validates the complete route before the first request, so an incompatible backup fails early instead of dropping data.
+
+Field support answers whether an adapter can represent a message field. Use [Delivery capabilities](/docs/adapters/capability-groups) when retries, idempotency, scheduled delivery, repeated headers, or personalized fanout matter.
+
+## Normalized message fields
+
+<AdapterFieldSupport />
+
+The comparison is source-derived from `SUPPORTED_MESSAGE_FIELDS` and adapter validation rules. Unsupported values are rejected by both `validate` and `send` before a provider call.
+
+## Route selection
+
+Pick the narrowest route that preserves the message you are actually sending. If a fallback cannot support one of the fields, remove that fallback for this send or normalize the message before it enters the route.
+
+For provider-specific option fields, payload notes, and credentials, open the linked adapter setup page from the comparison above.
+
+## Headers
+
+`headers` is a lossless array in v1, so repeated names stay visible to adapters that support repeated headers.
+
+```ts title="src/message.ts"
+const headers = [
+  { name: "X-Trace", value: "first" },
+  { name: "X-Trace", value: "second" },
+] as const;
+```
+
+Repeated names require every candidate adapter to advertise repeated-header support in [Delivery capabilities](/docs/adapters/capability-groups). Otherwise validation fails before the primary sends.
+
+## Attachments
+
+Each attachment has exactly one source: `content` or `path`. A string `content` value is raw by default; set `contentEncoding: "base64"` only when the string is already encoded.
+
+```ts title="src/message.ts"
+const attachments = [
+  {
+    filename: "receipt.txt",
+    content: "Order 123",
+    contentType: "text/plain",
+  },
+] as const;
+```
+
+See the [message reference](/docs/reference/message) for the exact v1 message and attachment types.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/index.mdx
@@ -1,0 +1,48 @@
+---
+title: Adapters
+description: Configure one of 22 provider API adapters or the built-in SMTP transport, 23 adapters total.
+---
+
+<ProviderGrid />
+
+## Compare support
+
+| Requirement | Check first |
+| --- | --- |
+| CC, BCC, reply-to, attachments, tags, or metadata | [Field support](/docs/adapters/field-support) |
+| Repeated headers, scheduled delivery, native idempotency, or personalized fanout | [Delivery capabilities](/docs/adapters/capability-groups) |
+| Existing SMTP service | [SMTP](/docs/adapters/smtp) |
+
+## Add more than one provider
+
+```ts title="src/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+export const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      name: "backup",
+      host: process.env.SMTP_HOST!,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+  fallback: { adapters: ["backup"] },
+});
+```
+
+Email SDK checks every fallback before sending. If your backup cannot handle part of the message, you get an error instead of a half-broken email.
+
+## Check your setup without sending
+
+```bash
+npx email-sdk adapters
+npx email-sdk doctor --adapter resend
+```
+
+`doctor` checks your credentials and required settings. `send --dry-run` checks the whole message without sending it.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/iterable.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/iterable.mdx
@@ -1,0 +1,115 @@
+---
+title: Iterable
+description: Trigger an Iterable campaign template for one recipient, with message content delivered as dataFields.
+icon: iterable
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Iterable adapter calls [Iterable's target email API](https://api.iterable.com/api/docs) with plain `fetch`. It works differently from most adapters: instead of sending raw content, it triggers an existing campaign template for exactly one recipient and hands your message to the template as `dataFields`.
+
+<ProviderBadge adapter="iterable" />
+
+## Configure
+
+Create a server-side API key in Iterable and copy the campaign ID of the template you want to trigger.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { iterable } from "@opencoredev/email-sdk/iterable";
+
+export const email = createEmailClient({
+  adapters: [
+    iterable({
+      apiKey: process.env.ITERABLE_API_KEY!,
+      campaignId: Number(process.env.ITERABLE_CAMPAIGN_ID!),
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Iterable API key.",
+      type: "string",
+      required: true,
+    },
+    campaignId: {
+      description:
+        "Campaign whose template renders the email. Non-numeric values throw an EmailValidationError when the adapter is created.",
+      type: "number",
+      required: true,
+    },
+    allowRepeatMarketingSends: {
+      description: "Forwarded to Iterable to allow re-sending a marketing campaign to the same user.",
+      type: "boolean",
+    },
+    dataFields: {
+      description:
+        "Extra template fields, as a static object or a function of the message. Merged in before the normalized fields, so subject/html/text/from win on conflicts.",
+      type: "Record<string, unknown> | (message) => Record<string, unknown>",
+    },
+    sendAt: {
+      description:
+        "Schedule the send. UTC timestamp in Iterable's expected format. This adapter option is separate from the message-level sendAt field, which Iterable rejects.",
+      type: "string",
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.iterable.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+The campaign template renders the email. The adapter passes `subject`, `html`, `text`, and `from` into `dataFields` so the template can use them, and forwards `metadata` as Iterable webhook metadata.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Your trial ends in 3 days",
+  html: "<p>Upgrade to keep your workspace.</p>",
+  metadata: { userId: "user_123" },
+});
+
+console.log(result.raw); // Iterable returns no message id; inspect the raw response
+```
+
+<Callout type="warn" title="One recipient, template-only fields">
+  Iterable target sends accept exactly one `to` recipient and no `cc`, `bcc`, `replyTo`, `headers`,
+  `attachments`, or `tags`. Any of those throw an `EmailValidationError` before a request is made.
+  Check [field support](/docs/adapters/field-support) before routing fallbacks through Iterable.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+ITERABLE_API_KEY="..." ITERABLE_CAMPAIGN_ID="12345" npx email-sdk doctor --adapter iterable
+```
+
+```bash
+ITERABLE_API_KEY="..." npx email-sdk send \
+  --adapter iterable \
+  --campaign-id 12345 \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Iterable smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+`--campaign-id` and `--iterable-send-at` override `ITERABLE_CAMPAIGN_ID` and `ITERABLE_SEND_AT`. Iterable's adapter option is separate from the message-level `--send-at` flag because this adapter does not support Email SDK scheduled messages. Drop `--dry-run` to trigger one real campaign send and confirm the API key and campaign are live.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/jetemail.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/jetemail.mdx
@@ -1,0 +1,109 @@
+---
+title: JetEmail
+description: Send through the JetEmail transactional API with CC, BCC, reply-to, custom headers, base64 attachments, and idempotent retries.
+icon: jetemail
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `native` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The JetEmail adapter calls JetEmail's transactional `POST /email` endpoint with plain `fetch`. JetEmail runs its own sending infrastructure (anycast IPs, managed reputation), and the adapter maps the normalized `EmailMessage` straight onto its REST payload.
+
+<ProviderBadge adapter="jetemail" />
+
+## Configure
+
+Create a JetEmail **transactional** API key (prefixed `transactional_`) in the [JetEmail dashboard](https://dash.jetemail.com) and verify the domain you send `from`.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { jetemail } from "@opencoredev/email-sdk/jetemail";
+
+export const email = createEmailClient({
+  adapters: [jetemail({ apiKey: process.env.JETEMAIL_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "JetEmail transactional API key (prefixed transactional_).",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.jetemail.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+    headers: {
+      description: "Extra headers merged into every request.",
+      type: "Record<string, string>",
+    },
+  }}
+/>
+
+## Send
+
+JetEmail accepts up to 50 recipients each across `to`, `cc`, and `bcc`, and maps `headers` to custom email headers. Attachments are base64-encoded automatically (40MB total).
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  cc: "team@acme.com",
+  replyTo: "support@acme.com",
+  subject: "Welcome to Acme",
+  html: "<p>Thanks for joining Acme.</p>",
+  text: "Thanks for joining Acme.",
+});
+
+console.log(result.id); // JetEmail message id, e.g. "19424fd2acd0004210"
+```
+
+<Callout type="warn" title="From requires a display name">
+  JetEmail rejects a bare email in `from`; it requires the `"Name <email>"` form. The adapter
+  fails fast with an `EmailValidationError` when `from` has no display name, so pass
+  `from: "Acme <hello@acme.com>"` or `from: { email: "hello@acme.com", name: "Acme" }`.
+</Callout>
+
+<Callout type="warn" title="No tags or metadata">
+  JetEmail's send API has no tags or metadata field, so the adapter rejects `tags` and `metadata`
+  with an `EmailValidationError` before the request. Check [field
+  support](/docs/adapters/field-support) before using JetEmail in a fallback route.
+</Callout>
+
+## Idempotent sends
+
+Pass an `idempotencyKey` and the adapter forwards it as JetEmail's `Idempotency-Key` header, so a retried send with the same key and body replays the original response instead of sending twice.
+
+```ts
+await email.send(message, { idempotencyKey: "receipt:order_123" });
+```
+
+## Verify from the CLI
+
+```bash
+JETEMAIL_API_KEY="transactional_..." npx email-sdk doctor --adapter jetemail
+```
+
+```bash
+JETEMAIL_API_KEY="transactional_..." npx email-sdk send \
+  --adapter jetemail \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "JetEmail smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to send for real. The dry run already enforces JetEmail's local rules (the display-name requirement on `from`, the 50-address caps), so what a live send actually tests is the `transactional_` key and whether your sending domain is verified on JetEmail's side.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/lettermint.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/lettermint.mdx
@@ -1,0 +1,121 @@
+---
+title: Lettermint
+description: Send through Lettermint's European transactional email API with CC, BCC, reply-to, headers, metadata, tags, base64 attachments, idempotent retries, and routes.
+icon: lettermint
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `native` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Lettermint adapter calls Lettermint's `POST /v1/send` endpoint with plain `fetch`. [Lettermint](https://lettermint.co/?ref=emailsdk) is a European transactional email service with a REST API, SMTP relay, routes, and built-in open/click tracking. The adapter maps the normalized `EmailMessage` straight onto its send payload and authenticates with the `x-lettermint-token` header.
+
+<ProviderBadge adapter="lettermint" />
+
+## Configure
+
+Create a Lettermint API token (prefixed `lm_`) for the project you send from, and verify the sending domain.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { lettermint } from "@opencoredev/email-sdk/lettermint";
+
+export const email = createEmailClient({
+  adapters: [lettermint({ apiToken: process.env.LETTERMINT_API_TOKEN! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiToken: {
+      description: "Lettermint API token (prefixed lm_), sent in the x-lettermint-token header.",
+      type: "string",
+      required: true,
+    },
+    route: {
+      description: "Optional Lettermint route slug. Defaults to the project's default route.",
+      type: "string",
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.lettermint.co/v1"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+    headers: {
+      description: "Extra headers merged into every request.",
+      type: "Record<string, string>",
+    },
+  }}
+/>
+
+## Send
+
+Lettermint accepts multiple recipients, CC, BCC, reply-to, custom headers, metadata, and attachments. Attachments are base64-encoded automatically.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome to Acme",
+  html: "<p>Thanks for joining Acme.</p>",
+  text: "Thanks for joining Acme.",
+});
+
+console.log(result.id); // Lettermint message_id
+```
+
+<Callout type="warn" title="One tag per message">
+  Lettermint represents a single freeform `tag` per email. The adapter sends the first tag's value
+  and fails fast with an `EmailValidationError` if a message carries more than one tag. Metadata
+  values are coerced to strings to match Lettermint's metadata shape.
+</Callout>
+
+<Callout title="From a verified sending domain">
+  The sender domain in `from` must be verified for your Lettermint project. Lettermint also caps a
+  message at 50 recipients across `to`, `cc`, and `bcc` combined; the adapter does not pre-check
+  this, so an oversized send fails at the API.
+</Callout>
+
+## Idempotent sends
+
+Pass an `idempotencyKey` and the adapter forwards it as Lettermint's `Idempotency-Key` header, so a retried send with the same key replays the original result instead of sending twice.
+
+```ts
+await email.send(message, { idempotencyKey: "receipt:order_123" });
+```
+
+## Routes
+
+Lettermint routes separate transactional and broadcast streams. Pass a `route` to target a specific one; omit it to use the project's default route.
+
+```ts
+const email = createEmailClient({
+  adapters: [lettermint({ apiToken: process.env.LETTERMINT_API_TOKEN!, route: "transactional" })],
+});
+```
+
+## Verify from the CLI
+
+```bash
+LETTERMINT_API_TOKEN="lm_..." npx email-sdk doctor --adapter lettermint
+```
+
+```bash
+LETTERMINT_API_TOKEN="lm_..." npx email-sdk send \
+  --adapter lettermint \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Lettermint smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to send for real. Route resolution only happens on Lettermint's end, so this doubles as your route check: a live send with `LETTERMINT_ROUTE` set proves that slug exists, and one without it proves your project's default route works.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/loops.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/loops.mdx
@@ -1,0 +1,105 @@
+---
+title: Loops
+description: Trigger a published Loops transactional email for one recipient, with metadata delivered as dataVariables.
+icon: loops
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Loops adapter calls the [Loops transactional API](https://loops.so/docs/api-reference/send-transactional-email) with plain `fetch`. It triggers a published transactional email by `transactionalId` for exactly one recipient and hands your message to the template as `dataVariables`.
+
+<ProviderBadge adapter="loops" />
+
+## Configure
+
+Create an API key in Loops with permission to send transactional email, then publish the transactional email and copy its `transactionalId`.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { loops } from "@opencoredev/email-sdk/loops";
+
+export const email = createEmailClient({
+  adapters: [
+    loops({
+      apiKey: process.env.LOOPS_API_KEY!,
+      transactionalId: process.env.LOOPS_TRANSACTIONAL_ID!,
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Loops API key.",
+      type: "string",
+      required: true,
+    },
+    transactionalId: {
+      description: "Published transactional email to render. Must be non-empty; the adapter throws at construction otherwise.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://app.loops.so"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+The Loops template renders the email. The adapter merges `subject`, `html`, `text`, `from`, and every `metadata` key into `dataVariables`; your template decides which of them appear. Exactly one `to` recipient is allowed per send.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Reset your password",
+  html: "<p>Use the button below to reset your password.</p>",
+  metadata: {
+    firstName: "Ada",
+    resetUrl: "https://acme.com/reset/abc123",
+  },
+});
+
+console.log(result.id); // Loops id (or transactionalId) from the response
+```
+
+Attachments are supported and sent as `{ filename, contentType, data }` with base64-encoded content.
+
+<Callout type="warn" title="Attachments need account enablement">
+  Loops only accepts transactional attachments on accounts where the capability has been enabled.
+  Without it, sends with attachments fail at the API. Also note `cc`, `bcc`, `replyTo`, `headers`,
+  and `tags` throw an `EmailValidationError` before any request; see
+  [field support](/docs/adapters/field-support).
+</Callout>
+
+## Verify from the CLI
+
+```bash
+LOOPS_API_KEY="..." LOOPS_TRANSACTIONAL_ID="cm..." npx email-sdk doctor --adapter loops
+```
+
+```bash
+LOOPS_API_KEY="..." LOOPS_TRANSACTIONAL_ID="cm..." npx email-sdk send \
+  --adapter loops \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Loops smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to trigger one real template send and confirm the API key and published transactional email are live.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/mailchimp.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/mailchimp.mdx
@@ -1,0 +1,92 @@
+---
+title: Mailchimp Transactional
+description: Send through Mailchimp Transactional (Mandrill) with typed recipients, tags, and metadata, but no replyTo field.
+icon: mailchimp
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | Yes | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Mailchimp adapter calls the [Mailchimp Transactional API](https://mailchimp.com/developer/transactional/api/messages/send-new-message/), the API formerly known as Mandrill, with plain `fetch`. Unusually, the API key travels in the request body rather than a header, and recipients are a single typed list (`to`/`cc`/`bcc` entries) instead of separate arrays.
+
+<ProviderBadge adapter="mailchimp" />
+
+## Configure
+
+Create a Transactional API key in the Mandrill dashboard (Settings → SMTP & API Info) and verify your sending domain.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailchimp } from "@opencoredev/email-sdk/mailchimp";
+
+export const email = createEmailClient({
+  adapters: [mailchimp({ apiKey: process.env.MAILCHIMP_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Mailchimp Transactional (Mandrill) API key, sent in the request body.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://mandrillapp.com/api/1.0"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Mailchimp maps `cc`, `bcc`, `headers`, `attachments`, `tags` (values only), and `metadata`. `sendAt` maps to Mailchimp's `send_at` (a UTC timestamp), and Mailchimp only schedules email for accounts with a positive balance.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  subject: "Your order has shipped",
+  html: "<p>Order ord_123 is on its way.</p>",
+  metadata: { orderId: "ord_123" },
+  tags: [{ name: "type", value: "shipping" }],
+});
+
+console.log(result.id); // Mandrill _id of the first recipient result
+```
+
+Mandrill responds with one result per recipient; the normalized `id` comes from the first result's `_id`. Each result also carries a per-recipient status (`sent`, `queued`, `rejected`). If a send succeeds but mail does not arrive, check `result.raw` during smoke tests, because a `rejected` status still counts as a successful API call.
+
+<Callout type="warn" title="No replyTo field">
+  This adapter does not support `replyTo`; setting it throws an `EmailValidationError` before
+  any request is made. Set a `Reply-To` header instead: `headers: [{ name: "Reply-To", value:
+  "support@acme.com" }]`. See [field support](/docs/adapters/field-support) for the full matrix.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+MAILCHIMP_API_KEY="md-..." npx email-sdk doctor --adapter mailchimp
+```
+
+```bash
+MAILCHIMP_API_KEY="md-..." npx email-sdk send \
+  --adapter mailchimp \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Mailchimp smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real send and check the per-recipient status in the output; Mandrill can accept the request and still reject the recipient.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/mailersend.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/mailersend.mdx
@@ -1,0 +1,93 @@
+---
+title: MailerSend
+description: Send through the MailerSend Email API with cc/bcc, headers, tags, attachments, and a single reply-to address.
+icon: mailersend
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | Yes | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The MailerSend adapter calls the [MailerSend Email API](https://developers.mailersend.com/api/v1/email.html) with plain `fetch`. Two quirks to know: MailerSend accepts exactly one reply-to address, and the message id comes back in the `x-message-id` response header rather than the body.
+
+<ProviderBadge adapter="mailersend" />
+
+## Configure
+
+Create an API token in the [MailerSend dashboard](https://app.mailersend.com/api-tokens) and verify the domain you plan to send from.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailersend } from "@opencoredev/email-sdk/mailersend";
+
+export const email = createEmailClient({
+  adapters: [mailersend({ apiKey: process.env.MAILERSEND_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "MailerSend API token, sent as a Bearer header.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.mailersend.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+MailerSend maps `cc`, `bcc`, `headers`, `attachments` (an attachment's `contentId` becomes MailerSend's `id`), and `tags` (values only). `replyTo` accepts a single address; two or more throw an `EmailValidationError` before any request. `sendAt` maps to `send_at` (a Unix timestamp in seconds), so MailerSend holds the message until then. It accepts at most 72 hours in the future.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  replyTo: "support@acme.com",
+  subject: "Reset your Acme password",
+  html: "<p>Click the link below to choose a new password.</p>",
+  tags: [{ name: "type", value: "password-reset" }],
+});
+
+console.log(result.id); // MailerSend message id from the x-message-id header
+```
+
+The response `id` comes from the `x-message-id` response header, falling back to `message_id` or `id` in the body. Use it to look the send up in MailerSend's activity log.
+
+<Callout type="warn" title="No metadata field">
+  MailerSend has no metadata concept, so `metadata` on a message throws an
+  `EmailValidationError` before any request is made. Use `tags` instead, or pick a
+  [metadata-capable adapter](/docs/adapters/field-support). MailerSend also gates custom
+  `headers` behind its Professional and Enterprise plans.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+MAILERSEND_API_KEY="mlsn..." npx email-sdk doctor --adapter mailersend
+```
+
+```bash
+MAILERSEND_API_KEY="mlsn..." npx email-sdk send \
+  --adapter mailersend \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "MailerSend smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real send. The token, domain verification, and plan limits only prove themselves against the live API.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/mailgun.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/mailgun.mdx
@@ -1,0 +1,122 @@
+---
+title: Mailgun
+description: "Send through the Mailgun Messages API with domain-scoped multipart sends, h:/v:/o: field mapping, and full field support."
+icon: mailgun
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| Yes | `none` | Yes | `native` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Mailgun adapter calls the [Mailgun Messages API](https://documentation.mailgun.com/docs/mailgun/api-reference/send/mailgun/messages/post-v3--domain-name--messages) with plain `fetch`. It is the one adapter that posts multipart form data instead of JSON, using Mailgun's prefixed field names: `h:` for headers, `v:` for metadata variables, `o:` for sending options. Every send is scoped to the `domain` you configure.
+
+<ProviderBadge adapter="mailgun" />
+
+## Configure
+
+Grab an API key from the [Mailgun dashboard](https://app.mailgun.com/settings/api_security) and note the sending domain it belongs to. Both are required.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailgun } from "@opencoredev/email-sdk/mailgun";
+
+export const email = createEmailClient({
+  adapters: [
+    mailgun({
+      apiKey: process.env.MAILGUN_API_KEY!,
+      domain: process.env.MAILGUN_DOMAIN!,
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Mailgun API key, sent as Basic auth (api:key).",
+      type: "string",
+      required: true,
+    },
+    domain: {
+      description: "Sending domain. Requests go to /v3/{domain}/messages.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for the EU region.",
+      type: "string",
+      default: '"https://api.mailgun.net"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+<Callout type="warn" title="EU domains need the EU base URL">
+  Domains created in Mailgun's EU region only respond on
+  `baseUrl: "https://api.eu.mailgun.net"`. Against the default US origin they fail with a 404.
+</Callout>
+
+## Send
+
+Mailgun maps every common field: `cc`, `bcc`, `replyTo`, `headers` (as `h:Name`), `attachments` (multipart `attachment`/`inline` parts by disposition), `tags` (values as `o:tag`), and `metadata` (as `v:key` variables, surfaced later in webhooks and logs). `sendAt` becomes a native scheduled send via `o:deliverytime` (RFC 2822); Mailgun accepts up to 3 days out on most plans, 7 with extended storage.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@mg.acme.com>",
+  to: "user@example.com",
+  replyTo: "support@acme.com",
+  subject: "Your receipt from Acme",
+  html: "<p>Thanks for your order.</p>",
+  metadata: { orderId: "ord_123" },
+  tags: [{ name: "type", value: "receipt" }],
+});
+
+console.log(result.id); // Mailgun message id
+```
+
+The response `id` is Mailgun's queued message id from the response body. Match it against delivery events in webhooks or the Mailgun logs.
+
+### Personalized sends
+
+Mailgun implements native `sendPersonalized`, so all recipients and variables travel in one request through Mailgun's `recipient-variables` field.
+
+```ts
+await email.sendPersonalized({
+  message: {
+    from: "Acme <hello@mg.acme.com>",
+    subject: "Hi %recipient.name%",
+    html: '<a href="https://acme.com/unsub?id=%recipient.id%">Unsubscribe</a>',
+  },
+  recipients: [
+    { to: "ada@example.com", variables: { name: "Ada", id: "u_1" } },
+    { to: "linus@example.com", variables: { name: "Linus", id: "u_2" } },
+  ],
+});
+```
+
+## Verify from the CLI
+
+```bash
+MAILGUN_API_KEY="key-..." MAILGUN_DOMAIN="mg.acme.com" \
+  npx email-sdk doctor --adapter mailgun
+```
+
+```bash
+MAILGUN_API_KEY="key-..." npx email-sdk send \
+  --adapter mailgun \
+  --domain mg.acme.com \
+  --from "Acme <hello@mg.acme.com>" \
+  --to user@example.com \
+  --subject "Mailgun smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Credentials also work as flags: `--api-key`, `--domain`, and `--base-url` (or `MAILGUN_BASE_URL`) override the environment. Drop `--dry-run` for one real send to prove the domain's DNS records and the account are actually ready.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/mailpace.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/mailpace.mdx
@@ -1,0 +1,89 @@
+---
+title: MailPace
+description: Send through the MailPace API, a deliberately minimal adapter for address fields and body content.
+icon: mailpace
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The MailPace adapter calls the [MailPace send API](https://docs.mailpace.com/reference/send) with plain `fetch`. It has the smallest adapter surface in the SDK: addresses, subject, and body only, with recipient lists serialized as comma-separated strings.
+
+<ProviderBadge adapter="mailpace" />
+
+## Configure
+
+Create a server token in the MailPace dashboard and verify the sending domain.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailpace } from "@opencoredev/email-sdk/mailpace";
+
+export const email = createEmailClient({
+  adapters: [mailpace({ apiKey: process.env.MAILPACE_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "MailPace server token, sent as the MailPace-Server-Token header.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://app.mailpace.com/api/v1"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+MailPace maps `cc`, `bcc`, and `replyTo` alongside `html`/`text` (sent as `htmlbody`/`textbody`). That is the whole surface, which makes it a good fit for sign-in alerts, receipts, and other plain notifications.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  replyTo: "support@acme.com",
+  subject: "New sign-in to your account",
+  text: "A new sign-in from Berlin, Germany was detected. If this was not you, reset your password.",
+});
+
+console.log(result.id); // MailPace message id (`id` or `message_id` in the response)
+```
+
+<Callout type="warn" title="No headers, attachments, tags, or metadata">
+  MailPace's send endpoint takes none of these, so any of them throws an `EmailValidationError`
+  before a request is made. Check your production message shape against the [field support
+  matrix](/docs/adapters/field-support) before routing through MailPace as a fallback.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+MAILPACE_API_KEY="..." npx email-sdk doctor --adapter mailpace
+```
+
+```bash
+MAILPACE_API_KEY="..." npx email-sdk send \
+  --adapter mailpace \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "MailPace smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real send to confirm the token and verified domain work end to end.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/mailtrap.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/mailtrap.mdx
@@ -1,0 +1,95 @@
+---
+title: Mailtrap
+description: Send through the Mailtrap Email Sending API with full field support and provider-side message inspection.
+icon: mailtrap
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Mailtrap adapter calls the [Mailtrap Email Sending API](https://api-docs.mailtrap.io/) with plain `fetch`. It supports every common transactional field, and Mailtrap's inspection tooling makes it a natural pick for staging environments.
+
+<ProviderBadge adapter="mailtrap" />
+
+## Configure
+
+Create a Mailtrap API token with Email Sending permission and verify your sending domain.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { mailtrap } from "@opencoredev/email-sdk/mailtrap";
+
+export const email = createEmailClient({
+  adapters: [mailtrap({ apiKey: process.env.MAILTRAP_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Mailtrap API token, sent as the Api-Token header.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://send.api.mailtrap.io"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Mailtrap maps `cc`, `bcc`, `headers`, `attachments`, `metadata`, and `tags`, with two limits: at most one tag (its value becomes the Mailtrap `category`) and at most one `replyTo`. `metadata` is sent as `custom_variables` with values stringified (`null` becomes `""`).
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  cc: "billing@acme.com",
+  replyTo: "support@acme.com",
+  subject: "Your receipt for order ord_123",
+  html: "<p>Thanks for your order. Receipt attached.</p>",
+  tags: [{ name: "type", value: "receipt" }],
+  metadata: { orderId: "ord_123" },
+  attachments: [
+    { filename: "receipt.pdf", path: "./receipts/ord_123.pdf" },
+  ],
+});
+
+console.log(result.id); // first entry of Mailtrap's message_ids
+```
+
+<Callout type="warn" title="One tag, one reply-to">
+  A second tag or a second `replyTo` throws an `EmailValidationError` before any request. Trim to
+  one of each when Mailtrap sits in a [fallback route](/docs/concepts/fallbacks-and-retries) behind
+  a multi-tag adapter.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+MAILTRAP_API_KEY="..." npx email-sdk doctor --adapter mailtrap
+```
+
+```bash
+MAILTRAP_API_KEY="..." npx email-sdk send \
+  --adapter mailtrap \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Mailtrap smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real smoke send, and confirm the token targets the intended Mailtrap project before pointing production at it.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/meta.json
@@ -1,0 +1,33 @@
+{
+  "title": "Adapters",
+  "icon": "MailAtSign",
+  "pages": [
+    "index",
+    "resend",
+    "sequenzy",
+    "jetemail",
+    "primitive",
+    "lettermint",
+    "postmark",
+    "sendgrid",
+    "cloudflare",
+    "unosend",
+    "ses",
+    "mailgun",
+    "mailersend",
+    "brevo",
+    "mailchimp",
+    "sparkpost",
+    "iterable",
+    "loops",
+    "plunk",
+    "mailtrap",
+    "scaleway",
+    "zeptomail",
+    "mailpace",
+    "smtp",
+    "field-support",
+    "capability-groups",
+    "verification"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/plunk.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/plunk.mdx
@@ -1,0 +1,94 @@
+---
+title: Plunk
+description: Send through the Plunk API with reply-to, headers, attachments, and metadata mapped to Plunk data.
+icon: plunk
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Plunk adapter calls the [Plunk send API](https://docs.useplunk.com) with plain `fetch`. Plunk takes a single `body` field, so the adapter sends `html` when present and falls back to `text`.
+
+<ProviderBadge adapter="plunk" />
+
+## Configure
+
+Create a secret API key in your Plunk project and verify the sender you plan to use in `from`.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { plunk } from "@opencoredev/email-sdk/plunk";
+
+export const email = createEmailClient({
+  adapters: [plunk({ apiKey: process.env.PLUNK_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Plunk secret API key.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://next-api.useplunk.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Plunk supports `headers`, `attachments`, `metadata` (sent as Plunk `data`), and a single `replyTo` (sent as `reply`, email address only; a second reply-to throws an `EmailValidationError`).
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  replyTo: "support@acme.com",
+  subject: "Your export is ready",
+  html: "<p>Download your workspace export below.</p>",
+  headers: [{ name: "X-Export-ID", value: "exp_123" }],
+  metadata: { exportId: "exp_123" },
+  attachments: [
+    { filename: "export.csv", content: "name,total\nAda,42", contentType: "text/csv" },
+  ],
+});
+
+console.log(result.id); // Plunk email id from data.emails[0], falling back to id/emailId
+```
+
+<Callout type="warn" title="No cc, bcc, or tags">
+  Plunk has no `cc`, `bcc`, or `tags`, so any of them on a message throws an
+  `EmailValidationError` before a request is made. Check
+  [field support](/docs/adapters/field-support) before using Plunk in a fallback route.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+PLUNK_API_KEY="sk_..." npx email-sdk doctor --adapter plunk
+```
+
+```bash
+PLUNK_API_KEY="sk_..." npx email-sdk send \
+  --adapter plunk \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Plunk smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real smoke send to confirm the API key and verified sender work end to end.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/postmark.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/postmark.mdx
@@ -1,0 +1,107 @@
+---
+title: Postmark
+description: Send through the Postmark Email API with message streams, metadata, and Postmark's single-tag model.
+icon: postmark
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| Yes | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Postmark adapter calls the [Postmark Email API](https://postmarkapp.com/developer/api/email-api) with plain `fetch`. Its distinctive feature is message streams: set `messageStream` once and every send routes through that Postmark stream.
+
+<ProviderBadge adapter="postmark" />
+
+## Configure
+
+Create a [server token](https://postmarkapp.com/developer/api/overview#authentication) for the server you send through, and make sure the sender signature or domain is approved in Postmark.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { postmark } from "@opencoredev/email-sdk/postmark";
+
+export const email = createEmailClient({
+  adapters: [
+    postmark({
+      serverToken: process.env.POSTMARK_SERVER_TOKEN!,
+      messageStream: "outbound",
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    serverToken: {
+      description: "Postmark server token.",
+      type: "string",
+      required: true,
+    },
+    messageStream: {
+      description: "Postmark message stream to send through.",
+      type: "string",
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.postmarkapp.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+    headers: {
+      description: "Extra HTTP headers sent with every request.",
+      type: "Record<string, string>",
+    },
+  }}
+/>
+
+## Send
+
+Postmark maps `cc`, `bcc`, `replyTo`, `headers`, `attachments`, `metadata`, and one tag.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  replyTo: "support@example.com",
+  subject: "Your receipt for order ord_123",
+  html: "<p>Thanks for your order.</p>",
+  metadata: { orderId: "ord_123" },
+  tags: [{ name: "type", value: "receipt" }],
+});
+
+console.log(result.id); // Postmark MessageID
+```
+
+`metadata` becomes Postmark `Metadata`, and `result.accepted` echoes Postmark's `To` line.
+
+<Callout type="warn" title="One tag per message">
+  Postmark has a single `Tag` field. The adapter serializes the first tag as `name:value` and a
+  second tag throws an `EmailValidationError` before any request is made. Need multiple tags?
+  Check the [field support matrix](/docs/adapters/field-support).
+</Callout>
+
+## Verify from the CLI
+
+```bash
+POSTMARK_SERVER_TOKEN="..." npx email-sdk doctor --adapter postmark
+```
+
+```bash
+POSTMARK_SERVER_TOKEN="..." npx email-sdk send \
+  --adapter postmark \
+  --message-stream outbound \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Postmark smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+The token also accepts the `--server-token` flag. Drop `--dry-run` for one real send to confirm the server token, sender signature, and message stream actually work together.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/primitive.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/primitive.mdx
@@ -1,0 +1,112 @@
+---
+title: Primitive
+description: Send through Primitive's email API for AI agents, with base64 attachments, idempotent retries, and fail-fast validation for fields it cannot represent.
+icon: primitive
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `native` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Primitive adapter calls Primitive's `POST /v1/send-mail` endpoint with plain `fetch`. [Primitive](https://www.primitive.dev) is email infrastructure for AI agents: a REST API for sending and receiving mail, with idempotency, typed errors, and an async delivery model. The adapter maps the normalized `EmailMessage` straight onto its send payload.
+
+<ProviderBadge adapter="primitive" />
+
+## Configure
+
+Create a Primitive API key (prefixed `prim_`) and verify the outbound domain you send `from`.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { primitive } from "@opencoredev/email-sdk/primitive";
+
+export const email = createEmailClient({
+  adapters: [primitive({ apiKey: process.env.PRIMITIVE_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Primitive API key (prefixed prim_) or OAuth access token (prefixed prim_oat_).",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.primitive.dev/v1"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+    headers: {
+      description: "Extra headers merged into every request.",
+      type: "Record<string, string>",
+    },
+  }}
+/>
+
+## Send
+
+Primitive's send API targets a single recipient and accepts `html`, `text`, and attachments. Attachments are base64-encoded automatically.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome to Acme",
+  html: "<p>Thanks for joining Acme.</p>",
+  text: "Thanks for joining Acme.",
+});
+
+console.log(result.id); // Primitive sent-email id
+```
+
+<Callout type="warn" title="One recipient, no CC or BCC">
+  Primitive's `send-mail` accepts exactly one recipient and has no CC or BCC field. The adapter
+  fails fast with an `EmailValidationError` when a message carries more than one recipient, `cc`, or
+  `bcc`, so route fan-out to multiple people as separate sends.
+</Callout>
+
+<Callout type="warn" title="No custom headers, tags, or metadata">
+  Primitive's send API has no custom-header, tags, or metadata field, so the adapter rejects
+  `headers`, `tags`, and `metadata` with an `EmailValidationError` before the request. Check [field
+  support](/docs/adapters/field-support) before using Primitive in a fallback route.
+</Callout>
+
+<Callout title="From a verified outbound domain">
+  The sender domain in `from` must be a verified outbound domain for your Primitive organization,
+  and recipient eligibility depends on your account's outbound entitlements.
+</Callout>
+
+## Idempotent sends
+
+Pass an `idempotencyKey` and the adapter forwards it as Primitive's `Idempotency-Key` header, so a retried send with the same key and body replays the original result instead of sending twice.
+
+```ts
+await email.send(message, { idempotencyKey: "receipt:order_123" });
+```
+
+## Verify from the CLI
+
+```bash
+PRIMITIVE_API_KEY="prim_..." npx email-sdk doctor --adapter primitive
+```
+
+```bash
+PRIMITIVE_API_KEY="prim_..." npx email-sdk send \
+  --adapter primitive \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Primitive smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to send for real. The single-recipient rule is checked locally, so the live send is really testing your `prim_` key and outbound domain. Check `accepted` and `rejected` in the response: Primitive queues delivery asynchronously, and those arrays tell you what it actually took.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/resend.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/resend.mdx
@@ -1,0 +1,102 @@
+---
+title: Resend
+description: Send through the Resend API with attachments, tags, and native idempotency keys.
+icon: resend
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `native` | Yes | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Resend adapter calls the [Resend Email API](https://resend.com/docs/api-reference/emails/send-email) with plain `fetch`. It is the default first adapter in these docs: setup is one API key, field support is broad, and it forwards [idempotency keys](/docs/concepts/sending-modes#idempotency) to the provider as the `Idempotency-Key` header, so Resend itself deduplicates retried sends.
+
+<ProviderBadge adapter="resend" />
+
+## Configure
+
+Grab an API key from the [Resend dashboard](https://resend.com/api-keys) and verify the domain you plan to send from.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+export const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Resend API key.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.resend.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+    headers: {
+      description: "Extra HTTP headers sent with every request.",
+      type: "Record<string, string>",
+    },
+  }}
+/>
+
+## Send
+
+Resend maps every common transactional field: `cc`, `bcc`, `replyTo`, `headers`, `attachments`, and `tags`. `sendAt` schedules the send on Resend's side, transmitted as `scheduled_at` in ISO 8601 form.
+
+```ts
+const result = await email.send(
+  {
+    from: "Acme <hello@acme.com>",
+    to: [{ email: "user@example.com", name: "Ada" }],
+    replyTo: "support@example.com",
+    subject: "Welcome to Acme",
+    html: "<p>Your workspace is ready.</p>",
+    tags: [{ name: "type", value: "welcome" }],
+    attachments: [
+      { filename: "welcome.txt", content: "Welcome to Acme.", contentType: "text/plain" },
+    ],
+  },
+  { idempotencyKey: "welcome:user_123" },
+);
+
+console.log(result.id); // Resend email id
+```
+
+The `idempotencyKey` is sent as Resend's `Idempotency-Key` header, so retried requests cannot double-send.
+
+<Callout type="warn" title="No metadata field">
+  Resend has no metadata concept, so `metadata` on a message throws an `EmailValidationError`
+  before any request is made. Use `tags` instead, or pick a [metadata-capable
+  adapter](/docs/adapters/field-support).
+</Callout>
+
+## Verify from the CLI
+
+```bash
+RESEND_API_KEY="re_..." npx email-sdk doctor --adapter resend
+```
+
+```bash
+RESEND_API_KEY="re_..." npx email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Resend smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to perform one real send from the environment that will send production email. Local validation cannot tell you whether the account, sender domain, and recipient policy are actually ready; one live send can.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/scaleway.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/scaleway.mdx
@@ -1,0 +1,109 @@
+---
+title: Scaleway
+description: Send through Scaleway Transactional Email with region-scoped endpoints and header-based reply-to.
+icon: scaleway
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| Yes | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Scaleway adapter calls the [Scaleway Transactional Email API](https://www.scaleway.com/en/developers/api/transactional-email/) with plain `fetch`. Sends are region-scoped: the adapter targets `/regions/{region}/emails` and defaults to `fr-par`.
+
+<ProviderBadge adapter="scaleway" />
+
+## Configure
+
+Create an IAM secret key in the Scaleway console, note your project ID, and verify the sending domain in Transactional Email.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { scaleway } from "@opencoredev/email-sdk/scaleway";
+
+export const email = createEmailClient({
+  adapters: [
+    scaleway({
+      secretKey: process.env.SCALEWAY_SECRET_KEY!,
+      projectId: process.env.SCALEWAY_PROJECT_ID!,
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    secretKey: {
+      description: "Scaleway IAM secret key, sent as the X-Auth-Token header.",
+      type: "string",
+      required: true,
+    },
+    projectId: {
+      description: "Scaleway project ID the emails belong to.",
+      type: "string",
+      required: true,
+    },
+    region: {
+      description: "Transactional Email region used in the endpoint path.",
+      type: "string",
+      default: '"fr-par"',
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.scaleway.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Scaleway maps `cc`, `bcc`, `replyTo`, `headers`, and `attachments`.
+
+```ts
+const result = await email.send({
+  from: "Acme <billing@acme.com>",
+  to: "user@example.com",
+  replyTo: "support@acme.com",
+  subject: "Your May invoice",
+  html: "<p>Invoice INV-2041 is attached.</p>",
+  attachments: [
+    { filename: "invoice.txt", content: "Invoice INV-2041: 49.00 EUR", contentType: "text/plain" },
+  ],
+});
+
+console.log(result.id); // Scaleway email id (`id` or `email_id` in the response)
+```
+
+`replyTo` travels as a `Reply-To` entry in Scaleway's `additional_headers`. Setting both `replyTo` and a manual `Reply-To` header throws an `EmailValidationError` before any request, so pick one.
+
+<Callout type="warn" title="No tags or metadata">
+  Scaleway has no tag or metadata concept, so either field throws an `EmailValidationError` before
+  any request is made. Pick a [tag-capable adapter](/docs/adapters/field-support) if you need them.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+SCALEWAY_SECRET_KEY="..." SCALEWAY_PROJECT_ID="..." npx email-sdk doctor --adapter scaleway
+```
+
+```bash
+SCALEWAY_SECRET_KEY="..." SCALEWAY_PROJECT_ID="..." npx email-sdk send \
+  --adapter scaleway \
+  --region fr-par \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Scaleway smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+`--region` falls back to the `SCALEWAY_REGION` env var, then `fr-par`. Drop `--dry-run` for one real send to prove the key, project, region, and sender domain line up.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/sendgrid.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/sendgrid.mdx
@@ -1,0 +1,105 @@
+---
+title: SendGrid
+description: Send through the Twilio SendGrid Mail Send API with the fullest field support of any adapter.
+icon: sendgrid
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | Yes | `native` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The SendGrid adapter calls the [Twilio SendGrid Mail Send API](https://www.twilio.com/docs/sendgrid/api-reference/mail-send/mail-send) with plain `fetch`. It supports every `EmailMessage` field: recipients land in a `personalizations` entry, `metadata` becomes `custom_args`, and tags become `categories`.
+
+<ProviderBadge adapter="sendgrid" />
+
+## Configure
+
+Create an API key with Mail Send permission in the [SendGrid dashboard](https://app.sendgrid.com/settings/api_keys) and verify the sender identity or domain you use in `from`.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sendgrid } from "@opencoredev/email-sdk/sendgrid";
+
+export const email = createEmailClient({
+  adapters: [sendgrid({ apiKey: process.env.SENDGRID_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "SendGrid API key with Mail Send permission.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.sendgrid.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Everything maps: `cc`, `bcc`, `headers`, `attachments`, `tags`, `metadata`, and even multiple `replyTo` addresses (sent as `reply_to_list`). `sendAt` schedules the send natively as `send_at` (a Unix timestamp in seconds); SendGrid accepts at most 72 hours in the future.
+
+```ts
+const result = await email.send({
+  from: "Acme <security@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  subject: "Reset your password",
+  html: "<p>Click the link below to reset your password.</p>",
+  text: "Use the link below to reset your password.",
+  metadata: { userId: "user_123", flow: "password-reset" },
+  tags: [{ name: "type", value: "password-reset" }],
+});
+
+console.log(result.id); // SendGrid message id from the x-message-id header
+```
+
+SendGrid's send endpoint returns `202 Accepted` with an empty body, so the adapter reads `result.id` from the `x-message-id` response header. `metadata` values arrive in SendGrid event webhooks as `custom_args`; tag values arrive as `categories`.
+
+### Personalized sends
+
+SendGrid implements native `sendPersonalized`, so the adapter emits one `personalizations` entry per recipient and sends the complete set in one request.
+
+```ts
+await email.sendPersonalized({
+  message: {
+    from: "Acme <hello@acme.com>",
+    subject: "Hi %recipient.name%",
+    html: '<a href="https://acme.com/unsub?id=%recipient.id%">Unsubscribe</a>',
+  },
+  recipients: [
+    { to: "ada@example.com", variables: { name: "Ada", id: "u_1" } },
+    { to: "linus@example.com", variables: { name: "Linus", id: "u_2" } },
+  ],
+});
+```
+
+## Verify from the CLI
+
+```bash
+SENDGRID_API_KEY="SG...." npx email-sdk doctor --adapter sendgrid
+```
+
+```bash
+SENDGRID_API_KEY="SG...." npx email-sdk send \
+  --adapter sendgrid \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "SendGrid smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real send. SendGrid account review and sender verification can block delivery even when the payload validates, and only a live send proves they are done.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/sequenzy.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/sequenzy.mdx
@@ -1,0 +1,112 @@
+---
+title: Sequenzy
+description: Send through the Sequenzy transactional API with metadata variables, template slugs, and URL or base64 attachments.
+icon: sequenzy
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Sequenzy adapter calls Sequenzy's transactional send endpoint with plain `fetch`. Its distinctive feature: reserved `metadata` keys switch a send from direct content to a Sequenzy template slug, so the same message shape covers both modes.
+
+<ProviderBadge adapter="sequenzy" />
+
+## Configure
+
+Create a Sequenzy API key and verify the sender domain or address you plan to use in `from`.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sequenzy } from "@opencoredev/email-sdk/sequenzy";
+
+export const email = createEmailClient({
+  adapters: [sequenzy({ apiKey: process.env.SEQUENZY_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Sequenzy API key.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.sequenzy.com/api/v1"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Sequenzy accepts up to 50 recipients and one `replyTo` per message. Flat `metadata` values become Sequenzy `variables`. Sequenzy has a single `body` field, so when a message carries both `html` and `text`, the adapter sends `html`. Omit `html` to send plain text.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  replyTo: "support@acme.com",
+  subject: "You've been invited to Acme",
+  html: "<p>Ada invited you to the Acme workspace.</p>",
+  metadata: { inviterName: "Ada", workspaceName: "Acme" },
+});
+
+console.log(result.id); // Sequenzy jobId; result.accepted lists the recipients Sequenzy took
+```
+
+Attachments work two ways: an `http(s)` `path` is forwarded as a Sequenzy URL attachment; anything else is encoded as base64 `content`.
+
+Reserved metadata keys map to provider fields instead of `variables`:
+
+| Metadata key                                             | Sequenzy field         |
+| -------------------------------------------------------- | ---------------------- |
+| `sequenzySlug`                                           | `slug`                 |
+| `sequenzyPreview`                                        | `preview`              |
+| `subscriberExternalId` or `sequenzySubscriberExternalId` | `subscriberExternalId` |
+
+When `metadata.sequenzySlug` is set, the adapter sends a template request: the slug and variables drive rendering, and `subject`/`html`/`text` are left out of the payload (they still satisfy local message validation).
+
+```ts
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "You've been invited to Acme",
+  html: "<p>Fallback body for local validation.</p>",
+  metadata: { sequenzySlug: "workspace-invite", inviterName: "Ada" },
+});
+```
+
+<Callout type="warn" title="No cc, bcc, headers, or tags">
+  Sequenzy rejects `cc`, `bcc`, `headers`, and `tags` with an `EmailValidationError` before any
+  request, as it does for more than 50 recipients or more than one `replyTo`. Check
+  [field support](/docs/adapters/field-support) before using Sequenzy in a fallback route.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+SEQUENZY_API_KEY="seq_live_..." npx email-sdk doctor --adapter sequenzy
+```
+
+```bash
+SEQUENZY_API_KEY="seq_live_..." npx email-sdk send \
+  --adapter sequenzy \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Sequenzy smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to send for real. Sequenzy queues sends as jobs, so success comes back as a `jobId` rather than a message id. If you use template slugs, add `--metadata "sequenzySlug=..."` to the live send, since the slug lookup only happens on Sequenzy's servers.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/ses.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/ses.mdx
@@ -1,0 +1,123 @@
+---
+title: AWS SES
+description: Send through the SES v2 SendEmail API with built-in SigV4 signing and no AWS SDK dependency.
+icon: ses
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| Yes | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The SES adapter calls the [SES v2 SendEmail API](https://docs.aws.amazon.com/ses/latest/APIReference-V2/API_SendEmail.html) with plain `fetch` and implements AWS Signature V4 signing itself, so your bundle does not pull in the AWS SDK. Pick a region, optionally a configuration set, and send.
+
+<ProviderBadge adapter="ses" />
+
+## Configure
+
+Use credentials allowed to call SES v2 `SendEmail` in your region, and verify the sender identity in that same region. New AWS accounts start in the SES sandbox, which limits recipients to verified addresses.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { ses } from "@opencoredev/email-sdk/ses";
+
+export const email = createEmailClient({
+  adapters: [
+    ses({
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      region: process.env.AWS_REGION!,
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    accessKeyId: {
+      description: "AWS access key ID.",
+      type: "string",
+      required: true,
+    },
+    secretAccessKey: {
+      description: "AWS secret access key.",
+      type: "string",
+      required: true,
+    },
+    region: {
+      description: "SES region, e.g. us-east-1.",
+      type: "string",
+      required: true,
+    },
+    sessionToken: {
+      description: "Session token for temporary credentials (STS, IAM roles).",
+      type: "string",
+    },
+    configurationSetName: {
+      description: "SES configuration set applied to every send.",
+      type: "string",
+    },
+    charset: {
+      description: "Charset for subject and body content.",
+      type: "string",
+      default: '"UTF-8"',
+    },
+    baseUrl: {
+      description: "Override the API origin.",
+      type: "string",
+      default: '"https://email.{region}.amazonaws.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+SES maps `cc`, `bcc`, `replyTo`, `headers`, `attachments`, and `tags` (as SES `EmailTags`, which flow to configuration-set event destinations).
+
+```ts
+const result = await email.send({
+  from: "Acme <billing@acme.com>",
+  to: "user@example.com",
+  replyTo: "support@example.com",
+  subject: "Your May invoice",
+  html: "<p>Your invoice for May is ready.</p>",
+  tags: [{ name: "type", value: "invoice" }],
+});
+
+console.log(result.id); // SES MessageId
+```
+
+<Callout type="warn" title="No metadata field">
+  SES v2 `SendEmail` has no metadata concept, so `metadata` on a message throws an
+  `EmailValidationError` before any request is made. Use `tags` instead, or pick a
+  [metadata-capable adapter](/docs/adapters/field-support).
+</Callout>
+
+## Verify from the CLI
+
+```bash
+AWS_ACCESS_KEY_ID="..." AWS_SECRET_ACCESS_KEY="..." AWS_REGION="us-east-1" \
+  npx email-sdk doctor --adapter ses
+```
+
+```bash
+npx email-sdk send \
+  --adapter ses \
+  --access-key-id "$AWS_ACCESS_KEY_ID" \
+  --secret-access-key "$AWS_SECRET_ACCESS_KEY" \
+  --region us-east-1 \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "SES smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+`--session-token` and `--configuration-set` flags are also available. Drop `--dry-run` for one real send. It is the only way to prove the identity is verified and the account is out of the SES sandbox.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/smtp.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/smtp.mdx
@@ -1,0 +1,176 @@
+---
+title: SMTP
+description: Send over raw SMTP with the built-in TCP/TLS transport. No Nodemailer, no HTTP API.
+icon: smtp
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| Yes | `message_id` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The SMTP adapter speaks the SMTP protocol directly over Node/Bun TCP and TLS sockets. There is no Nodemailer and no HTTP API in the path. Point it at PurelyMail, a self-hosted server, or any provider's SMTP endpoint, and register it more than once under different names for multiple routes.
+
+<ProviderBadge adapter="smtp" />
+
+## Configure
+
+Get the host, port, TLS mode, and credentials from your SMTP provider.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+export const email = createEmailClient({
+  adapters: [
+    smtp({
+      host: "smtp.purelymail.com",
+      port: 587,
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+});
+```
+
+<TypeTable
+  type={{
+    host: {
+      description: "SMTP server hostname.",
+      type: "string",
+      required: true,
+    },
+    port: {
+      description: "SMTP server port.",
+      type: "number",
+      default: "465 when secure, else 587",
+    },
+    secure: {
+      description: "Connect with implicit TLS from the first byte (typically port 465).",
+      type: "boolean",
+      default: "false",
+    },
+    auth: {
+      description:
+        'SMTP credentials. method picks the AUTH mechanism; the default is "plain" (AUTH PLAIN), set "login" for AUTH LOGIN.',
+      type: '{ user: string; pass: string; method?: "plain" | "login" }',
+    },
+    requireTLS: {
+      description: "Force a STARTTLS upgrade even when no auth is configured.",
+      type: "boolean",
+      default: "false",
+    },
+    allowInsecureAuth: {
+      description: "Permit AUTH over a plaintext connection. Only for trusted local servers.",
+      type: "boolean",
+      default: "false",
+    },
+    tls: {
+      description: "Extra options merged into the TLS connection (e.g. ca, rejectUnauthorized).",
+      type: "tls.ConnectionOptions",
+    },
+    defaults: {
+      description: "Default Reply-To header applied when a message has no replyTo.",
+      type: "{ replyTo?: string }",
+    },
+    name: {
+      description: "Adapter name override, for registering several SMTP servers side by side.",
+      type: "string",
+      default: '"smtp"',
+    },
+    heloName: {
+      description: "Hostname announced in the EHLO command.",
+      type: "string",
+      default: '"localhost"',
+    },
+    timeoutMs: {
+      description: "Timeout for the connection and each SMTP command.",
+      type: "number",
+      default: "15000",
+    },
+  }}
+/>
+
+### TLS and auth semantics
+
+With `secure: true` the whole session is TLS. Otherwise the adapter connects in plaintext and upgrades with `STARTTLS` before authenticating whenever `requireTLS` is set or `auth` is present, so credentials do not travel unencrypted. Authenticating against a server that cannot do TLS requires an explicit `allowInsecureAuth: true`; without it the adapter throws instead of sending the password in the clear.
+
+## Send
+
+SMTP maps `cc`, `bcc`, `replyTo`, and `headers`. When a message has both `html` and `text`, the adapter builds a `multipart/alternative` MIME body. The generated `Message-ID` header is `<{idempotencyKey}@email-sdk.local>` when send options include an `idempotencyKey`, and a random UUID otherwise. An explicit `Message-ID` in `headers` overrides it; set one yourself if you need a specific domain for threading or deduplication.
+
+```ts
+const result = await email.send({
+  from: "Acme <alerts@acme.com>",
+  to: "ops@example.com",
+  cc: "oncall@example.com",
+  subject: "Disk usage above 90% on db-1",
+  text: "db-1 is at 92% disk usage.",
+  html: "<p><strong>db-1</strong> is at 92% disk usage.</p>",
+  headers: [{ name: "X-Alert-ID", value: "alert_481" }],
+});
+
+console.log(result.accepted); // every recipient the server accepted
+console.log(result.id); // parsed from the server's "queued as ..." reply, else the idempotency key
+```
+
+`rejected` is always empty, because a refused recipient fails the SMTP conversation instead. Retryable transport failures surface as `EmailAdapterError`, so SMTP plays well with [retries and fallbacks](/docs/concepts/fallbacks-and-retries).
+
+<Callout type="warn" title="No attachments, tags, or metadata">
+  The built-in transport does not build attachment MIME parts, and SMTP has no tag or metadata
+  concept. Any of these fields throws an `EmailValidationError` before connecting. See the
+  [field support matrix](/docs/adapters/field-support).
+</Callout>
+
+## Multiple SMTP routes
+
+`name` lets you register the adapter twice and use one route as the [fallback](/docs/concepts/fallbacks-and-retries) for the other.
+
+```ts
+export const email = createEmailClient({
+  adapters: [
+    smtp({
+      name: "purelymail",
+      host: "smtp.purelymail.com",
+      auth: { user: process.env.PURELYMAIL_USER!, pass: process.env.PURELYMAIL_PASS! },
+    }),
+    smtp({
+      name: "backup-smtp",
+      host: "smtp.backup.example",
+      auth: { user: process.env.BACKUP_SMTP_USER!, pass: process.env.BACKUP_SMTP_PASS! },
+    }),
+  ],
+  defaultAdapter: "purelymail",
+  fallback: { adapters: ["backup-smtp"] },
+});
+```
+
+## Verify from the CLI
+
+`doctor` only checks `SMTP_HOST`; the other settings are optional.
+
+```bash
+SMTP_HOST=smtp.purelymail.com npx email-sdk doctor --adapter smtp
+```
+
+```bash
+npx email-sdk send \
+  --adapter smtp \
+  --host smtp.purelymail.com \
+  --port 587 \
+  --require-tls \
+  --user hello@acme.com \
+  --pass "$SMTP_PASS" \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "SMTP smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Each flag falls back to its env var: `--host`/`SMTP_HOST`, `--port`/`SMTP_PORT` (default 587), `--secure`/`SMTP_SECURE`, `--require-tls`/`SMTP_REQUIRE_TLS`, `--allow-insecure-auth`/`SMTP_ALLOW_INSECURE_AUTH`, `--user`/`SMTP_USER`, `--pass`/`SMTP_PASS`. Drop `--dry-run` for one real send to prove the host, TLS mode, and credentials actually deliver.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/sparkpost.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/sparkpost.mdx
@@ -1,0 +1,97 @@
+---
+title: SparkPost
+description: Send through the SparkPost Transmissions API with metadata, substitution data from tags, and a provider-side sandbox mode.
+icon: sparkpost
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | Yes | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The SparkPost adapter calls the [SparkPost Transmissions API](https://developers.sparkpost.com/api/transmissions/) with plain `fetch`. Two things set it apart: a `sandbox` option that routes sends through SparkPost's shared sandbox domain for testing, and tags become SparkPost `substitution_data` as `name: value` pairs instead of a flat list.
+
+<ProviderBadge adapter="sparkpost" />
+
+## Configure
+
+Create an API key with Transmissions permission in the [SparkPost dashboard](https://app.sparkpost.com/account/api-keys). SparkPost expects the raw key in the `Authorization` header, so the adapter sends it without a `Bearer` prefix.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sparkpost } from "@opencoredev/email-sdk/sparkpost";
+
+export const email = createEmailClient({
+  adapters: [sparkpost({ apiKey: process.env.SPARKPOST_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "SparkPost API key, sent as the Authorization header (no Bearer prefix).",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for the EU region.",
+      type: "string",
+      default: '"https://api.sparkpost.com/api/v1"',
+    },
+    sandbox: {
+      description: "Send through SparkPost's shared sandbox domain (options.sandbox on the transmission).",
+      type: "boolean",
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+SparkPost maps `replyTo`, `headers`, `attachments`, `metadata`, and `tags` (each tag becomes a `substitution_data` entry keyed by its name). `sendAt` schedules the transmission natively as `options.start_time`; SparkPost accepts at most 3 days in the future.
+
+```ts
+const result = await email.send({
+  from: { email: "alerts@acme.com", name: "Acme Alerts" },
+  to: "user@example.com",
+  replyTo: "support@acme.com",
+  subject: "Usage alert: 90% of plan limit",
+  html: "<p>Your workspace is at 90% of its monthly quota.</p>",
+  metadata: { workspaceId: "ws_123" },
+  tags: [{ name: "type", value: "usage-alert" }],
+});
+
+console.log(result.id); // SparkPost transmission id
+```
+
+The response `id` is the transmission id from `results.id` (or `results.transmission_id`). Use it to query SparkPost's events API for delivery status.
+
+<Callout type="warn" title="No cc or bcc">
+  This adapter sends one flat recipient list, so `cc` or `bcc` on a message throws an
+  `EmailValidationError` before any request is made. Add extra recipients to `to`, or pick a
+  [cc/bcc-capable adapter](/docs/adapters/field-support).
+</Callout>
+
+## Verify from the CLI
+
+```bash
+SPARKPOST_API_KEY="..." npx email-sdk doctor --adapter sparkpost
+```
+
+```bash
+SPARKPOST_API_KEY="..." npx email-sdk send \
+  --adapter sparkpost \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "SparkPost smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` for one real send, or set `sandbox: true` in code first to exercise the API through SparkPost's shared sandbox domain before touching your own.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/unosend.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/unosend.mdx
@@ -1,0 +1,92 @@
+---
+title: Unosend
+description: Send through the Unosend REST API, a single Bearer-authenticated endpoint with CC, BCC, tags, and attachments.
+icon: unosend
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The Unosend adapter calls the Unosend REST API with plain `fetch`. It is one of the simplest providers to wire up: one Bearer-authenticated `/emails` endpoint, one API key, no other configuration.
+
+<ProviderBadge adapter="unosend" />
+
+## Configure
+
+Create a server-side API key in your Unosend account and verify the domain you send from.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { unosend } from "@opencoredev/email-sdk/unosend";
+
+export const email = createEmailClient({
+  adapters: [unosend({ apiKey: process.env.UNOSEND_API_KEY! })],
+});
+```
+
+<TypeTable
+  type={{
+    apiKey: {
+      description: "Unosend API key.",
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.unosend.co"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+Unosend maps `cc`, `bcc`, `headers`, `tags`, `attachments`, and a single `replyTo` address.
+
+```ts
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: [{ email: "user@example.com", name: "Ada" }],
+  replyTo: "support@example.com",
+  subject: "You're invited to the Acme workspace",
+  html: "<p>Grace invited you to join the Acme workspace.</p>",
+  tags: [{ name: "type", value: "invite" }],
+});
+
+console.log(result.id); // Unosend email id
+```
+
+The adapter checks `success` in the response body and throws an `EmailAdapterError` when Unosend reports a failure, even on an HTTP 200.
+
+<Callout type="warn" title="No metadata, one reply-to">
+  Unosend has no metadata field and accepts only one `replyTo` address. A message with `metadata`
+  or multiple reply-to addresses throws an `EmailValidationError` before any request is made. Use
+  `tags`, or pick a [metadata-capable adapter](/docs/adapters/field-support).
+</Callout>
+
+## Verify from the CLI
+
+```bash
+UNOSEND_API_KEY="un_..." npx email-sdk doctor --adapter unosend
+```
+
+```bash
+UNOSEND_API_KEY="un_..." npx email-sdk send \
+  --adapter unosend \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Unosend smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to send for real. Unosend has no extra credentials to get wrong, so a live send that prints an `id` means the key and the verified domain were the whole story. If it fails, the CLI surfaces Unosend's own error message from the response body.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/verification.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/verification.mdx
@@ -1,0 +1,49 @@
+---
+title: How adapters are tested
+sidebarTitle: Verification
+heading: How adapters are tested
+sidebar: true
+description: See what Verified means and how adapter checks run.
+---
+
+Every adapter has tests for request building, validation, errors, and secret handling.
+
+**Verified** means the adapter also has a safe real-account check in release CI. The check signs in to the provider but does not send an email. A failed check blocks the release.
+
+## Verified adapters
+
+- Resend
+- Sequenzy
+- JetEmail
+- Primitive
+- Lettermint
+
+## How the release check works
+
+When adapter code changes on `main`, Depot checks that provider. A shared sending change checks every verified adapter.
+
+```bash
+bun run live:plan <base-sha> <head-sha>
+```
+
+Missing or invalid credentials fail the job.
+
+## Run the same checks locally
+
+```bash
+bun run live:resend
+bun run live:sequenzy
+bun run live:lettermint
+bun scripts/check-jetemail-account.ts
+bun scripts/check-primitive-account.ts
+```
+
+The scripts read `.env.local`, then `.env`, then your shell. Keep those files out of Git and do not paste keys into commands or chat.
+
+## Add another provider check
+
+1. Find an endpoint that checks the account without sending an email. Account, domain, identity, and settings endpoints usually work well.
+2. Add `scripts/check-<adapter>-account.ts`. Only print safe fields.
+3. Add the command and secret name to `adapter-verification.json`.
+4. Test a bad key and a good key. Neither run should create an email.
+5. Update the adapter page with what the check actually does.

--- a/apps/fumadocs/content/docs-v/1.0.0/adapters/zeptomail.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/adapters/zeptomail.mdx
@@ -1,0 +1,91 @@
+---
+title: ZeptoMail
+description: Send through Zoho ZeptoMail with automatic send-mail token prefixing.
+icon: zeptomail
+---
+
+## Capabilities
+
+| Repeated headers | Idempotency | Scheduling | Personalized |
+| --- | --- | --- | --- |
+| No | `none` | No | `expanded` |
+
+These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
+
+The ZeptoMail adapter calls the [Zoho ZeptoMail email API](https://www.zoho.com/zeptomail/help/api/email-sending.html) with plain `fetch`. Paste your send mail token as-is: the adapter prepends Zoho's `Zoho-enczapikey ` authorization prefix automatically when it is missing.
+
+<ProviderBadge adapter="zeptomail" />
+
+## Configure
+
+Create a Mail Agent in ZeptoMail, copy its send mail token, and verify the sending domain.
+
+```ts title="lib/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { zeptomail } from "@opencoredev/email-sdk/zeptomail";
+
+export const email = createEmailClient({
+  adapters: [zeptomail({ token: process.env.ZEPTOMAIL_TOKEN! })],
+});
+```
+
+<TypeTable
+  type={{
+    token: {
+      description:
+        'ZeptoMail send mail token. Works with or without the "Zoho-enczapikey " prefix.',
+      type: "string",
+      required: true,
+    },
+    baseUrl: {
+      description: "Override the API origin, e.g. for a proxy.",
+      type: "string",
+      default: '"https://api.zeptomail.com"',
+    },
+    fetch: {
+      description: "Custom fetch implementation for tests or special runtimes.",
+      type: "typeof fetch",
+    },
+  }}
+/>
+
+## Send
+
+ZeptoMail maps `cc`, `bcc`, `replyTo`, and `attachments`. Display names carry through to ZeptoMail's `email_address` recipient objects, and `html`/`text` become `htmlbody`/`textbody`.
+
+```ts
+const result = await email.send({
+  from: { email: "security@acme.com", name: "Acme Security" },
+  to: [{ email: "user@example.com", name: "Ada" }],
+  replyTo: "support@acme.com",
+  subject: "Reset your password",
+  html: '<p><a href="https://acme.com/reset?t=abc123">Reset your password</a></p>',
+  text: "Reset your password: https://acme.com/reset?t=abc123",
+});
+
+console.log(result.id); // ZeptoMail request_id (falls back to messageId or id)
+```
+
+<Callout type="warn" title="No headers, tags, or metadata">
+  The adapter does not map custom headers, tags, or metadata to the ZeptoMail API, so any of them
+  throws an `EmailValidationError` before a request is made. See the [field support
+  matrix](/docs/adapters/field-support) for alternatives.
+</Callout>
+
+## Verify from the CLI
+
+```bash
+ZEPTOMAIL_TOKEN="..." npx email-sdk doctor --adapter zeptomail
+```
+
+```bash
+ZEPTOMAIL_TOKEN="..." npx email-sdk send \
+  --adapter zeptomail \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "ZeptoMail smoke test" \
+  --text "It works" \
+  --dry-run
+```
+
+Drop `--dry-run` to send for real. ZeptoMail scopes each token to one Mail Agent, so a valid token can still fail when the `from` domain is not verified under that agent. Only a live send confirms the token, the agent, and the sender domain all line up.

--- a/apps/fumadocs/content/docs-v/1.0.0/agents/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/agents/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Machine-readable Email SDK docs
+description: Give agents current Email SDK documentation without scraping rendered HTML.
+---
+
+Use raw Markdown, LLM indexes, JSONL records, and the schema map to retrieve the current documentation directly.
+
+<Card title="Machine-readable docs" href="/docs/agents/machine-readable-docs" description="Use raw Markdown, LLM indexes, JSONL records, and the schema map." />
+
+Runtime integrations live under [Chat SDK](/docs/integrations/chat-sdk) and [AI SDK](/docs/integrations/ai-sdk). Installation guidance for coding agents lives in [Get started](/docs/getting-started/agent-skill).

--- a/apps/fumadocs/content/docs-v/1.0.0/agents/machine-readable-docs.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/agents/machine-readable-docs.mdx
@@ -1,0 +1,35 @@
+---
+title: Machine-readable documentation
+description: Use raw Markdown, LLM indexes, JSONL entities, and the schema map for agent retrieval.
+---
+
+The docs site exposes the active navigation through formats that do not require scraping rendered HTML.
+
+| Endpoint | Purpose |
+| --- | --- |
+| `/llms.txt` | Site-level LLM index |
+| `/docs/llms.txt` | Documentation-only index |
+| `/llms-full.txt` | Combined current documentation text |
+| `/feeds/docs.jsonl` | One typed JSON object per current page |
+| `/schemamap.xml` | Machine-readable surface map |
+| `/docs/<path>.md` | Raw Markdown for one current page |
+
+Every rendered page includes Copy Markdown and View Markdown controls. Historical documentation also has version-aware raw Markdown routes.
+
+## Prefer canonical URLs
+
+Use current `/docs/...` URLs unless you need behavior from a pinned historical release. The version picker stores `latest` separately, so readers who choose current docs continue to track future releases.
+
+## Retrieve one page
+
+```bash
+curl https://email-sdk.dev/docs/reference/client.md
+```
+
+The response starts with the page title and canonical URL, then includes processed Markdown with version-correct internal links.
+
+## Retrieve the full corpus
+
+Use `/llms-full.txt` for a compact single request or `/feeds/docs.jsonl` when your indexer wants discrete route records.
+
+<Card title="Coding-agent skill" href="/docs/getting-started/agent-skill" description="Install instructions that make agents refresh these sources before coding." />

--- a/apps/fumadocs/content/docs-v/1.0.0/agents/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/agents/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "For agents",
+  "icon": "Bot",
+  "pages": ["index", "machine-readable-docs"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/concepts/adapter-model.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/concepts/adapter-model.mdx
@@ -1,0 +1,73 @@
+---
+title: Adapters
+sidebarTitle: Adapters
+description: How adapters turn one Email SDK message into a provider request.
+---
+
+An adapter turns the Email SDK message into the request one provider expects.
+
+## Registered routes
+
+Adapter factories return literal names. `createEmailClient` derives the accepted route-name union from the adapters you pass, including custom SMTP names.
+
+```ts title="src/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({ name: "backup", host: process.env.SMTP_HOST! }),
+  ],
+  defaultAdapter: "resend",
+});
+
+await email.send(message, { adapter: "backup" });
+```
+
+Unknown literal names fail type checking. Unknown runtime strings throw `EmailAdapterNotFoundError`.
+
+## Adapter responsibilities
+
+Every adapter declares four capabilities and provides `send`. It may add adapter-specific validation and native personalized sending.
+
+```ts title="adapter-contract.ts"
+type EmailAdapterCapabilities = {
+  repeatedHeaders: boolean;
+  idempotency: "native" | "message_id" | "none";
+  scheduling: boolean;
+  personalized: "native" | "expanded" | "unsupported";
+};
+```
+
+The client validates every candidate route before the first provider call. Unsupported fields, repeated headers on an incapable route, invalid schedules, and adapter-specific limits fail with `EmailValidationError`.
+
+## Normalized results
+
+Every successful route returns the same top-level shape.
+
+```ts title="result.ts"
+type EmailSendResult<Name extends string = string, Raw = unknown> = {
+  adapter: Name;
+  id?: string;
+  accepted?: readonly string[];
+  rejected?: readonly string[];
+  raw?: Raw;
+};
+```
+
+The v1 root has no `provider` or `messageId` aliases. The [`/compat` subpath](/docs/reference/compatibility) keeps temporary v0 source compatibility.
+
+## Direct adapter access
+
+Use `adapter(name)` to access the exact adapter or `withAdapter(name)` to bind all client operations to one route.
+
+```ts title="src/email.ts"
+const backup = email.withAdapter("backup");
+await backup.validate(message);
+await backup.send(message);
+```
+
+<Card title="Adapter contract" href="/docs/reference/adapter-contract" description="Implement validation, capabilities, send, and optional personalized delivery." />
+<Card title="Capability groups" href="/docs/adapters/capability-groups" description="Choose routes by scheduling, idempotency, headers, and personalization." />

--- a/apps/fumadocs/content/docs-v/1.0.0/concepts/fallbacks-and-retries.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/concepts/fallbacks-and-retries.mdx
@@ -1,0 +1,80 @@
+---
+title: Retries and fallback
+sidebarTitle: Retries & fallback
+description: Retry one provider, then decide when it is safe to try another.
+---
+
+Retries stay on the current adapter. Fallback starts only after that adapter reaches a terminal failure.
+
+## Configure a route
+
+`maxAttempts` counts total calls, so `1` means one call and no retry.
+
+```ts title="src/email.ts"
+const email = createEmailClient({
+  adapters: [primary, backup],
+  defaultAdapter: "primary",
+  retry: { maxAttempts: 3 },
+  fallback: {
+    adapters: ["backup"],
+    onUnknownDelivery: "stop",
+  },
+});
+```
+
+The default retry policy makes one attempt. The default delay uses capped exponential backoff. Override `delay` or `shouldRetry` when your application has a specific policy.
+
+## Delivery certainty
+
+`EmailAdapterError.delivery` is either `not_sent` or `unknown`.
+
+| Delivery value | Meaning | Default fallback behavior |
+| --- | --- | --- |
+| `not_sent` | The adapter can prove the provider did not accept the message. | Continue to the next configured adapter. |
+| `unknown` | Dispatch may have started, so delivery cannot be ruled out. | Stop to avoid an automatic duplicate. |
+
+Network timeouts and failures after dispatch begins are conservatively classified as `unknown` unless the adapter can prove otherwise.
+
+Opt into continuation only when the duplicate-delivery risk is acceptable.
+
+```ts title="src/send-critical.ts"
+await email.send(message, {
+  fallback: {
+    adapters: ["backup"],
+    onUnknownDelivery: "continue",
+  },
+});
+```
+
+The SDK never claims exactly-once delivery across adapters. Use idempotency where the adapter supports it, and keep durable workflow state in your application.
+
+## Override one send
+
+Per-send policy replaces the client fallback object and retry object.
+
+```ts title="src/send.ts"
+await email.send(message, {
+  adapter: "primary",
+  retry: { maxAttempts: 1 },
+  fallback: { adapters: [] },
+});
+```
+
+## Abort the whole route
+
+An `AbortSignal` stops active work or backoff and prevents every later retry and fallback.
+
+```ts title="src/send.ts"
+const controller = new AbortController();
+
+const pending = email.send(message, { signal: controller.signal });
+controller.abort();
+await pending; // throws EmailAbortError
+```
+
+## Route exhaustion
+
+When no route succeeds, the client throws `EmailRouteError`. Its `failures` array preserves adapter order and contains typed `EmailAdapterError` values.
+
+<Card title="Error reference" href="/docs/reference/errors" description="Match on closed error codes and typed fields." />
+<Card title="Production pipeline" href="/docs/guides/production-send-pipeline" description="Combine routing with idempotency, queues, and observability." />

--- a/apps/fumadocs/content/docs-v/1.0.0/concepts/hooks.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/concepts/hooks.mdx
@@ -1,0 +1,76 @@
+---
+title: Hooks and middleware
+sidebarTitle: Hooks & middleware
+description: Observe sends with hooks or change them with middleware.
+---
+
+Hooks observe the send lifecycle. Middleware may change the message or options and can fail the operation.
+
+## Lifecycle order
+
+For a normal send, the client runs this sequence:
+
+1. `beforeSend` middleware prepares the message and send options.
+2. Public validation checks the complete route.
+3. `beforeSend` hooks run before each adapter attempt.
+4. The adapter sends or throws.
+5. Retry hooks run before an eligible backoff.
+6. `afterSend` middleware and hooks run after success.
+7. Error middleware and hooks run after a terminal adapter failure.
+
+## Add hooks
+
+Hook failures are swallowed because observability must not change delivery behavior.
+
+```ts title="src/email.ts"
+const email = createEmailClient({
+  adapters: [adapter],
+  hooks: {
+    onRetry(event) {
+      console.info("email retry", {
+        adapter: event.adapter,
+        attempt: event.attempt,
+        nextAttempt: event.nextAttempt,
+        delayMs: event.delayMs,
+        code: event.error.code,
+      });
+    },
+  },
+});
+```
+
+Hook events include the normalized message. Do not log addresses, subjects, bodies, headers, attachments, credentials, or arbitrary metadata without your own redaction policy.
+
+## Add middleware
+
+Middleware exceptions become `EmailMiddlewareError` with phase `before_send`, `after_send`, or `on_error`.
+
+```ts title="src/plugins/tenant-metadata.ts"
+import type { EmailPlugin } from "@opencoredev/email-sdk";
+
+export const tenantMetadata = (tenantId: string): EmailPlugin => ({
+  id: "tenant-metadata",
+  middleware: [
+    {
+      beforeSend({ message, options }) {
+        return {
+          message,
+          options: {
+            ...options,
+            metadata: { ...options?.metadata, tenantId },
+          },
+        };
+      },
+    },
+  ],
+});
+```
+
+Message `metadata` is provider-facing when an adapter supports it. Send-option `metadata` is application context for hooks, middleware, telemetry feature facts, and adapters that inspect context.
+
+## Use the built-in observability plugin
+
+The default redactor keeps the subject, recipient counts, body-presence booleans, attachment count, tag names, and metadata keys. Replace it if the subject is sensitive in your application.
+
+<Card title="Observability plugin" href="/docs/plugins/built-in/observability" description="Emit redacted log, metric, and trace events." />
+<Card title="Plugin API" href="/docs/reference/plugin-api" description="Look up hooks, middleware, adapter registration, and client extensions." />

--- a/apps/fumadocs/content/docs-v/1.0.0/concepts/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/concepts/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Concepts",
+  "icon": "BookOpen",
+  "pages": [
+    "adapter-model",
+    "fallbacks-and-retries",
+    "hooks",
+    "sending-modes"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/concepts/sending-modes.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/concepts/sending-modes.mdx
@@ -1,0 +1,71 @@
+---
+title: Sending modes
+sidebarTitle: Sending modes
+description: Pick the right method for batches, personalization, schedules, and idempotency.
+---
+
+Email SDK separates independent messages from one message personalized across recipients.
+
+## Independent sends
+
+Use `sendMany` when every item is a complete message with its own outcome. Execution is sequential and preserves input order.
+
+```ts title="src/send-notifications.ts"
+const results = await email.sendMany([
+  { message: welcomeMessage, options: { idempotencyKey: "welcome:1" } },
+  { message: receiptMessage, options: { idempotencyKey: "receipt:1" } },
+]);
+```
+
+The method returns one settled result per item. Item options override method-level options, including replacement of the fallback object.
+
+## Personalized recipients
+
+Use `sendPersonalized` when subject or body tokens vary by recipient.
+
+```ts title="src/send-campaign.ts"
+const result = await email.sendPersonalized(
+  {
+    message: {
+      from: "Acme <hello@acme.com>",
+      subject: "Hi %recipient.name%",
+      text: "Welcome, %recipient.name%.",
+    },
+    recipients: [
+      { to: "ada@example.com", variables: { name: "Ada" } },
+      { to: "linus@example.com", variables: { name: "Linus" } },
+    ],
+  },
+  { idempotencyKey: "campaign:42" },
+);
+```
+
+Mailgun and SendGrid use native personalized APIs. Other built-in adapters expand recipients into deterministic sequential sends. At least one accepted recipient resolves with `accepted` and `rejected`; zero accepted recipients throws `EmailAllRecipientsFailedError`.
+
+## Scheduled sends
+
+`sendAt` accepts a `Date` or RFC 3339 string with `Z` or a numeric offset.
+
+```ts title="src/send-later.ts"
+await email.send({
+  ...message,
+  sendAt: "2026-08-01T09:00:00Z",
+});
+```
+
+The SDK does not wait or queue. Capable adapters translate the timestamp into the provider's scheduling field. Incapable adapters reject it during validation.
+
+## Idempotency
+
+Pass `idempotencyKey` in send options, not in `EmailMessage`.
+
+```ts title="src/send-receipt.ts"
+await email.send(receipt, {
+  idempotencyKey: "receipt:order_123",
+});
+```
+
+Resend, JetEmail, Lettermint, and Primitive have native idempotency support. SMTP derives `Message-ID` from the key. Other adapters receive the key in context but cannot guarantee provider-side deduplication.
+
+<Card title="Message reference" href="/docs/reference/message" description="See exact message, attachment, header, and schedule types." />
+<Card title="Capability groups" href="/docs/adapters/capability-groups" description="Choose adapters that support the sending mode you need." />

--- a/apps/fumadocs/content/docs-v/1.0.0/getting-started/agent-skill.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/getting-started/agent-skill.mdx
@@ -1,0 +1,59 @@
+---
+title: Coding-agent skill
+description: Install dynamic Email SDK guidance for coding agents that integrate, review, or document the package.
+---
+
+The repository ships two dynamic skills for Claude Code and other skill-compatible coding agents:
+
+- `email-sdk` for new integrations, reviews, and adapter work.
+- `email-sdk-migrate` for source-grounded application upgrades.
+
+```bash
+npx skills add opencoredev/email-sdk --skill email-sdk
+npx skills add opencoredev/email-sdk --skill email-sdk-migrate
+```
+
+You can also copy `skills/email-sdk/` into your repository's agent skill directory.
+
+## Dynamic documentation
+
+The skill discovers the current documentation from [`/docs/llms.txt`](/docs/llms.txt), then fetches exact pages through the raw Markdown route at `/docs/<path>.md`. It does not rely on a frozen list of adapters, concepts, or UI templates.
+
+For email UI work it starts at [`/docs/ui.md`](/docs/ui.md), follows the current category links, and reads the selected template page before using its registry command or Manual source.
+
+## What the skill requires
+
+- Refresh the installed package README, exports, declarations, and relevant adapter source before editing.
+- Import every adapter from its own subpath.
+- Keep credentials in server environment variables.
+- Check field and capability compatibility before adding fallback routes.
+- Use idempotency for externally visible sends that may retry.
+- Use `doctor` and `send --dry-run` before an approved live provider check.
+- Keep bodies, recipients, credentials, and provider payloads out of logs.
+- Run the narrowest typecheck or test that covers the send path.
+
+## Prompt example
+
+```text
+Use the email-sdk skill.
+Wire Resend as the primary adapter and a named SMTP backup.
+Validate the full route before queueing.
+Add one unit test with the memory adapter.
+Do not send a real email.
+```
+
+## Migration prompt
+
+```text
+Use the email-sdk-migrate skill.
+Inspect the installed package and declarations before editing.
+Audit this repository for v0 surfaces, migrate it to v1, and preserve retry,
+fallback, idempotency, batch, and personalized-send semantics.
+Run typechecks and tests. Do not send live email.
+```
+
+The migration skill includes a deterministic scanner for common v0 spellings, but requires the agent to inspect each finding before changing generic application vocabulary.
+
+The skill guides code changes; it is not a runtime email tool. Use the [AI SDK integration](/docs/integrations/ai-sdk) for runtime agent calls.
+
+<Card title="Machine-readable docs" href="/docs/agents/machine-readable-docs" description="Give agents raw Markdown and complete documentation indexes." />

--- a/apps/fumadocs/content/docs-v/1.0.0/getting-started/credentials.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/getting-started/credentials.mdx
@@ -1,0 +1,57 @@
+---
+title: Provider credentials
+description: Configure adapter credentials in the server environment and verify required values with the CLI.
+---
+
+Credentials belong in the server process that constructs the adapter. Email SDK does not read a universal configuration file or expose credentials to browser code.
+
+## Required environment variables
+
+Run the adapter catalog to see the names required by the bundled CLI.
+
+```bash
+npx email-sdk adapters
+```
+
+Common adapters use these values:
+
+| Adapter | Required environment variables |
+| --- | --- |
+| Resend | `RESEND_API_KEY` |
+| Postmark | `POSTMARK_SERVER_TOKEN` |
+| SendGrid | `SENDGRID_API_KEY` |
+| AWS SES | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` |
+| Mailgun | `MAILGUN_API_KEY`, `MAILGUN_DOMAIN` |
+| Cloudflare | `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` |
+| SMTP | `SMTP_HOST`; auth also uses `SMTP_USER` and `SMTP_PASS` |
+
+The [adapter pages](/docs/adapters) list every credential and adapter-specific option.
+
+## Pass credentials to application code
+
+Adapter factories accept credentials explicitly. Environment variable names are a deployment convention rather than a hidden SDK lookup.
+
+```ts title="src/email.ts"
+import { resend } from "@opencoredev/email-sdk/resend";
+
+export const resendAdapter = resend({
+  apiKey: process.env.RESEND_API_KEY!,
+});
+```
+
+## Check configuration
+
+`doctor` checks whether the CLI has enough values to construct the adapter. It does not prove that a credential is accepted by the provider.
+
+```bash
+RESEND_API_KEY=re_xxx npx email-sdk doctor --adapter resend
+```
+
+Use `send --dry-run` to validate a full message without network delivery. Use a real send only with an approved test recipient.
+
+## SMTP transport security
+
+SMTP auth on a non-secure port requires TLS. The transport upgrades with STARTTLS by default. Set `allowInsecureAuth` only for a trusted local test server.
+
+<Card title="Browse adapters" href="/docs/adapters" description="Open the setup page for the provider you use." />
+<Card title="CLI doctor" href="/docs/reference/cli/doctor" description="See exact configuration checks and failure modes." />

--- a/apps/fumadocs/content/docs-v/1.0.0/getting-started/install.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/getting-started/install.mdx
@@ -1,0 +1,63 @@
+---
+title: Install
+description: Install the ESM-only SDK for Node.js 20+ or Bun 1.1+.
+---
+
+<Steps>
+
+<Step>
+
+### Install the package
+
+<PackageInstallTabs />
+
+The public package is `@opencoredev/email-sdk`. The unscoped `email-sdk` package is unrelated.
+
+</Step>
+
+<Step>
+
+### Confirm your runtime
+
+Use Node.js 20+ or Bun 1.1+. The package is ESM-only, so use `import` syntax or dynamic `import()` from a CommonJS application.
+
+```json title="package.json"
+{
+  "type": "module"
+}
+```
+
+</Step>
+
+<Step>
+
+### Import one adapter
+
+Adapters use separate package entry points, so your application imports only the integrations it uses.
+
+```ts title="email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+```
+
+</Step>
+
+<Step>
+
+### Verify the CLI
+
+A project install exposes the `email-sdk` binary. The built CLI uses a Node shebang and also runs under Bun.
+
+```bash
+npx email-sdk version
+npx email-sdk adapters
+```
+
+For a global Homebrew install, use `brew install opencoredev/tap/email-sdk` after the formula points at a published release.
+
+</Step>
+
+</Steps>
+
+<Card title="Quickstart" href="/docs/getting-started/quickstart" description="Create a client and send a validated message." />
+<Card title="Provider credentials" href="/docs/getting-started/credentials" description="Set the environment variables required by your adapter." />

--- a/apps/fumadocs/content/docs-v/1.0.0/getting-started/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/getting-started/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Get started",
+  "icon": "Rocket",
+  "pages": ["install", "quickstart", "credentials", "agent-skill"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/getting-started/quickstart.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/getting-started/quickstart.mdx
@@ -1,0 +1,63 @@
+---
+title: Quickstart
+description: Create a Resend client and send your first email.
+---
+
+Set a server-only Resend key:
+
+```bash title=".env.local"
+RESEND_API_KEY=re_xxx
+```
+
+Then create the client and send:
+
+```ts title="src/send-welcome.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+
+console.log(result.adapter, result.id);
+```
+
+That is the whole happy path. The result tells you which adapter ran and includes the provider receipt when one is available.
+
+## Check a message without sending
+
+Use `validate` when you want the same message and routing checks without a provider send request:
+
+```ts
+await email.validate({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+```
+
+## Check from the CLI
+
+`--dry-run` runs the same validation without sending email.
+
+```bash
+EMAIL_SDK_TELEMETRY=0 npx email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@acme.com>" \
+  --to user@example.com \
+  --subject "Welcome" \
+  --text "Your account is ready." \
+  --dry-run
+```
+
+<Card title="Add retries and fallback" href="/docs/concepts/fallbacks-and-retries" description="Choose retry counts and unknown-delivery policy deliberately." />
+<Card title="Schedule an email" href="/docs/guides/schedule-email" description="Use provider scheduling now, or an app-owned queue when you need more control." />
+<Card title="Test without a provider" href="/docs/guides/test-email-behavior" description="Capture sends with the memory adapter and capture plugin." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/create-adapter.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/create-adapter.mdx
@@ -1,0 +1,84 @@
+---
+title: Create an adapter
+description: Implement a literal route name, capabilities, no-network validation, sending, and typed failures.
+---
+
+An adapter maps `EmailMessage` into one provider request and refuses every field it cannot preserve.
+
+## Implement the contract
+
+```ts title="src/acme-mail.ts"
+import {
+  EmailAdapterError,
+  EmailValidationError,
+  type EmailAdapter,
+} from "@opencoredev/email-sdk";
+
+export function acmeMail(options: {
+  apiKey: string;
+  fetch?: typeof fetch;
+}): EmailAdapter<"acme-mail"> {
+  const fetcher = options.fetch ?? fetch;
+
+  return {
+    name: "acme-mail",
+    capabilities: {
+      repeatedHeaders: false,
+      idempotency: "none",
+      scheduling: false,
+      personalized: "expanded",
+    },
+    validate(message) {
+      if (message.attachments?.length) {
+        throw new EmailValidationError("acme-mail does not support attachments.");
+      }
+    },
+    async send(message, context) {
+      const response = await fetcher("https://api.acme.example/send", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${options.apiKey}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          from: message.from,
+          to: message.to,
+          subject: message.subject,
+          text: message.text,
+          html: message.html,
+        }),
+        signal: context.signal,
+      });
+
+      if (!response.ok) {
+        throw new EmailAdapterError(`acme-mail failed with HTTP ${response.status}.`, {
+          adapter: "acme-mail",
+          status: response.status,
+          retryable: response.status === 429 || response.status >= 500,
+          delivery: "not_sent",
+        });
+      }
+
+      const body = (await response.json()) as { id: string };
+      return { adapter: "acme-mail", id: body.id };
+    },
+  };
+}
+```
+
+## Classify delivery conservatively
+
+Use `not_sent` only when the adapter can prove the provider did not accept the message. Timeouts, connection loss after dispatch, and unparseable success responses are `unknown` unless the protocol proves otherwise.
+
+## Validate every unsupported field
+
+The client enforces declared repeated-header, scheduling, and personalized capabilities. Your adapter still owns address limits, provider-only format rules, and unsupported normalized fields.
+
+`validate` must not send network requests. The CLI relies on it as a shared dry boundary.
+
+## Add tests
+
+Test payload mapping, all unsupported fields, adapter-specific limits, abort forwarding, retryable status codes, `not_sent` versus `unknown`, idempotency forwarding when declared, and normalized result fields.
+
+<Card title="Adapter contract" href="/docs/reference/adapter-contract" description="Look up every adapter field and context value." />
+<Card title="Publish an adapter" href="/docs/guides/authoring/publish-community-adapter" description="Ship the adapter as a community package." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/create-first-plugin.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/create-first-plugin.mdx
@@ -1,0 +1,60 @@
+---
+title: Create your first plugin
+description: Add typed middleware and a client extension without changing adapter behavior.
+---
+
+This plugin records successful receipt ids and exposes them through `email.receipts`.
+
+## Define the extension
+
+```ts title="src/receipt-plugin.ts"
+import type { EmailPlugin } from "@opencoredev/email-sdk";
+
+export function receiptPlugin(): EmailPlugin<{
+  receipts: readonly { adapter: string; id?: string }[];
+}> {
+  const receipts: { adapter: string; id?: string }[] = [];
+
+  return {
+    id: "receipts",
+    middleware: [
+      {
+        afterSend(event) {
+          receipts.push({
+            adapter: event.response.adapter,
+            id: event.response.id,
+          });
+        },
+      },
+    ],
+    extendClient() {
+      return { receipts };
+    },
+  };
+}
+```
+
+## Mount the plugin
+
+```ts title="src/email.ts"
+const email = createEmailClient({
+  adapters: [adapter],
+  plugins: [receiptPlugin()],
+});
+
+await email.send(message);
+console.log(email.receipts);
+```
+
+`extendClient` must not reuse `adapters`, `defaultAdapter`, `validate`, `send`, `sendMany`, `sendPersonalized`, `adapter`, `withAdapter`, or another extension key.
+
+## Choose hooks or middleware
+
+Use hooks for best-effort observation because hook exceptions are swallowed. Use middleware when failure should be visible as `EmailMiddlewareError` or when you need to replace the message or send options before validation.
+
+## Keep setup synchronous
+
+Plugin adapter registration and `extendClient` run during synchronous client construction. Do asynchronous credential or remote configuration work before calling `createEmailClient`.
+
+<Card title="Plugin API" href="/docs/reference/plugin-api" description="See exact plugin, hook, middleware, and extension types." />
+<Card title="Publish a plugin" href="/docs/guides/authoring/publish-community-plugin" description="Package and document the extension for external users." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Extend",
+  "icon": "Wrench",
+  "pages": [
+    "create-first-plugin",
+    "create-adapter",
+    "publish-community-plugin",
+    "publish-community-adapter"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/publish-community-adapter.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/publish-community-adapter.mdx
@@ -1,0 +1,42 @@
+---
+title: Publish a community adapter
+description: Ship a provider adapter with literal routes, capabilities, no-network validation, typed failures, and evidence-backed claims.
+---
+
+Publish a community adapter when the provider is useful but is not maintained as an official core entry point.
+
+## Export an adapter factory
+
+The public return type should keep a literal route name and declare all four capabilities. Avoid re-exporting internal SDK helpers that are not part of the root contract.
+
+## Prove field behavior
+
+Test every normalized field as mapped or rejected. A provider capability claim belongs in documentation only after a payload test or live account check supports it.
+
+Required coverage includes:
+
+- common message validation
+- repeated header handling
+- idempotency forwarding or explicit `none`
+- scheduled-send mapping or rejection
+- native, expanded, or unsupported personalization
+- address and tag limits
+- abort forwarding
+- retryable status mapping
+- conservative `not_sent` and `unknown` delivery classification
+- normalized `adapter` and `id` results
+
+## Keep credentials safe
+
+Accept credentials through factory options and show environment variables in examples. Do not auto-load `.env`, print tokens, include auth values in errors, or expose provider response bodies by default.
+
+## Package for ESM consumers
+
+Declare `type: "module"`, ship declarations, require Node.js 20+ or Bun 1.1+ when your implementation uses the same runtime floor, and peer-depend on the compatible Email SDK major.
+
+## Document support honestly
+
+State provider account prerequisites, known limits, and which claims came from live evidence. The core registry listing does not make a community adapter officially supported.
+
+<Card title="Create an adapter" href="/docs/guides/authoring/create-adapter" description="Build the v1 contract before packaging it." />
+<Card title="Community extensions" href="/docs/plugins/community" description="Understand review and support expectations." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/publish-community-plugin.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/authoring/publish-community-plugin.mdx
@@ -1,0 +1,50 @@
+---
+title: Publish a community plugin
+description: Package a v1-compatible plugin with explicit peer versions, tests, and support documentation.
+---
+
+Community plugins are independent npm packages. They should depend on the public contract rather than repository internals.
+
+## Package the plugin
+
+```json title="package.json"
+{
+  "name": "@example/email-sdk-receipts",
+  "type": "module",
+  "peerDependencies": {
+    "@opencoredev/email-sdk": "^1.0.0"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  }
+}
+```
+
+Keep Email SDK as a peer and development dependency so consumers use one client type identity.
+
+## Test the public behavior
+
+Cover every middleware phase, hook, registered adapter, client extension, reserved-key collision, and duplicate plugin id your package uses. Use `memoryAdapter`, `failingAdapter`, and injected dependencies instead of real credentials.
+
+## Document the contract
+
+The package README should state:
+
+- exact import and setup
+- required environment variables
+- message or send-option changes
+- client extension types
+- failure behavior
+- data retained or logged
+- supported Email SDK versions
+
+Never include live provider credentials or message data in examples.
+
+## Request registry listing
+
+Add the package to the repository's community registry through a pull request. The listing is discovery, not a security or delivery endorsement.
+
+<Card title="Community extensions" href="/docs/plugins/community" description="See the review and support boundary for third-party packages." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Guides",
+  "icon": "BookOpen",
+  "pages": [
+    "schedule-email",
+    "production-send-pipeline",
+    "test-email-behavior",
+    "troubleshoot-failed-sends",
+    "migrate",
+    "authoring"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Migration guides",
+  "icon": "GitCompare",
+  "pages": ["v0-to-v1", "resend", "nodemailer", "sendgrid"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/nodemailer.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/nodemailer.mdx
@@ -1,0 +1,66 @@
+---
+title: Migrate from Nodemailer
+description: Replace a Nodemailer transporter with Email SDK's dependency-free SMTP adapter.
+---
+
+Email SDK includes its own SMTP transport. You do not need Nodemailer for basic address fields, text/HTML bodies, headers, TLS upgrade, and SMTP auth.
+
+## Replace the transporter
+
+```ts title="after.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+const email = createEmailClient({
+  adapters: [
+    smtp({
+      host: process.env.SMTP_HOST!,
+      port: Number(process.env.SMTP_PORT ?? 587),
+      auth: {
+        user: process.env.SMTP_USER!,
+        pass: process.env.SMTP_PASS!,
+      },
+    }),
+  ],
+});
+```
+
+On a non-secure port, SMTP auth upgrades with STARTTLS by default. `allowInsecureAuth` exists only for trusted local test servers.
+
+## Replace `sendMail`
+
+```ts title="after.ts"
+const result = await email.send(
+  {
+    from: "Acme <hello@acme.com>",
+    to: "user@example.com",
+    subject: "Welcome",
+    text: "Your account is ready.",
+    html: "<p>Your account is ready.</p>",
+    headers: [{ name: "X-App", value: "acme" }],
+  },
+  { idempotencyKey: "welcome:user_123" },
+);
+```
+
+The transport creates `multipart/alternative` for text plus HTML and derives `Message-ID` from the idempotency key.
+
+## Account for unsupported features
+
+The built-in SMTP adapter rejects attachments, tags, metadata, and schedules. Keep Nodemailer or build a custom adapter if your SMTP workflow depends on MIME attachments or advanced transport plugins.
+
+## Verify
+
+```bash
+SMTP_HOST=smtp.example.com npx email-sdk doctor --adapter smtp
+npx email-sdk send \
+  --adapter smtp \
+  --host smtp.example.com \
+  --from hello@example.com \
+  --to user@example.com \
+  --subject "Migration smoke test" \
+  --text "Dry run only." \
+  --dry-run
+```
+
+<Card title="SMTP adapter" href="/docs/adapters/smtp" description="See TLS, auth, custom names, and transport limits." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/resend.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/resend.mdx
@@ -1,0 +1,59 @@
+---
+title: Migrate from the Resend SDK
+description: Replace direct Resend calls with a typed Email SDK client while keeping Resend as the delivery adapter.
+---
+
+Keep your Resend API key and verified sender. The migration changes the application boundary, not the provider account.
+
+## Replace construction
+
+```ts title="before.ts"
+import { Resend } from "resend";
+const resend = new Resend(process.env.RESEND_API_KEY);
+```
+
+```ts title="after.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+## Replace sends
+
+```ts title="after.ts"
+const result = await email.send(
+  {
+    from: "Acme <hello@acme.com>",
+    to: "user@example.com",
+    subject: "Welcome",
+    html: "<p>Your account is ready.</p>",
+  },
+  { idempotencyKey: "welcome:user_123" },
+);
+
+console.log(result.id);
+```
+
+Email SDK maps CC, BCC, reply-to, headers, attachments, tags, and `sendAt`. It rejects message metadata because the Resend adapter has no metadata mapping.
+
+## Add a backup only when compatible
+
+A simple SMTP backup cannot carry Resend attachments, tags, or scheduling. Validate the complete route before queueing and keep `onUnknownDelivery: "stop"` unless you explicitly accept duplicate risk.
+
+## Verify
+
+```bash
+RESEND_API_KEY=re_xxx npx email-sdk doctor --adapter resend
+RESEND_API_KEY=re_xxx npx email-sdk send \
+  --adapter resend \
+  --from hello@example.com \
+  --to user@example.com \
+  --subject "Migration smoke test" \
+  --text "Dry run only." \
+  --dry-run
+```
+
+<Card title="Resend adapter" href="/docs/adapters/resend" description="See all options and mapped fields." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/sendgrid.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/sendgrid.mdx
@@ -1,0 +1,65 @@
+---
+title: Migrate from SendGrid
+description: Replace direct Mail Send payloads with normalized messages and explicit personalized sending.
+---
+
+Keep the SendGrid API key and verified sender. Email SDK calls the Mail Send API through the `sendgrid` adapter.
+
+## Create the client
+
+```ts title="src/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { sendgrid } from "@opencoredev/email-sdk/sendgrid";
+
+export const email = createEmailClient({
+  adapters: [sendgrid({ apiKey: process.env.SENDGRID_API_KEY! })],
+});
+```
+
+## Send a normalized message
+
+```ts title="src/send.ts"
+const result = await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+  metadata: { userId: "user_123" },
+  tags: [{ name: "type", value: "welcome" }],
+});
+```
+
+Metadata maps to `custom_args`, tag values map to SendGrid categories, and the adapter reads `id` from the `x-message-id` response header.
+
+## Replace personalized payloads
+
+```ts title="src/send-personalized.ts"
+await email.sendPersonalized({
+  message: {
+    from: "Acme <hello@acme.com>",
+    subject: "Hi %recipient.name%",
+    text: "Welcome, %recipient.name%.",
+  },
+  recipients: [
+    { to: "ada@example.com", variables: { name: "Ada" } },
+    { to: "linus@example.com", variables: { name: "Linus" } },
+  ],
+});
+```
+
+SendGrid has native personalized capability, so this stays one provider request.
+
+## Verify
+
+```bash
+SENDGRID_API_KEY=SG.x npx email-sdk doctor --adapter sendgrid
+SENDGRID_API_KEY=SG.x npx email-sdk send \
+  --adapter sendgrid \
+  --from hello@example.com \
+  --to user@example.com \
+  --subject "Migration smoke test" \
+  --text "Dry run only." \
+  --dry-run
+```
+
+<Card title="SendGrid adapter" href="/docs/adapters/sendgrid" description="See mapped fields, scheduling, and personalized delivery." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/v0-to-v1.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/migrate/v0-to-v1.mdx
@@ -1,0 +1,244 @@
+---
+title: Upgrade from Email SDK 0.x to v1
+description: Migrate constructor options, send options, results, errors, batches, personalization, headers, attachments, dates, and ESM usage.
+---
+
+v1 keeps `createEmailClient` and adapter subpath imports, but removes legacy aliases from the root and makes ambiguous delivery a first-class safety decision. Treat this as a behavior migration, not a vocabulary-only rename.
+
+<Callout title="Ask your coding agent to migrate the app">
+  Install the dynamic migration skill with `npx skills add opencoredev/email-sdk --skill email-sdk-migrate`, then ask the agent to audit before editing:
+
+  ```text
+  Use the email-sdk-migrate skill. Inspect the installed Email SDK version,
+  run the bundled migration audit, migrate this app to v1, preserve delivery
+  semantics, run focused tests and typechecks, and do not send live email.
+  ```
+
+  The skill reads the installed declarations and current migration docs instead of relying on a frozen codemod.
+</Callout>
+
+## Migration map
+
+| Area | v0 | v1 | Risk |
+| --- | --- | --- | --- |
+| Routing | providers, fallback arrays | adapters, explicit fallback policy | Medium |
+| Retry | retries after the first call | total `maxAttempts` | High |
+| Batches | `sendBatch` | ordered settled `sendMany` | Medium |
+| Personalization | message `recipientVariables` | `sendPersonalized` recipients | High |
+| Idempotency | message field | send option | High |
+| Results | provider aliases | normalized adapter result | Medium |
+| Errors | open provider failures | closed SDK error union | High |
+| Headers and dates | permissive shapes | lossless headers and zoned timestamps | Medium |
+
+Start with the high-risk rows because they can change whether an email is retried, duplicated, delayed, or considered successful.
+
+## 1. Choose an upgrade path
+
+- Migrate directly to the v1 root when you can update callers in one change.
+- Import from `@opencoredev/email-sdk/compat` as a temporary bridge when the migration must be incremental.
+
+The compat subpath is available for the v1 major only. It warns once per deprecated feature in development and keeps v1 unknown-delivery safety.
+
+## 2. Rename provider vocabulary
+
+```ts title="before-v0.ts"
+const email = createEmailClient({
+  providers: [resendAdapter, smtpAdapter],
+  defaultProvider: "resend",
+  fallback: ["smtp"],
+});
+
+await email.send(message, {
+  provider: "resend",
+  fallbackProviders: ["smtp"],
+});
+```
+
+```ts title="after-v1.ts"
+const email = createEmailClient({
+  adapters: [resendAdapter, smtpAdapter],
+  defaultAdapter: "resend",
+  fallback: { adapters: ["smtp"] },
+});
+
+await email.send(message, {
+  adapter: "resend",
+  fallback: { adapters: ["smtp"] },
+});
+```
+
+Rename `EmailProvider` to `EmailAdapter`, `EmailProviderContext` to `EmailAdapterContext`, `EmailProviderResponse` to `EmailSendResult`, `EmailProviderError` to `EmailAdapterError`, and `EmailProviderNotFoundError` to `EmailAdapterNotFoundError`.
+
+Adapter option types follow the same rule. For example, `ResendProviderOptions` becomes `ResendAdapterOptions` and `SmtpProviderOptions` becomes `SmtpAdapterOptions`. The same rename applies to every adapter subpath.
+
+The same rename applies to client inspection, bound clients, hooks, and middleware:
+
+| v0 | v1 |
+| --- | --- |
+| `client.providers` | `client.adapters` |
+| `client.defaultProvider` | `client.defaultAdapter` |
+| `client.provider(name)` | `client.adapter(name)` |
+| `client.withProvider(name)` | `client.withAdapter(name)` |
+| `event.provider` | `event.adapter` |
+| `memoryProvider` | `memoryAdapter` |
+| `failingProvider` | `failingAdapter` |
+| `MemoryProvider` | `MemoryAdapter` |
+
+The compat subpath keeps the client aliases and translates hook and middleware events while you migrate callers.
+
+## 3. Rename removed public types
+
+The v1 root exports only the adapter-first types. Update explicit imports and annotations:
+
+| v0 root type | v1 root type or shape |
+| --- | --- |
+| `SendOptions` | `EmailSendOptions` |
+| `SendBatchItem` | `EmailSendItem` with `{ message, options }` |
+| `SendBatchResult` | `EmailSendSettledResult`; successful entries use `result` instead of `response` |
+| `RecipientVariables` | `EmailPersonalizedRecipient["variables"]` for one recipient, passed through `sendPersonalized` |
+
+`RecipientVariables` has no root-level v1 alias because variables now belong to each `EmailPersonalizedRecipient`, not to an address-keyed message field. The compat subpath still exports all four legacy types for an incremental migration.
+
+## 4. Convert retry counts
+
+v0 counted retries after the first call. v1 counts total attempts.
+
+```ts title="before-v0.ts"
+retry: { retries: 2 } // three total calls
+```
+
+```ts title="after-v1.ts"
+retry: { maxAttempts: 3 }
+```
+
+Per-send `retries: 0` becomes `retry: { maxAttempts: 1 }`.
+
+## 5. Adopt delivery-aware fallback
+
+v1 advances automatically after `delivery: "not_sent"`. It stops after `delivery: "unknown"` unless you explicitly accept duplicate risk.
+
+```ts title="after-v1.ts"
+fallback: {
+  adapters: ["backup"],
+  onUnknownDelivery: "stop", // default
+}
+```
+
+## 6. Move idempotency into send options
+
+```ts title="before-v0.ts"
+await email.send({ ...message, idempotencyKey: "receipt:123" });
+```
+
+```ts title="after-v1.ts"
+await email.send(message, { idempotencyKey: "receipt:123" });
+```
+
+## 7. Read normalized results
+
+```ts title="before-v0.ts"
+console.log(result.provider, result.messageId);
+```
+
+```ts title="after-v1.ts"
+console.log(result.adapter, result.id);
+```
+
+The v1 root result has no legacy aliases.
+
+## 8. Replace `sendBatch` with `sendMany`
+
+```ts title="before-v0.ts"
+const results = await email.sendBatch([welcomeMessage, receiptMessage]);
+const first = results[0]?.ok ? results[0].response : undefined;
+```
+
+```ts title="after-v1.ts"
+const results = await email.sendMany([
+  { message: welcomeMessage },
+  { message: receiptMessage },
+]);
+const first = results[0]?.ok ? results[0].result : undefined;
+```
+
+`sendMany` is sequential, ordered, and settled. Concurrency is not configurable in v1.
+
+## 9. Replace `recipientVariables`
+
+```ts title="before-v0.ts"
+await email.send({
+  from: "hello@acme.com",
+  to: ["ada@example.com", "linus@example.com"],
+  subject: "Hi %recipient.name%",
+  text: "Welcome, %recipient.name%.",
+  recipientVariables: {
+    "ada@example.com": { name: "Ada" },
+    "linus@example.com": { name: "Linus" },
+  },
+});
+```
+
+```ts title="after-v1.ts"
+await email.sendPersonalized({
+  message: {
+    from: "hello@acme.com",
+    subject: "Hi %recipient.name%",
+    text: "Welcome, %recipient.name%.",
+  },
+  recipients: [
+    { to: "ada@example.com", variables: { name: "Ada" } },
+    { to: "linus@example.com", variables: { name: "Linus" } },
+  ],
+});
+```
+
+## 10. Convert headers to a lossless array
+
+```ts title="before-v0.ts"
+headers: { "X-Trace": "abc" }
+```
+
+```ts title="after-v1.ts"
+headers: [{ name: "X-Trace", value: "abc" }]
+```
+
+Repeated names are preserved only by adapters that declare `repeatedHeaders: true`.
+
+## 11. Fix attachment sources
+
+An attachment must contain exactly one of `content` or `path`. Remove one source from any v0 object that set both.
+
+## 12. Use zoned schedules
+
+`sendAt` accepts a `Date` or RFC 3339 string with `Z` or a numeric offset. Replace `2026-08-01 09:00` with `2026-08-01T09:00:00Z` or another explicit offset.
+
+## 13. Update error handling
+
+v1 has a closed error-code union: `validation_error`, `adapter_not_found`, `adapter_error`, `route_error`, `all_recipients_failed`, `middleware_error`, and `aborted`.
+
+`EmailRouteError.failures` replaces arbitrary route details. Middleware exceptions become `EmailMiddlewareError`.
+
+## 14. Confirm ESM and telemetry
+
+v1 is ESM-only on Node.js 20+ or Bun 1.1+. Telemetry remains enabled by default with the existing opt-outs: `telemetry: false`, `EMAIL_SDK_TELEMETRY=0`, or `DO_NOT_TRACK=1`.
+
+## 15. Use the compat bridge only temporarily
+
+```ts title="temporary-compat.ts"
+import { createEmailClient } from "@opencoredev/email-sdk/compat";
+```
+
+Compat translates legacy constructor and send option names, `retries`, `sendBatch`, message-level idempotency, recipient variables, and result aliases. Remove it after all callers use the v1 root.
+
+## 16. Verify the migration
+
+1. Run the application typecheck.
+2. Run unit tests with `memoryAdapter` and explicit `not_sent`/`unknown` failures.
+3. Run `email-sdk doctor` for each production adapter.
+4. Run representative `send --dry-run` commands with telemetry disabled.
+5. Review every fallback route against field and capability support.
+
+The migration is complete only when the application has no `/compat` import, no migration-skill findings that belong to Email SDK, and no tests that depend on legacy result aliases.
+
+<Card title="Compatibility reference" href="/docs/reference/compatibility" description="See exactly what the temporary bridge translates." />
+<Card title="Client reference" href="/docs/reference/client" description="Look up the complete v1 method and option surface." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/production-send-pipeline.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/production-send-pipeline.mdx
@@ -1,0 +1,74 @@
+---
+title: Build a production send pipeline
+description: Validate before queueing, preserve durable state, and use retries and fallback without hiding delivery uncertainty.
+---
+
+The core SDK owns one process-local delivery attempt. Your application owns durable queueing, persisted idempotency, and recovery after process failure.
+
+## Construct explicit routes
+
+```ts title="src/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+import { smtp } from "@opencoredev/email-sdk/smtp";
+
+export const email = createEmailClient({
+  adapters: [
+    resend({ apiKey: process.env.RESEND_API_KEY! }),
+    smtp({
+      name: "backup",
+      host: process.env.SMTP_HOST!,
+      auth: { user: process.env.SMTP_USER!, pass: process.env.SMTP_PASS! },
+    }),
+  ],
+  defaultAdapter: "resend",
+  retry: { maxAttempts: 2 },
+  fallback: {
+    adapters: ["backup"],
+    onUnknownDelivery: "stop",
+  },
+});
+```
+
+Choose the backup from the [field support](/docs/adapters/field-support) and [capability](/docs/adapters/capability-groups) tables. SMTP is not a universal backup because it rejects attachments, tags, metadata, and schedules.
+
+## Validate before accepting work
+
+Use the same public no-network boundary as `send` before committing a job to your queue.
+
+```ts title="src/jobs/enqueue-email.ts"
+await email.validate(message, {
+  fallback: { adapters: ["backup"] },
+});
+
+await queue.add("send-email", { message, idempotencyKey });
+```
+
+## Send with a stable idempotency key
+
+```ts title="src/jobs/send-email.ts"
+await email.send(job.message, {
+  idempotencyKey: job.idempotencyKey,
+  metadata: { jobId: job.id },
+  signal: job.signal,
+});
+```
+
+The key is effective only where the selected adapter supports it. Persist your own business-level deduplication before invoking the SDK.
+
+## Handle delivery certainty
+
+- Retry `not_sent` failures when `retryable` is true.
+- Let configured fallback advance after terminal `not_sent` failures.
+- Stop on `unknown` by default and reconcile provider state before retrying.
+- Opt into `onUnknownDelivery: "continue"` only when a duplicate is safer than a missed message.
+
+## Record safe facts
+
+Use hooks or `observabilityPlugin` for adapter, attempt, stable error code, duration, and redacted message facts. Avoid bodies, addresses, credentials, idempotency keys, provider response bodies, URLs, and filesystem paths.
+
+## Use a durable integration when needed
+
+[Convex Email](/docs/integrations/convex) provides queue state, attempts, cancellation, test-mode redirection, and webhook history for Convex applications.
+
+<Card title="Troubleshoot failures" href="/docs/guides/troubleshoot-failed-sends" description="Inspect typed errors and delivery classification." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/schedule-email.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/schedule-email.mdx
@@ -1,0 +1,49 @@
+---
+title: Schedule an email
+description: Use sendAt for a simple future send, and use an app-owned scheduler when you need more control.
+---
+
+For a simple send later today or this week, put `sendAt` on the message:
+
+```ts title="src/send-later.ts"
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Your trial ends tomorrow",
+  text: "Open your account to keep your work.",
+  sendAt: new Date(Date.now() + 60 * 60_000),
+});
+```
+
+The provider holds the email until that time. Email SDK does not keep a timer, run a cron job, or stay alive in the background.
+
+## Supported adapters
+
+`sendAt` works with Resend, SendGrid, Mailgun, MailerSend, Brevo, Mailchimp Transactional, and SparkPost. Other adapters reject the message before sending.
+
+Provider limits still apply. Several providers only accept schedules a few days ahead, so check the adapter page before using a long delay.
+
+If your client has a fallback that cannot schedule, disable that route for this send:
+
+```ts
+await email.send(message, {
+  fallback: { adapters: [] },
+});
+```
+
+Email SDK checks the whole route before sending, so it will not silently hand a scheduled message to an adapter that would send it immediately.
+
+## When to use your own scheduler
+
+Keep the schedule in your database and let a queue, workflow, or cron worker call `email.send` when you need:
+
+- cancellation or rescheduling
+- delays longer than the provider allows
+- a record of pending and completed work
+- retries that survive a server restart
+- the freedom to switch providers before the send happens
+
+A cron job is fine when it polls a durable outbox table. Do not rely on an in-memory timer because a deploy or crash will lose it.
+
+<Card title="Production send pipeline" href="/docs/guides/production-send-pipeline" description="Store delivery state and retries outside the core SDK." />
+<Card title="Delivery capabilities" href="/docs/adapters/capability-groups" description="Compare scheduling, idempotency, and personalized delivery support." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/test-email-behavior.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/test-email-behavior.mdx
@@ -1,0 +1,82 @@
+---
+title: Test email behavior
+description: Assert normalized messages, retries, fallback routes, and lifecycle events without sending real email.
+---
+
+The testing entry point provides an in-memory adapter and a configurable failing adapter.
+
+## Capture a successful send
+
+```ts title="src/email.test.ts"
+import { expect, test } from "bun:test";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { memoryAdapter } from "@opencoredev/email-sdk/testing";
+
+const memory = memoryAdapter();
+const email = createEmailClient({ adapters: [memory] });
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "user@example.com",
+  subject: "Welcome",
+  text: "Your account is ready.",
+});
+
+expect(memory.raw?.sent).toHaveLength(1);
+expect(memory.raw?.sent[0]?.message.subject).toBe("Welcome");
+```
+
+`memory.raw.clear()` resets the store.
+
+## Prove fallback behavior
+
+Fallback advances automatically only after a `not_sent` failure.
+
+```ts title="src/email.test.ts"
+import { EmailAdapterError } from "@opencoredev/email-sdk";
+import { failingAdapter, memoryAdapter } from "@opencoredev/email-sdk/testing";
+
+const primary = failingAdapter(
+  "primary",
+  new EmailAdapterError("Rejected before acceptance", {
+    adapter: "primary",
+    retryable: false,
+    delivery: "not_sent",
+  }),
+);
+const backup = memoryAdapter("backup");
+
+const email = createEmailClient({
+  adapters: [primary, backup],
+  fallback: { adapters: ["backup"] },
+});
+
+const result = await email.send(message);
+expect(result.adapter).toBe("backup");
+```
+
+Use `delivery: "unknown"` to prove the default route stops instead of risking a duplicate.
+
+## Prove retry counts
+
+`maxAttempts` is the total call count. Set `delay: () => 0` in tests.
+
+```ts title="src/email.test.ts"
+const email = createEmailClient({
+  adapters: [primary],
+  retry: {
+    maxAttempts: 3,
+    delay: () => 0,
+  },
+});
+```
+
+## Capture lifecycle events
+
+Use `capturePlugin()` when a test needs ordered `beforeSend`, `retry`, `afterSend`, and `error` records.
+
+## Keep telemetry off
+
+The repository test preload sets `EMAIL_SDK_TELEMETRY=0`. Application tests can also construct clients with `telemetry: false`.
+
+<Card title="Capture plugin" href="/docs/plugins/built-in/capture" description="Inspect complete lifecycle events through a typed client property." />

--- a/apps/fumadocs/content/docs-v/1.0.0/guides/troubleshoot-failed-sends.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/guides/troubleshoot-failed-sends.mdx
@@ -1,0 +1,64 @@
+---
+title: Troubleshoot failed sends
+description: Diagnose failures by the exported error class, stable code, adapter, and delivery classification.
+---
+
+Start with the error code. Provider messages alone do not tell you whether the failure happened before or after possible dispatch.
+
+## Validation fails before network work
+
+`EmailValidationError` means the common message, route, capability, schedule, or adapter-specific check failed.
+
+Check:
+
+1. `from`, at least one `to`, `subject`, and `text` or `html` are present.
+2. Every attachment has exactly one of `content` or `path`.
+3. `sendAt` has `Z` or a numeric offset.
+4. Every fallback adapter supports all non-empty fields.
+5. Adapter-specific recipient and tag limits match the message.
+
+Run the same path without sending:
+
+```bash
+EMAIL_SDK_TELEMETRY=0 npx email-sdk send \
+  --adapter resend \
+  --from hello@example.com \
+  --to user@example.com \
+  --subject "Validation smoke test" \
+  --text "Dry run only." \
+  --dry-run
+```
+
+## Adapter name is missing
+
+`EmailAdapterNotFoundError` includes the unregistered `adapter`. Construction catches unknown defaults and client fallbacks; runtime strings can still reach this error.
+
+```bash
+npx email-sdk adapters
+```
+
+## One adapter failed
+
+`EmailAdapterError` includes `adapter`, optional HTTP `status` and `requestId`, `retryable`, and `delivery`.
+
+- `not_sent` may advance to fallback.
+- `unknown` stops fallback unless you explicitly configured continuation.
+
+## Every route failed
+
+`EmailRouteError.failures` contains ordered `EmailAdapterError` values. Inspect each adapter and delivery value, then keep the full chain in server-side diagnostics without exposing provider bodies to users.
+
+## Personalized recipients all failed
+
+`EmailAllRecipientsFailedError.failures` means `sendPersonalized` accepted no recipients. Partial success resolves instead, with both `accepted` and `rejected` arrays.
+
+## Middleware or abort stopped the route
+
+`EmailMiddlewareError.phase` identifies `before_send`, `after_send`, or `on_error`. `EmailAbortError` means the signal stopped active work or backoff and prevented later retry/fallback.
+
+## Configuration is present but delivery still fails
+
+`doctor` checks required values, not provider account state. A live test can still fail because of sender verification, sandbox restrictions, API scope, region, account review, or rate limits.
+
+<Card title="Error reference" href="/docs/reference/errors" description="Open the exact class and field contract for each code." />
+<Card title="Adapter docs" href="/docs/adapters" description="Check provider-specific options and account requirements." />

--- a/apps/fumadocs/content/docs-v/1.0.0/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/index.mdx
@@ -1,0 +1,41 @@
+---
+title: Email SDK
+description: Send transactional email through 23 adapters with one typed TypeScript SDK.
+---
+
+Install the SDK, add the adapter for your provider, and call `email.send()`. The message shape stays the same if you switch providers later.
+
+<Card title="Send your first email" href="/docs/getting-started/quickstart" description="Install the SDK, configure one adapter, and send a message from Node.js or Bun." />
+
+## Start here
+
+```ts title="email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+export const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+Now call `email.send({ from, to, subject, text })`. Add retries, fallback, plugins, and more adapters only when you need them.
+
+## Included
+
+- 22 provider API adapters plus SMTP, 23 adapters total
+- Typed adapter names in `send`, `validate`, `adapter`, and `withAdapter`
+- Retries on the current adapter, then fallback only when delivery is known to have failed
+- Independent `sendMany` calls and personalized `sendPersonalized` delivery
+- Hooks, middleware, built-in plugins, and no-network test adapters
+- Provider-native scheduled sends with `sendAt`
+- CLI commands for adapter discovery, setup checks, and validated dry runs
+- Optional approval-gated AI SDK tools for agent workflows
+
+## Runtime boundary
+
+Email SDK is ESM-only and server-side. It supports Node.js 20+ and Bun 1.1+. Keep API keys and SMTP credentials out of browser bundles.
+
+<Card title="Install" href="/docs/getting-started/install" description="Install the SDK and confirm your Node.js or Bun version." />
+<Card title="Schedule an email" href="/docs/guides/schedule-email" description="Use sendAt for provider scheduling, or keep long-running jobs in your own queue." />
+<Card title="Choose an adapter" href="/docs/concepts/adapter-model" description="Set a default adapter and select another by its typed name when needed." />
+<Card title="Upgrade from 0.x" href="/docs/guides/migrate/v0-to-v1" description="Replace v0 provider names and send options with v1 adapters and options." />

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/ai-sdk.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/ai-sdk.mdx
@@ -1,0 +1,61 @@
+---
+title: AI SDK
+description: Add one narrow, approval-gated sendEmail tool to a Vercel AI SDK agent.
+icon: Bot
+---
+
+Email SDK exposes an optional [`/ai`](/docs/reference/client) entry point for [AI SDK](https://ai-sdk.dev/). It binds the sender in application code, restricts model-visible input, requires approval, and returns a secret-safe result.
+
+## Install
+
+```bash
+bun add ai @opencoredev/email-sdk
+```
+
+## Create the tool
+
+```ts title="src/agent/email-tools.ts"
+import { createEmailTools } from "@opencoredev/email-sdk/ai";
+import { email } from "../email.js";
+
+export const emailTools = createEmailTools({
+  client: email,
+  from: "Acme <hello@acme.com>",
+});
+```
+
+The helper returns `tools.sendEmail` and a matching `toolApproval` policy.
+
+```ts title="src/agent/respond.ts"
+import { generateText, type ModelMessage } from "ai";
+import { emailTools } from "./email-tools.js";
+
+export function respond(messages: ModelMessage[]) {
+  return generateText({
+    model: "openai/gpt-5.5",
+    messages,
+    tools: emailTools.tools,
+    toolApproval: emailTools.toolApproval,
+  });
+}
+```
+
+The first call returns a `tool-approval-request` instead of sending. Render that request, collect the user's decision, append a `tool-approval-response` to the messages, and call the model again. The tool executes only after an approved response. AI SDK 6 can still read the tool-level `needsApproval: true` fallback; AI SDK 7 applications should pass the returned top-level `toolApproval` map.
+
+## What the model can request
+
+The input schema accepts only:
+
+- `to`
+- `subject`
+- `text` and/or `html`
+
+The application binds `from`. The model cannot choose adapters, fallbacks, retries, idempotency keys, schedules, attachments, CC, BCC, headers, metadata, or provider URLs.
+
+Approved execution derives `email-tool:${toolCallId}` as the idempotency key and forwards the abort signal. Success returns only `{ status: "sent", adapter, id? }`. Failures become `Error("Email could not be sent.")`, so provider responses and raw errors do not reach the model.
+
+## Approval UI
+
+Render the exact recipients, subject, and body before approval. A denial is terminal and must result in zero provider calls.
+
+<Card title="Chat SDK" href="/docs/integrations/chat-sdk" description="Use Email SDK from multi-platform chat handlers." />

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/chat-sdk.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/chat-sdk.mdx
@@ -1,0 +1,64 @@
+---
+title: Chat SDK
+description: Send transactional email from Chat SDK handlers while keeping identity, authorization, and delivery policy in application code.
+icon: AiChat
+---
+
+[Chat SDK](https://chat-sdk.dev/) gives one event-driven API for Slack, Teams, Discord, Google Chat, and other chat platforms. Email SDK fits inside those handlers when a chat workflow needs to send a receipt, invite, report, or other transactional message.
+
+## Install
+
+```bash
+bun add chat @opencoredev/email-sdk
+```
+
+Configure Email SDK once in a server-only module. The Chat SDK handler should receive an already configured client rather than provider credentials.
+
+```ts title="src/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { resend } from "@opencoredev/email-sdk/resend";
+
+export const email = createEmailClient({
+  adapters: [resend({ apiKey: process.env.RESEND_API_KEY! })],
+});
+```
+
+## Send from a handler
+
+```ts title="src/bot.ts"
+import { Chat } from "chat";
+import { createSlackAdapter } from "@chat-adapter/slack";
+import { email } from "./email.js";
+
+export const bot = new Chat({
+  userName: "acme-ops",
+  adapters: { slack: createSlackAdapter() },
+});
+
+bot.onNewMention(async (thread, message) => {
+  if (message.text.trim() !== "send my weekly report") return;
+
+  const user = await loadAuthorizedUser(message.author.id);
+  const report = await renderWeeklyReport(user.id);
+
+  await email.send(
+    {
+      from: "Acme Reports <reports@acme.com>",
+      to: user.email,
+      subject: "Your weekly report",
+      html: report.html,
+    },
+    { idempotencyKey: `weekly-report:${user.id}:${report.week}` },
+  );
+
+  await thread.post("Your weekly report was queued for email delivery.");
+});
+```
+
+Keep the authorization check, recipient lookup, sender, template, and idempotency key in application code. Do not let arbitrary chat text select recipients, adapters, fallback routes, headers, or attachments.
+
+## Add an AI agent
+
+Chat SDK and AI SDK can be used together. Chat SDK owns the conversation and platform adapters; [AI SDK](/docs/integrations/ai-sdk) owns model execution and the approval-gated `sendEmail` tool.
+
+<Card title="AI SDK" href="/docs/integrations/ai-sdk" description="Add a narrow email tool with explicit user approval." />

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/index.mdx
@@ -1,0 +1,36 @@
+---
+title: Convex
+description: Durable, provider-portable transactional email for Convex applications.
+---
+
+`@opencoredev/convex-email` is a real Convex Component: it owns isolated tables, queues provider work outside your mutation, retries safe failures, deduplicates sends, stores an event timeline, and exposes reactive delivery status.
+
+Email SDK owns message validation and provider adapters. The Convex component owns durable application state around those sends.
+
+## What you get
+
+- **Fast mutations.** `send` stores the message and returns an email id before the provider request runs.
+- **Durable idempotency.** Reusing an idempotency key returns the original email id instead of queueing another message.
+- **Retry and recovery.** Failed attempts use exponential backoff, stale processing work is recovered safely, and terminal failures can be retried manually.
+- **Provider portability.** Use any serializable built-in Email SDK adapter configuration, including named fallback routes.
+- **Reactive status.** Query queue state, provider receipts, attempted adapters, normalized delivery state, and the complete event timeline.
+- **Safe testing.** Redirect all recipients to a sandbox mailbox or use the in-memory adapter without changing application flow.
+
+## Public API
+
+| Method | Purpose |
+| --- | --- |
+| `send(ctx, message)` | Queue one email and return its component id. |
+| `sendBatch(ctx, messages)` | Queue up to 100 messages and return ids in input order. |
+| `status(ctx, { emailId })` | Read the current stored email state. |
+| `listEvents(ctx, { emailId })` | Read the ordered queue, attempt, retry, and webhook timeline. |
+| `cancel(ctx, { emailId })` | Cancel work that has not started. |
+| `retry(ctx, { emailId })` | Start a fresh retry cycle for a terminal failure. |
+| `setConfig(ctx, config)` | Replace test, sender, retry, and retention defaults. |
+
+<CardGroup cols={2}>
+  <Card title="Install and configure" href="/docs/integrations/convex/setup" description="Mount the component, map provider secrets, and create the server client." />
+  <Card title="Send and track email" href="/docs/integrations/convex/sending-and-status" description="Queue messages and expose reactive status to your application." />
+  <Card title="Process webhooks" href="/docs/integrations/convex/webhooks" description="Verify provider events and store normalized delivery state." />
+  <Card title="Test and recover" href="/docs/integrations/convex/testing-and-recovery" description="Redirect recipients, inspect failures, cancel work, and retry safely." />
+</CardGroup>

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Convex",
+  "icon": "Convex",
+  "pages": ["index", "setup", "sending-and-status", "webhooks", "testing-and-recovery"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/sending-and-status.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/sending-and-status.mdx
@@ -1,0 +1,92 @@
+---
+title: Send and track email
+description: Queue email from Convex mutations, expose reactive status, and inspect the complete event timeline.
+---
+
+## Queue from a mutation
+
+```ts title="convex/users.ts"
+import { v } from "convex/values";
+import { mutation } from "./_generated/server";
+import { email } from "./email";
+
+export const sendWelcomeEmail = mutation({
+  args: { userId: v.id("users") },
+  returns: v.string(),
+  handler: async (ctx, { userId }) => {
+    const user = await ctx.db.get(userId);
+    if (!user) throw new Error("User not found.");
+
+    return await email.send(ctx, {
+      to: user.email,
+      subject: "Welcome to Acme",
+      text: `Hi ${user.name}, your account is ready.`,
+      idempotencyKey: `welcome:${userId}`,
+    });
+  },
+});
+```
+
+`send` writes the queue record in the calling mutation's transaction and returns its component id. If the outer mutation rolls back, the email is not queued. Provider delivery starts after the transaction commits.
+
+Use a stable idempotency key for every user-visible message that application code may enqueue again. Reusing the key returns the existing email id.
+
+## Expose reactive status
+
+Component functions are not directly callable from a browser. Wrap the query in your app and apply the same authorization rules as the related application data.
+
+```ts title="convex/emailQueries.ts"
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+import { email } from "./email";
+
+export const status = query({
+  args: { emailId: v.string() },
+  handler: async (ctx, args) => {
+    await requireEmailOperationsAccess(ctx);
+    return await email.status(ctx, args);
+  },
+});
+
+export const events = query({
+  args: { emailId: v.string() },
+  handler: async (ctx, args) => {
+    await requireEmailOperationsAccess(ctx);
+    return await email.listEvents(ctx, args);
+  },
+});
+```
+
+A subscribed client updates as the record moves through `queued`, `processing`, `sent`, `failed`, or `canceled`. Webhooks add `deliveryStatus` values `delivered`, `bounced`, or `complained` without discarding queue history.
+
+## Understand the two status layers
+
+| Field | Meaning |
+| --- | --- |
+| `status` | Whether the component queued and handed the message to a provider. |
+| `deliveryStatus` | What a provider webhook later reported about mailbox delivery. |
+| `attemptedAdapters` | Every named adapter attempted across the current record. |
+| `providerMessageId` | The provider receipt used to correlate webhook events. |
+| `lastError` | The last component send failure, if the send is retrying or terminal. |
+| `nextAttemptAt` | When the next automatic retry becomes eligible. |
+
+A `sent` queue status is not proof of inbox delivery. Treat webhook-backed `delivered` as the positive delivery signal.
+
+## Batch enqueue
+
+```ts
+const ids = await email.sendBatch(ctx, messages);
+```
+
+`sendBatch` accepts at most 100 messages per mutation and returns ids in input order. Duplicate idempotency keys within the batch resolve to the same stored email.
+
+## Cancel before processing
+
+```ts
+const canceled = await email.cancel(ctx, { emailId });
+```
+
+Cancellation returns `true` only while the record is still queued. It cannot recall a provider request that already started.
+
+<Card title="Process webhooks" href="/docs/integrations/convex/webhooks" description="Turn provider events into normalized delivery state." />
+<Card title="Test and recover" href="/docs/integrations/convex/testing-and-recovery" description="Inspect failures and start a safe manual retry." />

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/setup.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/setup.mdx
@@ -1,0 +1,129 @@
+---
+title: Install and configure
+description: Mount the Convex component, map provider secrets, create the server client, and set safe defaults.
+---
+
+<Steps>
+
+<Step>
+
+### Install the packages
+
+```bash
+bun add @opencoredev/convex-email @opencoredev/email-sdk
+```
+
+The component uses the same built-in adapters as Email SDK, but its configuration must be serializable across the Convex component boundary.
+
+</Step>
+
+<Step>
+
+### Mount the component
+
+Declare only the environment variables your routes need, then map them into the component instance.
+
+```ts title="convex/convex.config.ts"
+import convexEmail from "@opencoredev/convex-email/convex.config.js";
+import { defineApp } from "convex/server";
+import { v } from "convex/values";
+
+const app = defineApp({
+  env: {
+    RESEND_API_KEY: v.optional(v.string()),
+    SMTP_HOST: v.optional(v.string()),
+    SMTP_PORT: v.optional(v.string()),
+    SMTP_USER: v.optional(v.string()),
+    SMTP_PASS: v.optional(v.string()),
+  },
+});
+
+app.use(convexEmail, {
+  env: {
+    RESEND_API_KEY: app.env.RESEND_API_KEY,
+    SMTP_HOST: app.env.SMTP_HOST,
+    SMTP_PORT: app.env.SMTP_PORT,
+    SMTP_USER: app.env.SMTP_USER,
+    SMTP_PASS: app.env.SMTP_PASS,
+  },
+});
+
+export default app;
+```
+
+Run `bunx convex dev` after installing the component so Convex generates `components.convexEmail` in your app.
+
+</Step>
+
+<Step>
+
+### Set provider secrets
+
+```bash
+bunx convex env set RESEND_API_KEY re_xxx
+```
+
+Secrets stay in the Convex deployment. Adapter configuration stores environment-variable names, never raw credentials.
+
+</Step>
+
+<Step>
+
+### Create the server client
+
+```ts title="convex/email.ts"
+import { ConvexEmail } from "@opencoredev/convex-email";
+import { components } from "./_generated/api";
+
+export const email = new ConvexEmail(components.convexEmail, {
+  adapters: [
+    { kind: "resend" },
+    { kind: "smtp", name: "backup-smtp" },
+  ],
+  defaultAdapter: "resend",
+  fallbackAdapters: ["backup-smtp"],
+  maxAttempts: 3,
+  retryBaseMs: 30_000,
+});
+```
+
+The client is server-only. Component functions are internal to your Convex backend, so expose app queries and mutations with your own authorization checks.
+
+</Step>
+
+<Step>
+
+### Store application defaults
+
+`setConfig` replaces the complete stored configuration. Put it behind an internal mutation or administrator-only action.
+
+```ts title="convex/emailAdmin.ts"
+import { internalMutation } from "./_generated/server";
+import { email } from "./email";
+
+export const configure = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    await email.setConfig(ctx, {
+      defaultFrom: "Acme <hello@acme.com>",
+      testMode: true,
+      sandboxTo: ["email-preview@acme.com"],
+      maxAttempts: 3,
+      retryBaseMs: 30_000,
+      cleanupAfterDays: 30,
+    });
+  },
+});
+```
+
+Start with test mode enabled. Move to production by replacing the config with `testMode: false` after your provider domain, webhook verification, and monitoring are ready.
+
+</Step>
+
+</Steps>
+
+<Callout type="info" title="Serializable adapter options">
+Custom `fetch` functions, SMTP TLS objects, and function-valued provider options cannot cross the component boundary. Use the equivalent serializable option or keep that specialized send in an application Node action.
+</Callout>
+
+<Card title="Send and track email" href="/docs/integrations/convex/sending-and-status" description="Queue messages and expose reactive state." />

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/testing-and-recovery.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/testing-and-recovery.mdx
@@ -1,0 +1,81 @@
+---
+title: Test and recover
+description: Redirect recipients, use in-memory delivery, inspect failure history, cancel queued work, and retry terminal failures.
+---
+
+## Redirect every recipient
+
+Test mode changes the stored message before it is queued. It replaces `to`, removes `cc` and `bcc`, and adds `metadata.convexEmailTestMode: true`.
+
+```ts title="convex/emailAdmin.ts"
+await email.setConfig(ctx, {
+  defaultFrom: "Acme <hello@acme.com>",
+  testMode: true,
+  sandboxTo: ["email-preview@acme.com"],
+  maxAttempts: 2,
+  retryBaseMs: 1_000,
+  cleanupAfterDays: 7,
+});
+```
+
+`setConfig` replaces the whole document, so include every value you want to keep. Test mode without `sandboxTo` fails before enqueueing and cannot contact the original recipients.
+
+## Use in-memory delivery
+
+```ts title="convex/email.ts"
+export const email = new ConvexEmail(components.convexEmail, {
+  adapters: [{ kind: "memory" }],
+  defaultAdapter: "memory",
+});
+```
+
+The memory adapter exercises the real queue, scheduler, status, event, idempotency, cancellation, and cleanup behavior without a network call.
+
+For `convex-test`, register the packaged component helper:
+
+```ts title="convex/test.setup.ts"
+import convexEmailTest from "@opencoredev/convex-email/test";
+import { convexTest } from "convex-test";
+
+export function createTest() {
+  const t = convexTest();
+  convexEmailTest.registerConvexEmail(t);
+  return t;
+}
+```
+
+## Read the failure before retrying
+
+```ts
+const status = await email.status(ctx, { emailId });
+const events = await email.listEvents(ctx, { emailId });
+```
+
+Check `lastError`, `attemptCount`, `attemptedAdapters`, and the ordered events. Fix missing credentials, invalid sender configuration, unsupported message fields, or provider policy errors before starting another cycle.
+
+## Retry a terminal failure
+
+```ts title="convex/emailAdmin.ts"
+import { v } from "convex/values";
+import { internalMutation } from "./_generated/server";
+import { email } from "./email";
+
+export const retry = internalMutation({
+  args: { emailId: v.string() },
+  returns: v.boolean(),
+  handler: async (ctx, args) => email.retry(ctx, args),
+});
+```
+
+`retry` returns `true` only for a terminal `failed` record. It resets the attempt counter, clears the terminal error, appends a manual `retry_scheduled` event, and queues processing immediately. Sent and canceled messages are not retryable.
+
+Use an idempotency key on the original message. Automatic recovery refuses to retry stale in-flight sends without one because the provider may already have accepted the message before the worker lost its result.
+
+## Expose only authorized operations
+
+`exposeApi()` can generate app function definitions for send, batch, status, events, cancellation, and retry. Configuration functions stay excluded unless `includeConfigApi: true`.
+
+Most applications should write explicit wrappers instead. That keeps authentication, tenant checks, recipient policy, and administrator-only recovery visible in application code.
+
+<Card title="Send and track email" href="/docs/integrations/convex/sending-and-status" description="Understand queue state and event history." />
+<Card title="Test core Email SDK" href="/docs/guides/test-email-behavior" description="Use memory and failing adapters outside Convex." />

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/webhooks.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/convex/webhooks.mdx
@@ -1,0 +1,64 @@
+---
+title: Process webhooks
+description: Verify provider webhook requests in application code and store normalized delivery events in the Convex component.
+---
+
+Provider webhooks are public HTTP endpoints. The application owns the URL and signature check; the component owns deduplication, message correlation, event history, and normalized delivery state.
+
+## Register a route
+
+```ts title="convex/http.ts"
+import { httpRouter } from "convex/server";
+import { email } from "./email";
+import { verifyResendWebhook } from "./webhookVerification";
+
+const http = httpRouter();
+
+email.registerRoutes(http, {
+  pathPrefix: "/email",
+  providers: ["resend"],
+  verify: async ({ body, headers }) =>
+    verifyResendWebhook({
+      body,
+      headers,
+      secret: process.env.RESEND_WEBHOOK_SECRET!,
+    }),
+});
+
+export default http;
+```
+
+This registers `POST /email/webhooks/resend` on your deployment's `.convex.site` domain.
+
+<Callout type="warn" title="Never omit verification in production">
+`verify` receives the provider name, original `Request`, raw body, and normalized headers. Verify the raw request with the provider's official algorithm before the component sees it. A shared header comparison is acceptable for a private development tunnel, not for an internet-facing production endpoint.
+</Callout>
+
+## What the component stores
+
+Every accepted delivery receives a stable provider delivery id. Replayed webhook requests return successfully without creating a duplicate event.
+
+When `providerMessageId` matches a stored send, the component appends a `webhook` event and updates normalized state:
+
+| Provider event | Stored result |
+| --- | --- |
+| Delivered | `deliveryStatus: "delivered"` and `deliveredAt` |
+| Permanent bounce or rejection | `deliveryStatus: "bounced"` |
+| Spam complaint | `deliveryStatus: "complained"` |
+| Temporary failure | Event history only |
+| Open, click, or unknown event | Event history only |
+
+Bounces and complaints remain sticky against a late delivered event. When both a bounce and complaint arrive, the latest terminal webhook wins.
+
+## Supported payload shapes
+
+The current normalizer understands Resend, Postmark, and Mailgun-style payloads. Other providers are stored through the generic event path when they expose a provider message id and event name, but you should test their exact payload shape before relying on normalized `deliveryStatus`.
+
+## Test locally
+
+1. Send through a provider test address and capture the stored `providerMessageId`.
+2. POST a signed test webhook to the route.
+3. Query `email.status` and `email.listEvents`.
+4. Replay the same delivery id and confirm no second event appears.
+
+<Card title="Send and track email" href="/docs/integrations/convex/sending-and-status" description="Read queue state and the webhook-backed delivery result." />

--- a/apps/fumadocs/content/docs-v/1.0.0/integrations/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/integrations/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Integrations",
+  "icon": "Integrations",
+  "pages": ["convex", "chat-sdk", "ai-sdk"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Email SDK",
+  "pages": [
+    "index",
+    "getting-started",
+    "adapters",
+    "concepts",
+    "plugins",
+    "ui",
+    "integrations",
+    "agents",
+    "guides",
+    "reference"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/capture.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/capture.mdx
@@ -1,0 +1,60 @@
+---
+title: Capture plugin
+description: Record lifecycle events in memory and expose the store through a typed client extension.
+---
+
+`capturePlugin` is useful in application tests and local debugging. It stores full normalized messages, so do not use it as an unbounded production log.
+
+```ts title="src/email.test.ts"
+import { expect, test } from "bun:test";
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { capturePlugin } from "@opencoredev/email-sdk/plugins/capture";
+import { memoryAdapter } from "@opencoredev/email-sdk/testing";
+
+const email = createEmailClient({
+  adapters: [memoryAdapter()],
+  plugins: [capturePlugin()],
+});
+
+await email.send(message);
+expect(email.capture.events.map((event) => event.type)).toEqual([
+  "beforeSend",
+  "afterSend",
+]);
+```
+
+## Captured events
+
+The store records `beforeSend`, `afterSend`, `retry`, and `error`. Success, retry, and error records include the adapter and attempt. The store keeps the complete message and send metadata.
+
+## Supply a store
+
+Use `createEmailCaptureStore` when multiple clients or tests should share an explicitly managed store.
+
+```ts title="src/email.test.ts"
+import {
+  capturePlugin,
+  createEmailCaptureStore,
+} from "@opencoredev/email-sdk/plugins/capture";
+
+const store = createEmailCaptureStore();
+const plugin = capturePlugin(store);
+
+store.clear();
+```
+
+## Rename the client property
+
+```ts title="src/email.ts"
+const email = createEmailClient({
+  adapters: [adapter],
+  plugins: [capturePlugin({ clientKey: "emailEvents" })],
+});
+
+email.emailEvents.clear();
+```
+
+The plugin rejects a client key that collides with a built-in client property or another extension.
+
+<Card title="Test email behavior" href="/docs/guides/test-email-behavior" description="Assert messages, retries, fallback, and failures without network calls." />
+<Card title="Plugin API" href="/docs/reference/plugin-api" description="See captured event and extension types." />

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/defaults.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/defaults.mdx
@@ -1,0 +1,46 @@
+---
+title: Defaults plugin
+description: Apply reply-to, headers, tags, metadata, send metadata, and idempotency defaults before validation.
+---
+
+`defaultsPlugin` merges defaults into each send while preserving explicit per-message and per-send values.
+
+```ts title="src/email.ts"
+import { defaultsPlugin } from "@opencoredev/email-sdk/plugins/defaults";
+
+const email = createEmailClient({
+  adapters: [adapter],
+  plugins: [
+    defaultsPlugin({
+      replyTo: "support@example.com",
+      headers: [{ name: "X-App", value: "billing" }],
+      tags: [{ name: "environment", value: "production" }],
+      metadata: { application: "billing" },
+      sendMetadata: { queue: "transactional" },
+      idempotencyKeyPrefix: "billing:",
+    }),
+  ],
+});
+```
+
+## Merge rules
+
+- Explicit `replyTo` wins over the default.
+- Header and tag arrays append message values after defaults.
+- Message metadata and send metadata merge by key, with explicit values winning.
+- An explicit send-option idempotency key wins over `idempotencyKey`.
+- `idempotencyKeyPrefix` is prepended once unless the key already starts with it.
+
+Defaults run in `beforeSend` middleware, so the complete merged message is validated against every candidate adapter.
+
+## Avoid incompatible defaults
+
+A default field applies to every send through the client. If one fallback adapter cannot represent that field, validation fails even when the primary can.
+
+```ts title="src/email.ts"
+// SMTP does not support tags, so do not apply a global tag default
+// when SMTP is part of the route.
+```
+
+<Card title="Field support" href="/docs/adapters/field-support" description="Check defaults against every candidate route." />
+<Card title="Plugin API" href="/docs/reference/plugin-api" description="See middleware and plugin type definitions." />

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Built-in plugins",
+  "icon": "PackagePlus",
+  "pages": ["defaults", "routing", "timeout", "observability", "capture"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/observability.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/observability.mdx
@@ -1,0 +1,68 @@
+---
+title: Observability plugin
+description: Emit send, retry, and error events through isolated log, metric, and trace callbacks.
+---
+
+`observabilityPlugin` calls each configured observer with `Promise.allSettled`, so observer failures do not reject the send.
+
+```ts title="src/email.ts"
+import { observabilityPlugin } from "@opencoredev/email-sdk/plugins/observability";
+
+const email = createEmailClient({
+  adapters: [adapter],
+  plugins: [
+    observabilityPlugin({
+      log(event) {
+        console.info(event.type, {
+          adapter: event.adapter,
+          attempt: event.attempt,
+        });
+      },
+    }),
+  ],
+});
+```
+
+## Event types
+
+| Type | Emitted when | Additional fields |
+| --- | --- | --- |
+| `email.sent` | An adapter succeeds. | `responseId?` |
+| `email.retry` | A retry is scheduled. | `nextAttempt`, `delayMs`, `error` |
+| `email.error` | An adapter reaches terminal failure. | `error` |
+
+Every event includes the adapter, attempt, redacted message facts, and optional send metadata.
+
+## Default redaction
+
+The built-in redactor keeps:
+
+- `subject`
+- recipient counts
+- whether HTML or text exists
+- attachment count
+- tag names
+- metadata keys
+
+It excludes bodies, addresses, attachment contents, and metadata values. If subjects are sensitive, provide `redactMessage` and return a stricter `RedactedEmailMessage`.
+
+```ts title="src/email.ts"
+observabilityPlugin({
+  redactMessage(message) {
+    return {
+      subject: "[redacted]",
+      toCount: Array.isArray(message.to) ? message.to.length : 1,
+      ccCount: 0,
+      bccCount: 0,
+      hasHtml: Boolean(message.html),
+      hasText: Boolean(message.text),
+      attachmentCount: message.attachments?.length ?? 0,
+      tagNames: [],
+      metadataKeys: [],
+    };
+  },
+});
+```
+
+<Card title="Hooks and middleware" href="/docs/concepts/hooks" description="Understand lifecycle ordering and failure isolation." />
+<Card title="Telemetry and privacy" href="/docs/reference/telemetry" description="Separate SDK analytics from your application observability." />

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/routing.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/routing.mdx
@@ -1,0 +1,35 @@
+---
+title: Routing plugin
+description: Select a registered adapter from the prepared message and send options before route validation.
+---
+
+`routingPlugin` centralizes application routing rules without hiding fallback behavior inside an adapter.
+
+```ts title="src/email.ts"
+import { routingPlugin } from "@opencoredev/email-sdk/plugins/routing";
+
+const email = createEmailClient({
+  adapters: [primary, transactional],
+  plugins: [
+    routingPlugin({
+      select({ message, options }) {
+        if (options?.metadata?.tenant === "enterprise") return "primary";
+        if (message.tags?.some((tag) => tag.name === "receipt")) {
+          return "transactional";
+        }
+      },
+    }),
+  ],
+});
+```
+
+The selector may be async. Returning `undefined` preserves the caller's adapter choice or the client default. Returning a name sets the primary adapter; normal retry, validation, and fallback rules still apply.
+
+## Keep rules deterministic
+
+Route from data already present in the message or send metadata. Avoid network calls in the selector because they delay every send and can fail as `EmailMiddlewareError` before provider validation.
+
+A routing plugin does not register adapters. Every returned name must already exist on the client.
+
+<Card title="Delivery capabilities" href="/docs/adapters/capability-groups" description="Make sure every selected route preserves the required behavior." />
+<Card title="Fallback and retries" href="/docs/concepts/fallbacks-and-retries" description="Understand what happens after the primary route fails." />

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/timeout.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/built-in/timeout.mdx
@@ -1,0 +1,28 @@
+---
+title: Timeout plugin
+description: Bound one logical send, including retries and fallback, while preserving caller cancellation.
+---
+
+`timeoutPlugin` adds an `AbortSignal.timeout` to every send. When a caller already supplies a signal, the plugin combines both and aborts on whichever happens first.
+
+```ts title="src/email.ts"
+import { timeoutPlugin } from "@opencoredev/email-sdk/plugins/timeout";
+
+const email = createEmailClient({
+  adapters: [primary, backup],
+  plugins: [timeoutPlugin({ timeoutMs: 10_000 })],
+  retry: { maxAttempts: 2 },
+  fallback: { adapters: ["backup"] },
+});
+```
+
+The timeout covers the whole logical operation after `beforeSend` begins. It does not reset for each retry or fallback adapter. A timeout surfaces as `EmailAbortError` and stops routing.
+
+## Choose the bound from the user operation
+
+Use a short timeout for request-response flows and a larger timeout in durable workers. The plugin is not a queue deadline and does not cancel a provider request after the provider has already accepted it.
+
+`timeoutMs` must be a positive finite number. Use a custom `id` when registering multiple instances for separate composed clients.
+
+<Card title="Aborted error" href="/docs/reference/errors/aborted" description="Handle caller cancellation and timeout failures." />
+<Card title="Production pipeline" href="/docs/guides/production-send-pipeline" description="Use durable worker deadlines and persisted recovery." />

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/community.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/community.mdx
@@ -1,0 +1,41 @@
+---
+title: Community plugins and adapters
+description: Evaluate third-party Email SDK extensions without treating them as core-maintained integrations.
+---
+
+Community packages can register adapters, hooks, middleware, and typed client extensions through the public plugin contract.
+
+<CommunityPluginRegistry />
+
+## Review before installing
+
+Check the package source and release history for:
+
+- support for the current `@opencoredev/email-sdk` major
+- a literal adapter name and complete capability declaration
+- explicit validation for every normalized field the provider cannot represent
+- secret-safe errors, logs, and examples
+- tests for payload mapping, retries, aborts, idempotency, and ambiguous delivery
+- no browser credential exposure
+
+A community adapter should return `EmailSendResult` and throw typed `EmailAdapterError` values with conservative `delivery` classification.
+
+## Install without changing the root client
+
+```ts title="src/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { acmePlugin } from "@example/email-sdk-acme";
+
+const email = createEmailClient({
+  plugins: [acmePlugin({ apiKey: process.env.ACME_API_KEY! })],
+});
+```
+
+The plugin must register at least one adapter when the client has no `adapters` option.
+
+## Support boundary
+
+The Email SDK maintainers do not verify third-party credentials, delivery claims, or account behavior. Report core contract defects to Email SDK and package-specific defects to the community maintainer.
+
+<Card title="Publish a community plugin" href="/docs/guides/authoring/publish-community-plugin" description="Package, test, and document a plugin for external users." />
+<Card title="Publish a community adapter" href="/docs/guides/authoring/publish-community-adapter" description="Ship a provider route without adding it to core." />

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/index.mdx
@@ -1,0 +1,50 @@
+---
+title: Plugin system
+description: Transform send options, select routes, observe lifecycle events, enforce time bounds, and extend the typed client.
+---
+
+Plugins compose around `createEmailClient` without changing adapter implementations. Choose a built-in by the job it owns; do not stack plugins that solve the same problem.
+
+## Built-in plugins
+
+| Plugin | Use it for | Surface | Import |
+| --- | --- | --- | --- |
+| [Defaults](/docs/plugins/built-in/defaults) | Shared reply-to, headers, tags, metadata, and idempotency prefixes | `beforeSend` | `@opencoredev/email-sdk/plugins/defaults` |
+| [Routing](/docs/plugins/built-in/routing) | Select a registered adapter from the prepared message or send metadata | `beforeSend` | `@opencoredev/email-sdk/plugins/routing` |
+| [Timeout](/docs/plugins/built-in/timeout) | Bound one logical send, including retries and fallback, with caller cancellation preserved | `beforeSend` | `@opencoredev/email-sdk/plugins/timeout` |
+| [Observability](/docs/plugins/built-in/observability) | Emit redacted logs, metrics, and traces | hooks + middleware | `@opencoredev/email-sdk/plugins/observability` |
+| [Capture](/docs/plugins/built-in/capture) | Record lifecycle events for tests and local inspection | hooks + middleware + client extension | `@opencoredev/email-sdk/plugins/capture` |
+
+```ts title="src/email.ts"
+const email = createEmailClient({
+  adapters: [primary, transactional],
+  plugins: [
+    defaultsPlugin({ replyTo: "support@example.com" }),
+    routingPlugin({
+      select: ({ message }) =>
+        message.tags?.some((tag) => tag.name === "transactional")
+          ? "transactional"
+          : undefined,
+    }),
+    timeoutPlugin({ timeoutMs: 10_000 }),
+  ],
+});
+```
+
+## Plugin surfaces
+
+| Surface | Purpose | Failure behavior |
+| --- | --- | --- |
+| `adapters` | Register additional routes synchronously. | Duplicate names fail client construction. |
+| `hooks` | Observe attempts, retries, success, and terminal errors. | Exceptions are swallowed. |
+| `middleware` | Transform messages/options and react after success or failure. | Exceptions become `EmailMiddlewareError`. |
+| `extendClient` | Add a typed application-facing property or method. | Reserved-key collisions fail client construction. |
+
+Plugin ids must be unique. Adapter registration and client construction stay synchronous. Order matters for `beforeSend`: each middleware receives the output of the previous one.
+
+## Build or install a plugin
+
+Community packages remain outside the core support boundary. Review source, dependency versions, field validation, secret handling, and maintenance status before use.
+
+<Card title="Write a plugin" href="/docs/guides/authoring/create-first-plugin" description="Build a typed plugin with middleware and a client extension." />
+<Card title="Plugin API" href="/docs/reference/plugin-api" description="Look up every plugin field and event type." />

--- a/apps/fumadocs/content/docs-v/1.0.0/plugins/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/plugins/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Plugins",
+  "icon": "Plug",
+  "pages": ["index", "built-in", "community"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/adapter-contract.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/adapter-contract.mdx
@@ -1,0 +1,74 @@
+---
+title: Adapter contract
+description: Exact v1 adapter capabilities, validation context, send context, personalized operation, and result contract.
+---
+
+```ts title="types.ts"
+type EmailAdapter<Name extends string = string, RawClient = unknown, RawResult = unknown> = {
+  readonly name: Name;
+  readonly capabilities: EmailAdapterCapabilities;
+  readonly raw?: RawClient;
+  validate?(message: EmailMessage, context: EmailAdapterValidationContext): MaybePromise<void>;
+  send(
+    message: EmailMessage,
+    context: EmailAdapterContext,
+  ): MaybePromise<EmailSendResult<Name, RawResult>>;
+  sendPersonalized?(
+    input: EmailPersonalizedInput,
+    context: EmailAdapterContext,
+  ): MaybePromise<EmailPersonalizedResult<Name>>;
+};
+```
+
+## Capabilities
+
+```ts title="types.ts"
+type EmailAdapterCapabilities = {
+  repeatedHeaders: boolean;
+  idempotency: "native" | "message_id" | "none";
+  scheduling: boolean;
+  personalized: "native" | "expanded" | "unsupported";
+};
+```
+
+Capabilities are enforced by the client. They do not replace adapter-specific field and limit validation.
+
+## Validation context
+
+```ts title="types.ts"
+type EmailAdapterValidationContext = {
+  adapter: string;
+  operation: "send" | "personalized";
+};
+```
+
+`validate` must be deterministic and no-network. It runs for every candidate route before the first adapter send.
+
+## Send context
+
+```ts title="types.ts"
+type EmailAdapterContext = EmailAdapterValidationContext & {
+  attempt: number;
+  signal?: AbortSignal;
+  idempotencyKey?: string;
+  metadata?: Readonly<Record<string, unknown>>;
+};
+```
+
+Forward `signal` to network work. Honor idempotency only when the provider or transport supports the declared capability.
+
+## Results
+
+Return the adapter routing name and normalized receipt fields. `raw` may keep an adapter-specific typed response for application code, but AI integrations intentionally project it away.
+
+## Failures
+
+Throw `EmailValidationError` for caller input the adapter can reject before dispatch. Throw `EmailAdapterError` for provider or transport failures.
+
+`delivery: "not_sent"` requires proof that the provider did not accept the message. Use `unknown` for timeouts and failures after possible dispatch.
+
+## Personalized operation
+
+Implement `sendPersonalized` only for a native bulk/personalization API. Adapters with `personalized: "expanded"` can omit it; the client renders and sends recipients sequentially.
+
+<Card title="Create an adapter" href="/docs/guides/authoring/create-adapter" description="Build and test a complete implementation." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/cli/adapters.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/cli/adapters.mdx
@@ -1,0 +1,19 @@
+---
+title: email-sdk adapters
+description: List every bundled CLI adapter with required environment variables and provider notes.
+---
+
+```bash
+email-sdk adapters
+email-sdk adapters --json
+```
+
+The command reads the static CLI registry and does not inspect credentials or make network requests.
+
+The current registry contains 23 routes: Resend, Postmark, SendGrid, Cloudflare, Unosend, Iterable, AWS SES, Mailgun, MailerSend, Brevo, Mailchimp Transactional, SparkPost, Loops, Sequenzy, JetEmail, Lettermint, Primitive, Plunk, Mailtrap, Scaleway, ZeptoMail, MailPace, and SMTP.
+
+The human output includes the routing name, required environment variable names, and one provider note. JSON output returns the same `name`, `env`, and `note` records.
+
+`email-sdk providers` is an accepted command alias.
+
+<Card title="Provider credentials" href="/docs/getting-started/credentials" description="Configure the values listed by this command." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/cli/doctor.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/cli/doctor.mdx
@@ -1,0 +1,34 @@
+---
+title: email-sdk doctor
+description: Check whether required adapter configuration is present without authenticating to the provider.
+---
+
+```bash
+RESEND_API_KEY=re_xxx email-sdk doctor --adapter resend
+```
+
+Success prints:
+
+```text
+resend looks configured.
+```
+
+## Selection
+
+Use `--adapter <name>` or the `--provider` alias. Without either flag, the command selects the first adapter whose required environment variables are all set.
+
+## What it checks
+
+`doctor` checks the required environment variables from the CLI registry. It also recognizes the corresponding credential flags, such as `--api-key`, `--server-token`, `--host`, or provider-specific account fields.
+
+It does not call the provider, verify sender domains, inspect API scopes, or prove deliverability.
+
+## Failures
+
+- Unknown adapter: `Unsupported adapter "<name>".`
+- Missing values: `Missing environment for <adapter>: <NAMES>`
+- No explicit or detectable route: `Pass --adapter or set the required environment for one adapter.`
+
+Use `send --dry-run` after doctor to validate a representative message and adapter-specific constraints.
+
+<Card title="Send command" href="/docs/reference/cli/send" description="Validate the exact message without provider delivery." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/cli/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/cli/index.mdx
@@ -1,0 +1,33 @@
+---
+title: CLI reference
+description: Commands, runtime, aliases, telemetry, adapter detection, and exit behavior for the email-sdk binary.
+---
+
+The `@opencoredev/email-sdk` package installs the `email-sdk` binary with a Node shebang. It supports Node.js 20+ and Bun 1.1+.
+
+## Commands
+
+| Command | Purpose |
+| --- | --- |
+| `version` | Print package name and version; `--json` returns JSON. |
+| `adapters` | List bundled adapter names, required environment, and notes; `--json` returns JSON. |
+| `doctor` | Check whether required values are present for one adapter. |
+| `send` | Build, validate, and optionally send one message. |
+
+`providers` aliases `adapters`. `--provider` aliases `--adapter` in CLI input, but new examples use adapter vocabulary.
+
+## Adapter selection
+
+Pass `--adapter`. If omitted, `doctor` and `send` select the first bundled adapter whose required environment variables are all present. Explicit selection is clearer when more than one credential set exists.
+
+## Failures
+
+Usage and SDK errors print one message to stderr and exit with status 1. Unexpected errors are rethrown after telemetry flush.
+
+## Telemetry
+
+CLI runs use the same default telemetry and environment opt-outs as the SDK. Set `EMAIL_SDK_TELEMETRY=0` for repeatable smoke tests.
+
+<Card title="List adapters" href="/docs/reference/cli/adapters" description="Inspect the bundled registry and credential names." />
+<Card title="Check setup" href="/docs/reference/cli/doctor" description="Verify required values are present." />
+<Card title="Validate or send" href="/docs/reference/cli/send" description="See every message and adapter flag." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/cli/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/cli/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "CLI commands",
+  "icon": "Terminal",
+  "pages": ["index", "adapters", "doctor", "send"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/cli/send.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/cli/send.mdx
@@ -1,0 +1,49 @@
+---
+title: email-sdk send
+description: Build one message from flags or JSON, validate it with the selected adapter, and optionally send it.
+---
+
+## Safe dry run
+
+```bash
+EMAIL_SDK_TELEMETRY=0 email-sdk send \
+  --adapter resend \
+  --from "Acme <hello@example.com>" \
+  --to user@example.com \
+  --subject "Welcome" \
+  --text "Your account is ready." \
+  --dry-run
+```
+
+Dry run creates the real adapter with placeholder credentials where needed, calls `client.validate`, and prints `{ ok, adapter, message }`. It does not call the adapter send method. Attachment output includes paths and metadata, never file contents.
+
+## Message flags
+
+| Flag | Behavior |
+| --- | --- |
+| `--from` | Sender address |
+| `--to` | Comma-separated recipients |
+| `--subject` | Subject |
+| `--text`, `--html` | At least one body |
+| `--cc`, `--bcc`, `--reply-to` | Comma-separated addresses |
+| `--header "Name: value"` | Repeatable lossless headers |
+| `--tag name=value` | Repeatable tags |
+| `--metadata key=value` | Repeatable provider metadata, parsed as strings |
+| `--attachment path[:type]` | Repeatable server-side files; `--attach` also works |
+| `--message path` | Start from an `EmailMessage` JSON file; explicit flags override fields |
+| `--send-at` | RFC 3339 schedule for capable adapters |
+| `--dry-run` | Validate and print without sending |
+
+## Adapter flags
+
+Common credential flags include `--api-key`, `--server-token`, and `--base-url`. Cloudflare adds `--api-token` and `--account-id`. Iterable adds `--campaign-id`, `--iterable-send-at`, and `--allow-repeat-marketing-sends`. SMTP adds host, port, TLS, and auth flags.
+
+Run `email-sdk help` for the current list.
+
+## Live sends
+
+Without `--dry-run`, the command constructs one adapter, calls `client.send`, and prints the normalized result as JSON. There is no CLI fallback route or retry flag.
+
+Do not run a live command against an external recipient without approval.
+
+<Card title="Adapter pages" href="/docs/adapters" description="See provider-specific environment and field rules." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/client.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/client.mdx
@@ -1,0 +1,129 @@
+---
+title: Client reference
+description: Exact construction options, methods, routing helpers, validation results, and send results for the v1 client.
+---
+
+## `createEmailClient(options)`
+
+Construction is synchronous and requires at least one adapter after plugins register their routes.
+
+```ts title="types.ts"
+type EmailClientOptions<Adapters, Plugins> = {
+  adapters?: Adapters;
+  defaultAdapter?: Adapters[number]["name"];
+  fallback?: EmailFallbackConfig<Adapters[number]["name"]>;
+  retry?: EmailRetryConfig;
+  hooks?: EmailHooks;
+  plugins?: Plugins;
+  telemetry?: boolean;
+};
+```
+
+| Option | Default | Behavior |
+| --- | --- | --- |
+| `adapters` | `[]` | Literal-named adapter routes. Plugins may add routes. |
+| `defaultAdapter` | First registered adapter | Primary route for operations without an override. |
+| `fallback` | No fallback | Candidate adapters and unknown-delivery policy. |
+| `retry` | `{ maxAttempts: 1 }` | Client-level retry policy. |
+| `hooks` | None | Best-effort lifecycle observers. |
+| `plugins` | `[]` | Synchronous route, hook, middleware, and extension composition. |
+| `telemetry` | `true` | Anonymous SDK analytics unless an environment opt-out applies. |
+
+Duplicate adapter names, duplicate plugin ids, unknown default/fallback names, `maxAttempts < 1`, async plugin adapters, and extension-key collisions throw during construction.
+
+## Client properties
+
+```ts title="types.ts"
+readonly adapters: ReadonlyMap<RouteName, EmailAdapter>;
+readonly defaultAdapter: RouteName;
+```
+
+## `validate(message, options?)`
+
+Runs common message, route, capability, adapter-specific, schedule, and personalized checks without calling an adapter's send method.
+
+```ts title="types.ts"
+type EmailValidationResult<Name extends string> = {
+  adapter: Name;
+  warnings: readonly { code: string; message: string }[];
+};
+```
+
+Built-in validation currently returns an empty warnings array on success.
+
+## `send(message, options?)`
+
+```ts title="types.ts"
+type EmailSendOptions<Name extends string> = {
+  adapter?: Name;
+  fallback?: {
+    adapters: readonly Name[];
+    onUnknownDelivery?: "stop" | "continue";
+  };
+  retry?: {
+    maxAttempts?: number;
+    delay?: (attempt: number, error: EmailSdkError) => number;
+    shouldRetry?: (error: EmailSdkError, attempt: number) => boolean;
+  };
+  signal?: AbortSignal;
+  idempotencyKey?: string;
+  metadata?: Readonly<Record<string, unknown>>;
+};
+```
+
+Per-send retry and fallback objects replace the client objects. `adapter` selects the primary route. `metadata` is lifecycle context, separate from provider-facing `message.metadata`.
+
+```ts title="types.ts"
+type EmailSendResult<Name extends string = string, Raw = unknown> = {
+  adapter: Name;
+  id?: string;
+  accepted?: readonly string[];
+  rejected?: readonly string[];
+  raw?: Raw;
+};
+```
+
+## `sendMany(items, options?)`
+
+```ts title="types.ts"
+type EmailSendItem<Name extends string> = {
+  message: EmailMessage;
+  options?: EmailSendOptions<Name>;
+};
+
+type EmailSendSettledResult<Name extends string> =
+  | { ok: true; index: number; result: EmailSendResult<Name> }
+  | { ok: false; index: number; error: EmailSdkError };
+```
+
+Items run sequentially in input order. Item options shallowly override method options. The method always returns one settled result per item.
+
+## `sendPersonalized(input, options?)`
+
+```ts title="types.ts"
+type EmailPersonalizedInput = {
+  message: Omit<EmailMessage, "to" | "cc" | "bcc">;
+  recipients: readonly {
+    to: EmailAddress;
+    variables: Readonly<Record<string, string | number | boolean>>;
+  }[];
+};
+```
+
+At least one accepted recipient resolves with `accepted` and `rejected`. Zero accepted recipients throws `EmailAllRecipientsFailedError`.
+
+## `adapter(name)`
+
+Returns the exact adapter type for a registered literal name. Unknown runtime names throw `EmailAdapterNotFoundError`.
+
+## `withAdapter(name)`
+
+Returns `validate`, `send`, `sendMany`, and `sendPersonalized` bound to one adapter.
+
+```ts title="src/email.ts"
+const backup = email.withAdapter("backup");
+await backup.send(message);
+```
+
+<Card title="Message reference" href="/docs/reference/message" description="Look up every normalized message field." />
+<Card title="Error reference" href="/docs/reference/errors" description="Handle the closed v1 error union." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/community-registry.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/community-registry.mdx
@@ -1,0 +1,46 @@
+---
+title: Community registry
+description: Static registry schema, trust labels, and validation for third-party adapters and plugins.
+---
+
+The registry lives at `apps/fumadocs/content/community/plugins.json` and is rendered on the [community extensions page](/docs/plugins/community).
+
+## Entry fields
+
+| Field | Required | Contract |
+| --- | --- | --- |
+| `name` | Yes | Unique display name |
+| `package` | Yes | Unique valid npm package name |
+| `kind` | Yes | `adapter`, `plugin`, or `hybrid` |
+| `status` | Yes | `community`, `verified`, or `official` |
+| `description` | Yes | One-line summary |
+| `href` | Yes | HTTPS package or docs URL |
+| `repo` | Yes | HTTPS public source repository |
+| `maintainer` | Yes | Maintainer handle |
+| `pluginId` | When applicable | Unique plugin id |
+| `adapter` | Adapter/hybrid | Literal routing name |
+| `importName` | When applicable | Public factory export |
+| `verifiedVersion` | Verified/official | Exact audited version |
+| `verification` | Verified/official | Review metadata |
+
+Verification metadata requires `reviewedAt`, `reviewedBy`, `provenance: true`, `noInstallScripts: true`, and `runtimeDependencies`; notes are optional.
+
+## Status labels
+
+- `community` means listed by pull request without endorsement or audit.
+- `verified` means the exact `verifiedVersion` passed the configured static and npm checks.
+- `official` means maintained by OpenCore or in this repository.
+
+Verification does not carry forward automatically to a new package version.
+
+## Validate locally
+
+```bash
+bun run community:check
+```
+
+CI checks the schema, duplicates, required adapter names, and verification blocks. Network validation for verified and official entries downloads the declared package version and checks repository metadata, install scripts, runtime dependency count, Email SDK peer dependency, binary exports, and suspicious shipped JavaScript tokens.
+
+Static checks reduce obvious supply-chain risk but do not prove third-party code or provider behavior is safe.
+
+<Card title="Publish a plugin" href="/docs/guides/authoring/publish-community-plugin" description="Prepare a package and registry change." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/compatibility.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/compatibility.mdx
@@ -1,0 +1,41 @@
+---
+title: Compatibility subpath
+description: Temporary v0 source compatibility available only during the v1 major.
+---
+
+Import the migration bridge explicitly.
+
+```ts title="src/email.ts"
+import { createEmailClient } from "@opencoredev/email-sdk/compat";
+```
+
+The v1 root does not export legacy provider vocabulary or result aliases.
+
+## Translated surfaces
+
+Compat accepts and translates:
+
+- `providers` and `defaultProvider`
+- per-send `provider`, `fallbackAdapters`, and `fallbackProviders`
+- client `fallback: string[]`
+- `retry.retries` and per-send `retries`
+- `sendBatch` and legacy batch item routing fields
+- message-level `idempotencyKey`
+- message-level `recipientVariables`
+- result `provider` and `messageId`
+- legacy adapters without a capability declaration
+- legacy hooks, middleware, and plugin contexts
+
+Result aliases are non-enumerable getters. Compat warnings print once per deprecated feature only in development, never in production or tests.
+
+## Safety differences that compat does not undo
+
+Compat keeps v1 delivery certainty. Legacy fallback arrays become `{ adapters, onUnknownDelivery: "stop" }`. An ambiguous outcome does not automatically advance.
+
+Legacy adapters receive permissive inferred capabilities because v0 had no declarations. Treat that as a migration convenience and add explicit v1 capabilities before removing compat.
+
+## Removal plan
+
+The bridge exists for the v1 major and is excluded from the v2 contract. Do not build new features against it.
+
+<Card title="v0 to v1 migration" href="/docs/guides/migrate/v0-to-v1" description="Replace every translated surface with its v1 form." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/aborted.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/aborted.mdx
@@ -1,0 +1,18 @@
+---
+title: aborted
+description: An AbortSignal stopped active adapter work or retry backoff and cancelled the remaining route.
+---
+
+`EmailAbortError` has code `aborted`, is not retryable, and may retain the signal reason as its cause.
+
+Abort stops the complete route immediately. No later retry or fallback adapter runs.
+
+```ts title="src/send.ts"
+const controller = new AbortController();
+const pending = email.send(message, { signal: controller.signal });
+
+controller.abort("request closed");
+await pending; // throws EmailAbortError
+```
+
+Adapters should forward the signal to fetch, sockets, and other cancellable work. The core retry delay is also abortable.

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/adapter-error.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/adapter-error.mdx
@@ -1,0 +1,23 @@
+---
+title: adapter_error
+description: One adapter or transport failed with explicit retryability and delivery certainty.
+---
+
+`EmailAdapterError` exposes:
+
+- `adapter`
+- optional HTTP `status`
+- optional provider `requestId`
+- `retryable`
+- `delivery: "not_sent" | "unknown"`
+- standard `cause`
+
+`not_sent` means fallback may proceed. `unknown` means delivery cannot be ruled out and fallback stops by default.
+
+```ts title="src/send.ts"
+if (error instanceof EmailAdapterError && error.delivery === "unknown") {
+  await reconcileProviderState(error.requestId);
+}
+```
+
+A retryable flag does not override abort or unknown-delivery policy. It only participates in the configured retry decision for the current adapter.

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/adapter-not-found.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/adapter-not-found.mdx
@@ -1,0 +1,16 @@
+---
+title: adapter_not_found
+description: A runtime route name does not match a registered adapter.
+---
+
+`EmailAdapterNotFoundError` has code `adapter_not_found`, is not retryable, and exposes the missing `adapter` string.
+
+Literal route names normally fail type checking. This error remains necessary for values that enter from untyped configuration, JSON, plugin code, or other runtime boundaries.
+
+```ts title="src/send.ts"
+if (error instanceof EmailAdapterNotFoundError) {
+  console.error(error.adapter);
+}
+```
+
+List registered routes through `email.adapters` or run `email-sdk adapters` for bundled CLI names.

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/all-recipients-failed.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/all-recipients-failed.mdx
@@ -1,0 +1,12 @@
+---
+title: all_recipients_failed
+description: A personalized send accepted no recipients on any route allowed by delivery policy.
+---
+
+`EmailAllRecipientsFailedError` has code `all_recipients_failed` and exposes ordered adapter `failures`.
+
+`sendPersonalized` resolves partial success. This error appears only when `accepted` would be empty.
+
+Fallback is considered only when every recipient failure for the current route is `not_sent`, unless the caller explicitly enabled continuation after unknown delivery.
+
+Check recipient validation, native provider rejection details available through server-side causes, and adapter capability before retrying.

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Error reference
+description: Closed v1 error codes, exported classes, retryability, delivery certainty, and route failure structure.
+---
+
+Every SDK-owned failure extends `EmailSdkError` and uses one exported `EmailErrorCode`.
+
+| Code | Class | Key fields |
+| --- | --- | --- |
+| `validation_error` | `EmailValidationError` | Message and cause |
+| `adapter_not_found` | `EmailAdapterNotFoundError` | `adapter` |
+| `adapter_error` | `EmailAdapterError` | `adapter`, `status?`, `requestId?`, `retryable`, `delivery` |
+| `route_error` | `EmailRouteError` | Ordered `failures` |
+| `all_recipients_failed` | `EmailAllRecipientsFailedError` | Ordered `failures` |
+| `middleware_error` | `EmailMiddlewareError` | `phase` |
+| `aborted` | `EmailAbortError` | Cause |
+
+`isRetryableEmailError(error)` returns true only for `EmailSdkError` instances whose `retryable` field is true.
+
+Provider response bodies, credentials, URLs, filesystem paths, and arbitrary details are not public error fields.
+
+## Match safely
+
+```ts title="src/send.ts"
+try {
+  await email.send(message);
+} catch (error) {
+  if (error instanceof EmailAdapterError) {
+    console.error(error.adapter, error.status, error.delivery);
+  }
+}
+```
+
+<Card title="Troubleshooting" href="/docs/guides/troubleshoot-failed-sends" description="Diagnose failures by code and delivery classification." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/meta.json
@@ -1,0 +1,14 @@
+{
+  "title": "Error codes",
+  "icon": "CircleAlert",
+  "pages": [
+    "index",
+    "validation-error",
+    "adapter-not-found",
+    "adapter-error",
+    "route-error",
+    "all-recipients-failed",
+    "middleware-error",
+    "aborted"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/middleware-error.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/middleware-error.mdx
@@ -1,0 +1,16 @@
+---
+title: middleware_error
+description: Plugin middleware threw while preparing a send or handling its outcome.
+---
+
+`EmailMiddlewareError` has code `middleware_error`, is not retryable, and exposes `phase`:
+
+- `before_send`
+- `after_send`
+- `on_error`
+
+The original exception remains the standard `cause`.
+
+Hook exceptions do not produce this error because hooks are isolated and swallowed. Only middleware failures are delivery-visible.
+
+A `before_send` failure happens before adapter dispatch. An `after_send` failure can occur after the provider accepted the message, so application recovery must not assume the email was unsent.

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/route-error.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/route-error.mdx
@@ -1,0 +1,18 @@
+---
+title: route_error
+description: Every attempted adapter route failed without producing a successful normalized result.
+---
+
+`EmailRouteError` has code `route_error` and an ordered `failures: readonly EmailAdapterError[]` array.
+
+The array contains every terminal adapter failure reached by the route. Unknown delivery may stop the route before later configured adapters are attempted.
+
+```ts title="src/send.ts"
+if (error instanceof EmailRouteError) {
+  for (const failure of error.failures) {
+    console.error(failure.adapter, failure.delivery, failure.status);
+  }
+}
+```
+
+The error cause is the final failure in the array. Preserve ordering in diagnostics because it explains primary, retry, and fallback decisions.

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/errors/validation-error.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/errors/validation-error.mdx
@@ -1,0 +1,16 @@
+---
+title: validation_error
+description: The message, route, schedule, capability, or adapter-specific input is invalid before dispatch.
+---
+
+`EmailValidationError` has code `validation_error` and is not retryable.
+
+It covers missing required message fields, invalid attachment sources, invalid zoned timestamps, incompatible fallback fields, repeated headers on incapable adapters, recipient/tag limits, duplicate adapter/plugin names, invalid retry counts, and other synchronous configuration errors.
+
+Fix the input or client construction. Retrying unchanged data cannot succeed.
+
+```ts title="src/validate.ts"
+await email.validate(message, options);
+```
+
+Use public `validate` or CLI `send --dry-run` to reproduce this class without sending.

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/message.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/message.mdx
@@ -1,0 +1,99 @@
+---
+title: Message reference
+description: Exact v1 address, envelope, body, header, attachment, metadata, tag, and schedule types.
+---
+
+## `EmailMessage`
+
+A message requires `from`, at least one `to`, `subject`, and `text`, `html`, or both.
+
+```ts title="types.ts"
+type EmailMessage = EmailEnvelope &
+  ({ html: string; text?: string } | { text: string; html?: string });
+
+type EmailEnvelope = {
+  from: EmailAddress;
+  to: OneOrMany<EmailAddress>;
+  subject: string;
+  cc?: OneOrMany<EmailAddress>;
+  bcc?: OneOrMany<EmailAddress>;
+  replyTo?: OneOrMany<EmailAddress>;
+  headers?: readonly EmailHeader[];
+  attachments?: readonly EmailAttachment[];
+  tags?: readonly EmailTag[];
+  metadata?: Readonly<Record<string, string | number | boolean | null>>;
+  sendAt?: Date | Rfc3339Timestamp;
+};
+```
+
+## Addresses
+
+```ts title="types.ts"
+type EmailAddress = string | { email: string; name?: string };
+type OneOrMany<T> = T | readonly T[];
+```
+
+String values may be plain mailboxes or display-name forms such as `Acme <hello@example.com>`. Adapter-specific address rules still apply.
+
+## Headers
+
+```ts title="types.ts"
+type EmailHeader = { name: string; value: string };
+```
+
+Headers are an array so repeated names remain lossless. The client compares names case-insensitively and rejects duplicates when any candidate route lacks repeated-header capability.
+
+## Attachments
+
+```ts title="types.ts"
+type EmailAttachment = {
+  filename: string;
+  contentType?: string;
+  contentId?: string;
+  disposition?: "attachment" | "inline";
+} & (
+  | {
+      content: string | Uint8Array | ArrayBuffer | Blob;
+      path?: never;
+      contentEncoding?: "raw" | "base64";
+    }
+  | {
+      path: string;
+      content?: never;
+      contentEncoding?: never;
+    }
+);
+```
+
+Exactly one source is required. String content is raw by default and is encoded by adapters that require Base64. `path` is server-side filesystem input.
+
+## Tags and metadata
+
+```ts title="types.ts"
+type EmailTag = { name: string; value: string };
+```
+
+Tags and message metadata are provider-facing fields. Unsupported routes reject them. Send-option metadata is a separate `Record<string, unknown>` used as lifecycle context.
+
+## Scheduled sends
+
+`Rfc3339Timestamp` requires `Z` or a numeric offset. Offset-less and informal strings fail runtime validation.
+
+```ts title="src/message.ts"
+const sendAt = "2026-08-01T09:00:00-04:00" as const;
+```
+
+Past times are allowed at the SDK boundary because provider behavior and clock skew vary. The adapter/provider may send immediately or reject its scheduling window.
+
+## Personalized input
+
+`sendPersonalized` removes `to`, `cc`, and `bcc` from the shared message and accepts an explicit recipient array. Variable keys may contain letters, numbers, `_`, and hyphens. Recipient addresses must be unique.
+
+Unknown `%recipient.key%` tokens remain unchanged during expanded sending.
+
+## Idempotency
+
+`idempotencyKey` is not an `EmailMessage` field in v1. Pass it as the second argument to `send`, `sendMany` item options, or `sendPersonalized`.
+
+<Card title="Field support" href="/docs/adapters/field-support" description="See which built-in adapters map each optional field." />
+<Card title="Sending modes" href="/docs/concepts/sending-modes" description="Choose send, sendMany, or sendPersonalized." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Reference",
+  "icon": "LibraryBig",
+  "pages": [
+    "client",
+    "message",
+    "adapter-contract",
+    "plugin-api",
+    "community-registry",
+    "compatibility",
+    "telemetry",
+    "cli",
+    "errors"
+  ]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/plugin-api.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/plugin-api.mdx
@@ -1,0 +1,69 @@
+---
+title: Plugin API
+description: Exact plugin context, hooks, middleware, adapter registration, and typed client extension contracts.
+---
+
+## `EmailPlugin`
+
+```ts title="types.ts"
+type EmailPlugin<Extension extends object = object> = {
+  id: string;
+  adapters?: EmailAdapter[] | ((ctx: EmailPluginContext) => EmailAdapter[]);
+  hooks?: EmailHooks;
+  middleware?: EmailSendMiddleware[];
+  extendClient?: (ctx: EmailPluginContext) => Extension;
+};
+```
+
+Plugin ids are unique. Adapter registration and client extensions run synchronously during construction.
+
+## Plugin context
+
+```ts title="types.ts"
+type EmailPluginContext = {
+  adapters: ReadonlyMap<string, EmailAdapter>;
+  defaultAdapter: string;
+  addAdapter(adapter: EmailAdapter): void;
+};
+```
+
+`addAdapter` rejects duplicate route names.
+
+## Hooks
+
+```ts title="types.ts"
+type EmailHooks = {
+  beforeSend?(event: EmailHookEvent): MaybePromise<void>;
+  afterSend?(event: EmailAfterSendEvent): MaybePromise<void>;
+  onError?(event: EmailErrorEvent): MaybePromise<void>;
+  onRetry?(event: EmailHookEvent & {
+    error: EmailSdkError;
+    nextAttempt: number;
+    delayMs: number;
+  }): MaybePromise<void>;
+};
+```
+
+Hook exceptions are swallowed. Use them only for best-effort observation.
+
+## Middleware
+
+```ts title="types.ts"
+type EmailSendMiddleware = {
+  beforeSend?(event: EmailBeforeSendEvent): MaybePromise<EmailBeforeSendResult | void>;
+  afterSend?(event: EmailAfterSendEvent): MaybePromise<void>;
+  onError?(event: EmailErrorEvent): MaybePromise<void>;
+};
+```
+
+`beforeSend` may replace the message and/or send options. Middleware exceptions become `EmailMiddlewareError` with a phase.
+
+Multiple `beforeSend` middleware entries run in order. Replacement options shallowly merge into the current options.
+
+## Client extensions
+
+`extendClient` returns an object merged into the client. The resulting extension type is the intersection of every plugin extension.
+
+Reserved-key collisions throw `EmailValidationError` during construction.
+
+<Card title="Create a plugin" href="/docs/guides/authoring/create-first-plugin" description="Build a typed middleware and extension example." />

--- a/apps/fumadocs/content/docs-v/1.0.0/reference/telemetry.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/reference/telemetry.mdx
@@ -1,0 +1,47 @@
+---
+title: Telemetry and privacy
+description: Anonymous SDK and CLI analytics, redacted error reporting, storage, and opt-out behavior.
+---
+
+Core SDK and CLI telemetry are enabled by default. The first enabled run prints an opt-out notice to stderr and stores a random anonymous id plus the notice marker.
+
+## Opt out
+
+```bash
+export EMAIL_SDK_TELEMETRY=0
+# or
+export DO_NOT_TRACK=1
+```
+
+```ts title="src/email.ts"
+const email = createEmailClient({
+  adapters: [adapter],
+  telemetry: false,
+});
+```
+
+`NODE_ENV=test` also disables capture. Repository tests use a Bun preload that sets `EMAIL_SDK_TELEMETRY=0` for every in-process run.
+
+When disabled, telemetry does not write config, print the notice, or make network requests.
+
+## Events
+
+The current event names are `client created`, `email sent`, `email batch sent`, and `cli command run`.
+
+Allowed facts include built-in adapter names, operation/command names, counts, success, durations, stable error codes, runtime and SDK versions, CI facts, and feature-presence booleans. Custom adapter names become `custom`.
+
+## Error reports
+
+Handled provider and unknown failures may produce a PostHog `$exception` event. Caller validation mistakes and unknown adapter names are excluded.
+
+Error reporting limits cause depth, frames, message length, duplicate classes, and reports per process. It scrubs email addresses, URLs, quoted text, long tokens, home directories, and filesystem paths from messages and stacks.
+
+## Data that is not collected
+
+Telemetry does not collect message bodies, subjects, addresses, headers, attachments, credentials, idempotency keys, provider response bodies, URLs, or filesystem paths.
+
+## Local state
+
+The default state file is `~/.config/email-sdk/telemetry.json`, or `$XDG_CONFIG_HOME/email-sdk/telemetry.json` when `XDG_CONFIG_HOME` is set.
+
+<Card title="Observability plugin" href="/docs/plugins/built-in/observability" description="Configure your own application log, metric, and trace events." />

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/account/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/account/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Account",
+  "icon": "KeyRound",
+  "pages": ["verification-code", "password-reset", "team-invite"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/account/password-reset.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/account/password-reset.mdx
@@ -1,0 +1,50 @@
+---
+title: Password reset
+description: A secure reset action with request context.
+---
+
+<EmailExample id="password-reset" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/password-reset.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/password-reset.tsx"
+import {
+  EmailButton,
+  EmailCard,
+  EmailHeading,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function PasswordResetEmail({ resetUrl }: { resetUrl: string }) {
+  return (
+    <ShadcnEmail preview="Reset your password within the next 30 minutes">
+      <EmailCard>
+        <EmailHeading>Reset your password</EmailHeading>
+        <EmailText>
+          We received a request to reset the password for your Acme account.
+        </EmailText>
+        <EmailButton href={resetUrl}>Reset password</EmailButton>
+        <EmailText muted style={{ fontSize: 13, marginTop: 20 }}>
+          This link expires in 30 minutes. The request came from Safari on macOS.
+        </EmailText>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/account/team-invite.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/account/team-invite.mdx
@@ -1,0 +1,56 @@
+---
+title: Team invite
+description: A personal invitation to join a workspace.
+---
+
+<EmailExample id="team-invite" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/team-invite.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/team-invite.tsx"
+import {
+  EmailButton,
+  EmailCard,
+  EmailHeading,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function TeamInviteEmail({ inviteUrl, inviter }: {
+  inviteUrl: string;
+  inviter: string;
+}) {
+  return (
+    <ShadcnEmail preview={`${inviter} invited you to join Acme`}>
+      <EmailCard>
+        <EmailHeading>Join {inviter} on Acme</EmailHeading>
+        <EmailText>{inviter} invited you to collaborate in the Acme workspace.</EmailText>
+        <EmailText style={{
+          borderLeft: "2px solid #d4d4d8",
+          color: "#52525b",
+          fontStyle: "italic",
+          paddingLeft: 16,
+        }}>
+          “We’re keeping launch notes, approvals, and customer updates here.”
+        </EmailText>
+        <EmailButton href={inviteUrl}>Join workspace</EmailButton>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/account/verification-code.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/account/verification-code.mdx
@@ -1,0 +1,56 @@
+---
+title: Verification code
+description: A focused one-time code with a clear expiry.
+---
+
+<EmailExample id="verification-code" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/verification-code.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/verification-code.tsx"
+import {
+  EmailCard,
+  EmailHeading,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function VerificationCodeEmail({ code }: { code: string }) {
+  return (
+    <ShadcnEmail preview={`${code} is your verification code`}>
+      <EmailCard>
+        <EmailHeading>Verify your email</EmailHeading>
+        <EmailText>Enter this code to finish signing in. It expires in 10 minutes.</EmailText>
+        <EmailText style={{
+          backgroundColor: "#f4f4f5",
+          borderRadius: 8,
+          fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+          fontSize: 28,
+          fontWeight: 700,
+          letterSpacing: 8,
+          padding: "18px 20px",
+          textAlign: "center",
+        }}>
+          {code}
+        </EmailText>
+        <EmailText muted>If you didn’t request this code, ignore this email.</EmailText>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/invoice-due.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/invoice-due.mdx
@@ -1,0 +1,56 @@
+---
+title: Invoice due
+description: A clear invoice summary before payment is due.
+---
+
+<EmailExample id="invoice-due" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/invoice-due.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/invoice-due.tsx"
+import {
+  EmailButton,
+  EmailCard,
+  EmailHeading,
+  EmailSeparator,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function InvoiceDueEmail({ amount, dueDate, invoiceUrl }: {
+  amount: string;
+  dueDate: string;
+  invoiceUrl: string;
+}) {
+  return (
+    <ShadcnEmail preview={`Your invoice is due ${dueDate}`}>
+      <EmailCard>
+        <EmailHeading>Invoice due {dueDate}</EmailHeading>
+        <EmailText>
+          Your invoice is ready and will be charged to your saved payment method.
+        </EmailText>
+        <EmailSeparator />
+        <EmailText muted>Amount due</EmailText>
+        <EmailText style={{ fontSize: 24, fontWeight: 700 }}>{amount}</EmailText>
+        <EmailText muted>Due date: {dueDate}</EmailText>
+        <EmailButton href={invoiceUrl}>View invoice</EmailButton>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Commerce",
+  "icon": "ReceiptText",
+  "pages": ["receipt", "invoice-due", "refund-confirmed"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/receipt.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/receipt.mdx
@@ -1,0 +1,54 @@
+---
+title: Receipt
+description: A compact payment confirmation and receipt link.
+---
+
+<EmailExample id="receipt" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/receipt.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/receipt.tsx"
+import {
+  EmailButton,
+  EmailCard,
+  EmailHeading,
+  EmailSeparator,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function ReceiptEmail({ amount, receiptUrl }: {
+  amount: string;
+  receiptUrl: string;
+}) {
+  return (
+    <ShadcnEmail preview="Payment received for order #1842">
+      <EmailCard>
+        <EmailHeading>Payment received</EmailHeading>
+        <EmailText>Thanks for your payment. Here’s a summary for order #1842.</EmailText>
+        <EmailSeparator />
+        <EmailText>Acme Pro · July <strong>{amount}</strong></EmailText>
+        <EmailText>Tax <strong>$0.00</strong></EmailText>
+        <EmailSeparator />
+        <EmailText style={{ fontSize: 18, fontWeight: 700 }}>Total {amount}</EmailText>
+        <EmailButton href={receiptUrl}>View receipt</EmailButton>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/refund-confirmed.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/commerce/refund-confirmed.mdx
@@ -1,0 +1,49 @@
+---
+title: Refund confirmed
+description: A reassuring refund status with timing details.
+---
+
+<EmailExample id="refund-confirmed" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/refund-confirmed.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/refund-confirmed.tsx"
+import {
+  EmailCard,
+  EmailHeading,
+  EmailSeparator,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function RefundConfirmedEmail({ amount }: { amount: string }) {
+  return (
+    <ShadcnEmail preview={`Your ${amount} refund is on its way`}>
+      <EmailCard>
+        <EmailHeading>Your refund is on its way</EmailHeading>
+        <EmailText>We issued a {amount} refund to your Visa ending in 4242.</EmailText>
+        <EmailSeparator />
+        <EmailText muted>Refund amount</EmailText>
+        <EmailText style={{ fontSize: 24, fontWeight: 700 }}>{amount}</EmailText>
+        <EmailText muted>Expected in 3–5 business days</EmailText>
+        <EmailText muted>Your bank may take additional time to post the credit.</EmailText>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/components.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/components.mdx
@@ -1,0 +1,52 @@
+---
+title: Components
+description: The small set of email-safe primitives used by every template.
+---
+
+Use these server-rendered components instead of your app’s browser UI components. They output portable inline HTML without CSS variables, client JavaScript, or Radix dependencies.
+
+## ShadcnEmail
+
+The root document supplies preview text, background, font, width, and theme.
+
+```tsx
+<ShadcnEmail preview="Your receipt is ready" theme="dark">
+  {/* email content */}
+</ShadcnEmail>
+```
+
+`theme` accepts `"light"`, `"dark"`, or resolved token overrides from `createShadcnEmailTheme()`.
+
+## Content primitives
+
+```tsx
+<EmailCard>
+  <EmailHeading>Welcome to Acme</EmailHeading>
+  <EmailText>Your workspace is ready.</EmailText>
+  <EmailButton href="https://acme.com/dashboard">Open dashboard</EmailButton>
+  <EmailSeparator />
+</EmailCard>
+```
+
+- `EmailCard` provides a centered, bordered content surface.
+- `EmailHeading` sets the primary email heading.
+- `EmailText` handles readable body copy and muted text.
+- `EmailButton` renders an inbox-safe link in default or outline style.
+- `EmailSeparator` adds a portable horizontal rule.
+
+## Theme tokens
+
+```tsx
+import { createShadcnEmailTheme } from "@opencoredev/email-sdk/react";
+
+const theme = createShadcnEmailTheme({
+  background: "#fafafa",
+  primary: "#7c3aed",
+  primaryForeground: "#ffffff",
+  radius: 12,
+});
+
+<ShadcnEmail theme={theme}>{/* email content */}</ShadcnEmail>;
+```
+
+Pass resolved colors rather than CSS variable expressions because email clients cannot reliably read your application stylesheet.

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/index.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/index.mdx
@@ -1,0 +1,32 @@
+---
+title: Email UI
+description: Browse complete, email-safe templates by the job they need to do.
+icon: Blocks
+---
+
+Start with a real email, see the rendered result, then copy the TSX into `src/ui/email`. Every example uses the same small set of Email SDK React components and works with any adapter after rendering.
+
+<EmailExampleGallery />
+
+## Install once
+
+```bash
+bun add react react-dom @react-email/render
+```
+
+Render any example with `renderEmail`, then pass the returned `html` and `text` through your normal Email SDK client.
+
+```tsx
+import { renderEmail } from "@opencoredev/email-sdk/react";
+
+const content = await renderEmail(<WelcomeEmail name="Ada" />);
+
+await email.send({
+  from: "Acme <hello@acme.com>",
+  to: "ada@example.com",
+  subject: "Welcome to Acme",
+  ...content,
+});
+```
+
+Routing, retries, fallback, scheduling, hooks, and telemetry still use the normal send pipeline.

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "UI",
+  "icon": "Blocks",
+  "pagesIndex": "index",
+  "pages": ["account", "product", "commerce", "components"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/product/meta.json
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/product/meta.json
@@ -1,0 +1,5 @@
+{
+  "title": "Product",
+  "icon": "Gauge",
+  "pages": ["welcome", "trial-ending", "usage-alert"]
+}

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/product/trial-ending.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/product/trial-ending.mdx
@@ -1,0 +1,53 @@
+---
+title: Trial ending
+description: An honest reminder before a trial expires.
+---
+
+<EmailExample id="trial-ending" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/trial-ending.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/trial-ending.tsx"
+import {
+  EmailButton,
+  EmailCard,
+  EmailHeading,
+  EmailSeparator,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function TrialEndingEmail({ endsOn }: { endsOn: string }) {
+  return (
+    <ShadcnEmail preview="Your Acme trial ends in 3 days">
+      <EmailCard>
+        <EmailHeading>Your trial ends in 3 days</EmailHeading>
+        <EmailText>
+          Your Acme trial ends {endsOn}. Your workspace and data will stay available.
+        </EmailText>
+        <EmailSeparator />
+        <EmailText muted>Current plan</EmailText>
+        <EmailText style={{ fontWeight: 700 }}>Pro trial</EmailText>
+        <EmailText muted>Trial ends</EmailText>
+        <EmailText style={{ fontWeight: 700 }}>{endsOn}</EmailText>
+        <EmailButton href="https://acme.com/plans">Choose a plan</EmailButton>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/product/usage-alert.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/product/usage-alert.mdx
@@ -1,0 +1,55 @@
+---
+title: Usage alert
+description: A calm limit warning with a direct next action.
+---
+
+<EmailExample id="usage-alert" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/usage-alert.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/usage-alert.tsx"
+import {
+  EmailButton,
+  EmailCard,
+  EmailHeading,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function UsageAlertEmail({ percent }: { percent: number }) {
+  return (
+    <ShadcnEmail preview={`You have used ${percent}% of this month’s email volume`}>
+      <EmailCard>
+        <EmailHeading>You’re nearing your email limit</EmailHeading>
+        <EmailText>Your workspace has used {percent}% of its monthly email volume.</EmailText>
+        <div style={{
+          backgroundColor: "#e4e4e7",
+          borderRadius: 999,
+          height: 8,
+          margin: "24px 0",
+          overflow: "hidden",
+        }}>
+          <div style={{ backgroundColor: "#18181b", height: "100%", width: `${percent}%` }} />
+        </div>
+        <EmailText>85,240 of 100,000 emails used</EmailText>
+        <EmailButton href="https://acme.com/usage">Review usage</EmailButton>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/content/docs-v/1.0.0/ui/product/welcome.mdx
+++ b/apps/fumadocs/content/docs-v/1.0.0/ui/product/welcome.mdx
@@ -1,0 +1,50 @@
+---
+title: Welcome
+description: A useful first step after account creation.
+---
+
+<EmailExample id="welcome" />
+
+## Installation
+
+<Tabs items={["CLI", "Manual"]}>
+<Tab value="CLI">
+
+```bash
+npx shadcn@latest add https://email-sdk.dev/r/welcome.json
+```
+
+</Tab>
+<Tab value="Manual">
+
+Copy this template into your app and customize its props, words, and links.
+
+```tsx title="src/ui/email/welcome.tsx"
+import {
+  EmailButton,
+  EmailCard,
+  EmailHeading,
+  EmailText,
+  ShadcnEmail,
+} from "@opencoredev/email-sdk/react";
+
+export function WelcomeEmail({ name }: { name: string }) {
+  return (
+    <ShadcnEmail preview="Your workspace is ready">
+      <EmailCard>
+        <EmailHeading>Your workspace is ready</EmailHeading>
+        <EmailText>
+          Welcome, {name}. Send your first email or invite your team when you’re ready.
+        </EmailText>
+        <EmailText>✓ Connect a provider</EmailText>
+        <EmailText>✓ Send a test email</EmailText>
+        <EmailText>✓ Invite your team</EmailText>
+        <EmailButton href="https://acme.com/dashboard">Open dashboard</EmailButton>
+      </EmailCard>
+    </ShadcnEmail>
+  );
+}
+```
+
+</Tab>
+</Tabs>

--- a/apps/fumadocs/source.config.ts
+++ b/apps/fumadocs/source.config.ts
@@ -9,6 +9,15 @@ export const docs = defineDocs({
   },
 });
 
+export const docsV100 = defineDocs({
+  dir: "content/docs-v/1.0.0",
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
+});
+
 export const docsV020 = defineDocs({
   dir: "content/docs-v/0.2.0",
   docs: {

--- a/apps/fumadocs/src/lib/source.ts
+++ b/apps/fumadocs/src/lib/source.ts
@@ -1,5 +1,6 @@
 import {
   docs,
+  docsV100,
   docsV020,
   docsV021,
   docsV030,
@@ -17,6 +18,11 @@ import { loader } from "fumadocs-core/source";
 import { resolveDocsIcon } from "./docs-icons";
 import { docsRoute } from "./shared";
 import { type DocsVersion, docsVersions, getDocsVersionBase, latestDocsVersion } from "./versions";
+
+const v100DocsVersion = docsVersions.find((version) => version.collection === "docsV100");
+if (!v100DocsVersion) {
+  throw new Error("Missing docs source config for v1.0.0");
+}
 
 const v020DocsVersion = docsVersions.find((version) => version.collection === "docsV020");
 if (!v020DocsVersion) {
@@ -77,6 +83,11 @@ const sources = {
   docs: loader({
     source: docs.toFumadocsSource(),
     baseUrl: docsRoute,
+    icon: resolveDocsIcon,
+  }),
+  docsV100: loader({
+    source: docsV100.toFumadocsSource(),
+    baseUrl: getDocsVersionBase(v100DocsVersion),
     icon: resolveDocsIcon,
   }),
   docsV065: loader({

--- a/apps/fumadocs/src/lib/versions.ts
+++ b/apps/fumadocs/src/lib/versions.ts
@@ -26,6 +26,16 @@ export const docsVersions = [
     external: false,
   },
   {
+    label: "v1.0.0",
+    version: "v1.0.0",
+    description: "Docs for the v1.0.0 release",
+    href: "/docs/v/1.0.0",
+    collection: "docsV100",
+    contentPath: "content/docs-v/1.0.0",
+    current: false,
+    external: false,
+  },
+  {
     label: "v0.6.5",
     version: "v0.6.5",
     description: "Docs for the v0.6.5 patch release",

--- a/apps/fumadocs/src/routes/docs/$.tsx
+++ b/apps/fumadocs/src/routes/docs/$.tsx
@@ -171,6 +171,7 @@ function createDocsClientLoader(collection: (typeof browserCollections)[DocsVers
 
 const clientLoaders = {
   docs: createDocsClientLoader(browserCollections.docs),
+  docsV100: createDocsClientLoader(browserCollections.docsV100),
   docsV065: createDocsClientLoader(browserCollections.docsV065),
   docsV064: createDocsClientLoader(browserCollections.docsV064),
   docsV063: createDocsClientLoader(browserCollections.docsV063),


### PR DESCRIPTION
## Why

The 1.0.1 release PR cannot pass the docs version check until the published 1.0.0 docs have a frozen archive.

## What changed

- Copy the docs from the 1.0.0 git tag into the versioned docs archive.
- Register the archive with the server and browser loaders.

## Testing

- `EMAIL_SDK_VALIDATE_DOCS_PACKAGE_VERSION=1.0.1 bun run docs:versions:check`
- `bunx oxlint apps/fumadocs/source.config.ts apps/fumadocs/src/lib/source.ts apps/fumadocs/src/lib/versions.ts "apps/fumadocs/src/routes/docs/$.tsx"`
- `bun run release:ci` against the 1.0.1 release branch plus this commit