### PR TITLE
feat(email-sdk): add Cloudflare Worker binding support to cloudflare adapter

### DIFF
--- a/.changeset/add-cloudflare-worker-binding.md
+++ b/.changeset/add-cloudflare-worker-binding.md
@@ -1,0 +1,5 @@
+---
+"@opencoredev/email-sdk": minor
+---
+
+Add support for Cloudflare Email Workers binding (`SendEmail`) in `cloudflare` adapter.

--- a/apps/fumadocs/content/docs/adapters/cloudflare.mdx
+++ b/apps/fumadocs/content/docs/adapters/cloudflare.mdx
@@ -1,6 +1,6 @@
 ---
 title: Cloudflare Email Sending
-description: Send through Cloudflare's Email Sending REST API with plain-address recipients and a 50-recipient cap.
+description: Send through Cloudflare's Email Sending REST API or Worker binding with plain-address recipients and a 50-recipient cap.
 icon: cloudflare
 ---
 
@@ -12,11 +12,40 @@ icon: cloudflare
 
 These values come from the adapter's exported `capabilities` declaration. The [field support matrix](/docs/adapters/field-support) covers normalized message fields.
 
-The Cloudflare adapter calls Cloudflare's Email Sending REST API with plain `fetch`, so no Worker binding is required. It is the natural pick when your sending domain already lives in Cloudflare. The trade-off is strict recipient rules: plain addresses only, 50 recipients max.
+The Cloudflare adapter supports both Cloudflare Worker `send_email` bindings and Cloudflare's Email Sending REST API. It is the natural pick when your sending domain lives in Cloudflare or when sending directly from a Cloudflare Worker. The trade-off is strict recipient rules: plain addresses only, 50 recipients max.
 
 <ProviderBadge adapter="cloudflare" />
 
 ## Configure
+
+### Worker binding (Cloudflare Workers)
+
+In a Cloudflare Worker, bind Email Sending in your `wrangler.json` (or `wrangler.toml`) and pass the binding object (`env.SEB`) directly to the adapter.
+
+```ts title="src/index.ts"
+import { createEmailClient } from "@opencoredev/email-sdk";
+import { cloudflare } from "@opencoredev/email-sdk/cloudflare";
+
+export interface Env {
+  SEB: { send(message: any): Promise<unknown> };
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const email = createEmailClient({
+      adapters: [
+        cloudflare({
+          binding: env.SEB,
+        }),
+      ],
+    });
+
+    // ...
+  },
+};
+```
+
+### REST API
 
 Enable Email Sending for your account and domain, then create an [API token](https://dash.cloudflare.com/profile/api-tokens) with Email Sending permission. You also need your account ID.
 
@@ -36,23 +65,25 @@ export const email = createEmailClient({
 
 <TypeTable
   type={{
+    binding: {
+      description: "Cloudflare Worker SendEmail binding object (e.g. env.SEB). Mutually exclusive with REST API options.",
+      type: "CloudflareSendEmailBinding",
+    },
     apiToken: {
-      description: "Cloudflare API token with Email Sending permission.",
+      description: "Cloudflare API token with Email Sending permission. Required for REST API mode.",
       type: "string",
-      required: true,
     },
     accountId: {
-      description: "Cloudflare account ID used in the send endpoint path.",
+      description: "Cloudflare account ID used in the send endpoint path. Required for REST API mode.",
       type: "string",
-      required: true,
     },
     baseUrl: {
-      description: "Override the API origin, e.g. for a proxy.",
+      description: "Override the API origin, e.g. for a proxy. (REST API mode only)",
       type: "string",
       default: '"https://api.cloudflare.com/client/v4"',
     },
     fetch: {
-      description: "Custom fetch implementation for tests or special runtimes.",
+      description: "Custom fetch implementation for tests or special runtimes. (REST API mode only)",
       type: "typeof fetch",
     },
   }}
@@ -75,7 +106,7 @@ const result = await email.send({
 console.log(result.accepted); // delivered + queued recipients
 ```
 
-Cloudflare does not return a message id; instead `result.accepted` lists delivered and queued recipients and `result.rejected` lists permanent bounces. Total recipients across `to`, `cc`, and `bcc` are capped at 50.
+Cloudflare REST API does not return a message id; instead `result.accepted` lists delivered and queued recipients and `result.rejected` lists permanent bounces. Worker bindings return the message ID if provided by the binding. Total recipients across `to`, `cc`, and `bcc` are capped at 50.
 
 <Callout type="warn" title="Plain recipient addresses only">
   `to`, `cc`, and `bcc` must be bare addresses like `"user@example.com"`; a display name throws an
@@ -101,3 +132,4 @@ npx email-sdk send \
 ```
 
 Drop `--dry-run` for one real send; only Cloudflare can prove the domain and account are cleared to deliver.
+

--- a/apps/fumadocs/src/lib/docs-lastmod.generated.json
+++ b/apps/fumadocs/src/lib/docs-lastmod.generated.json
@@ -1,7 +1,7 @@
 {
   "adapters/brevo.mdx": "2026-07-22",
   "adapters/capability-groups.mdx": "2026-07-22",
-  "adapters/cloudflare.mdx": "2026-07-22",
+  "adapters/cloudflare.mdx": "2026-08-08",
   "adapters/field-support.mdx": "2026-07-22",
   "adapters/index.mdx": "2026-07-27",
   "adapters/iterable.mdx": "2026-07-22",
@@ -54,7 +54,7 @@
   "integrations/chat-sdk.mdx": "2026-07-22",
   "integrations/convex/index.mdx": "2026-07-22",
   "integrations/convex/sending-and-status.mdx": "2026-07-22",
-  "integrations/convex/setup.mdx": "2026-07-22",
+  "integrations/convex/setup.mdx": "2026-08-03",
   "integrations/convex/testing-and-recovery.mdx": "2026-07-22",
   "integrations/convex/webhooks.mdx": "2026-07-22",
   "plugins/built-in/capture.mdx": "2026-07-22",

--- a/packages/email-sdk/src/adapters.test.ts
+++ b/packages/email-sdk/src/adapters.test.ts
@@ -325,6 +325,56 @@ describe("provider payloads", () => {
     ).rejects.toThrow("cloudflare failed.");
   });
 
+  test("Cloudflare sends via Worker binding", async () => {
+    let sentPayload: any;
+    const binding = {
+      async send(payload: any) {
+        sentPayload = payload;
+        return { id: "msg_123" };
+      },
+    };
+
+    const adapter = cloudflare({ binding });
+    expect(adapter.raw).toEqual({ binding });
+
+    const response = await adapter.send(
+      {
+        ...cloudflareMessage,
+        to: "ada@example.com",
+        cc: "cc@example.com",
+        bcc: "bcc@example.com",
+      },
+      context,
+    );
+
+    expect(response.id).toBe("msg_123");
+    expect(response.accepted).toEqual(["ada@example.com", "cc@example.com", "bcc@example.com"]);
+    expect(sentPayload).toMatchObject({
+      from: { address: "hello@example.com", name: "Acme" },
+      to: ["ada@example.com"],
+      cc: ["cc@example.com"],
+      bcc: ["bcc@example.com"],
+      replyTo: "reply@example.com",
+      reply_to: "reply@example.com",
+      subject: "Welcome",
+      text: "Hello",
+      html: "<p>Hello</p>",
+      headers: { "X-Test": "yes" },
+    });
+  });
+
+  test("Cloudflare binding surfaces send errors", async () => {
+    const binding = {
+      async send() {
+        throw new Error("Binding send failed");
+      },
+    };
+
+    await expect(cloudflare({ binding }).send(cloudflareMessage, context)).rejects.toThrow(
+      "cloudflare failed: Binding send failed",
+    );
+  });
+
   test("Cloudflare exposes a safe HTTP error without the raw response body", async () => {
     const error = await cloudflare({
       apiToken: "cf_token",

--- a/packages/email-sdk/src/cloudflare.ts
+++ b/packages/email-sdk/src/cloudflare.ts
@@ -1,20 +1,42 @@
 import { EmailAdapterError, EmailValidationError } from "./errors.js";
 import { jsonProvider } from "./http.js";
-import { base64Attachments, commonHeadersObject, emailParts } from "./payloads.js";
-import type { EmailAddress, EmailMessage, EmailAdapter, OneOrMany } from "./types.js";
+import { base64Attachments, commonHeadersObject, emailParts, stringAddresses } from "./payloads.js";
+import type { EmailAddress, EmailAdapter, EmailMessage, OneOrMany } from "./types.js";
 import {
   SUPPORTED_MESSAGE_FIELDS,
   arrayify,
   assertMaxItems,
   assertSupportedMessageFields,
+  builtInAdapterDefinition,
 } from "./utils.js";
 
-export type CloudflareAdapterOptions = {
+export type CloudflareSendEmailBinding = {
+  send(message: any): Promise<unknown>;
+};
+
+export type CloudflareHttpAdapterOptions = {
   apiToken: string;
   accountId: string;
   baseUrl?: string;
   fetch?: typeof fetch;
+  binding?: never;
 };
+
+export type CloudflareBindingAdapterOptions = {
+  binding: CloudflareSendEmailBinding;
+  apiToken?: never;
+  accountId?: never;
+  baseUrl?: never;
+  fetch?: never;
+};
+
+export type CloudflareAdapterOptions =
+  | CloudflareHttpAdapterOptions
+  | CloudflareBindingAdapterOptions;
+
+export type CloudflareAdapterRaw =
+  | { baseUrl: string; accountId: string }
+  | { binding: CloudflareSendEmailBinding };
 
 type CloudflareSendResponse = {
   success?: boolean;
@@ -29,6 +51,85 @@ type CloudflareSendResponse = {
 
 export function cloudflare(
   options: CloudflareAdapterOptions,
+): EmailAdapter<"cloudflare", CloudflareAdapterRaw> {
+  if ("binding" in options && options.binding) {
+    return fromBinding(options.binding);
+  }
+
+  return fromHttp(options);
+}
+
+function fromBinding(
+  binding: CloudflareSendEmailBinding,
+): EmailAdapter<"cloudflare", { binding: CloudflareSendEmailBinding }> {
+  return {
+    name: "cloudflare",
+    ...builtInAdapterDefinition("cloudflare"),
+    raw: { binding },
+    async send(message) {
+      assertCloudflareMessage(message);
+
+      const attachments = await base64Attachments(message);
+
+      const payload = {
+        from: cloudflareAddress(message.from),
+        to: cloudflareRecipients(message.to),
+        cc: cloudflareOptionalRecipients(message.cc),
+        bcc: cloudflareOptionalRecipients(message.bcc),
+        replyTo: cloudflareOptionalReplyTo(message.replyTo),
+        reply_to: cloudflareOptionalReplyTo(message.replyTo),
+        subject: message.subject,
+        html: message.html,
+        text: message.text,
+        headers: commonHeadersObject(message),
+        attachments: attachments?.map((attachment) => ({
+          content: attachment.content,
+          filename: attachment.filename,
+          type: attachment.contentType ?? "application/octet-stream",
+          disposition: attachment.disposition ?? "attachment",
+          contentId: attachment.contentId,
+          content_id: attachment.contentId,
+        })),
+      };
+
+      try {
+        const result = (await binding.send(payload)) as
+          | { id?: string; messageId?: string }
+          | void;
+        const id =
+          typeof result === "object" && result !== null
+            ? (result.id ?? result.messageId)
+            : undefined;
+
+        const accepted = [
+          ...stringAddresses(message.to),
+          ...(message.cc ? stringAddresses(message.cc) : []),
+          ...(message.bcc ? stringAddresses(message.bcc) : []),
+        ];
+
+        return {
+          adapter: "cloudflare",
+          id,
+          accepted,
+          raw: result ?? undefined,
+        };
+      } catch (error) {
+        if (error instanceof EmailAdapterError || error instanceof EmailValidationError) {
+          throw error;
+        }
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        throw new EmailAdapterError(`cloudflare failed: ${errorMessage}`, {
+          adapter: "cloudflare",
+          cause: error,
+          retryable: false,
+        });
+      }
+    },
+  };
+}
+
+function fromHttp(
+  options: CloudflareHttpAdapterOptions,
 ): EmailAdapter<"cloudflare", { baseUrl: string; accountId: string }> {
   const baseUrl = options.baseUrl ?? "https://api.cloudflare.com/client/v4";
 


### PR DESCRIPTION
## Why

The Cloudflare adapter only supported Cloudflare's Email Sending REST API (`apiToken` and `accountId`). Applications running directly inside a Cloudflare Worker could not utilize the native `SendEmail` Worker binding (`env.SEB`), forcing unnecessary API token configuration.

## What changed

- add Cloudflare Worker Email Sending Binding (`SendEmail`) support to the `cloudflare()` adapter
- allow passing `binding` option (e.g. `binding: env.SEB`) as a mutually exclusive alternative to REST API credentials (`apiToken`/`accountId`)
- map message recipients (`to`, `cc`, `bcc`, `replyTo`), headers, text/html content, and attachments to the Cloudflare Worker binding payload
- add unit tests for binding send behavior, result message ID parsing, and error handling in `cloudflare.test.ts`
- update Cloudflare adapter documentation in `apps/fumadocs` with Worker binding configuration examples and `<TypeTable>` options
- add a minor changeset for `@opencoredev/email-sdk`