### PR TITLE
docs(site): add Context.dev and Customer.io sponsors

### DIFF
--- a/apps/fumadocs/public/landing/sponsors/context-dev.svg
+++ b/apps/fumadocs/public/landing/sponsors/context-dev.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 460 460">
+  <rect width="460" height="460" fill="#2e64e8" />
+  <path
+    fill="#fff"
+    d="M179 120h190c6 0 11 5 11 11v190c0 6-5 11-11 11H179c-6 0-11-5-11-11V131c0-6 5-11 11-11Z"
+  />
+  <circle cx="123" cy="277" r="64" fill="#fff" />
+  <circle cx="231" cy="269" r="63" fill="#2e64e8" />
+</svg>

--- a/apps/fumadocs/public/landing/sponsors/customerio.svg
+++ b/apps/fumadocs/public/landing/sponsors/customerio.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" rx="4" fill="#0b393d" />
+  <path fill="#dfffc9" d="M44 44h28l28 28-28 28-28-28V44Zm0 84 28-28 28 28-28 28H44v-28Z" />
+  <path fill="#dfffc9" d="M100 44h28l28 28v56l-28 28h-28v-28l28-28-28-28V44Z" />
+</svg>

--- a/apps/fumadocs/scripts/og/sponsor-row.test.ts
+++ b/apps/fumadocs/scripts/og/sponsor-row.test.ts
@@ -36,10 +36,21 @@ describe("og sponsor row", () => {
   });
 
   test("shrinks the row as sponsors are added instead of overflowing", () => {
-    const short = sponsorRowLayout(names.slice(0, -1));
-    const long = sponsorRowLayout(names);
+    const fittingNames = [
+      "Resend",
+      "Sequenzy",
+      "JetEmail",
+      "Primitive",
+      "Lettermint",
+      "Instatus",
+      "Neon",
+      "Notra",
+    ];
+    const short = sponsorRowLayout(fittingNames);
+    const long = sponsorRowLayout([...fittingNames, "Zernio"]);
 
-    expect(long.scale).toBeLessThan(short.scale);
+    expect(short.scale).toBe(1);
+    expect(long.scale).toBeLessThan(1);
     expect(long.slots.at(-1)!.labelEndX).toBeLessThanOrEqual(sponsorRowGeometry.rightEdge + 0.001);
   });
 

--- a/apps/fumadocs/scripts/og/sponsor-row.test.ts
+++ b/apps/fumadocs/scripts/og/sponsor-row.test.ts
@@ -36,11 +36,10 @@ describe("og sponsor row", () => {
   });
 
   test("shrinks the row as sponsors are added instead of overflowing", () => {
-    const short = sponsorRowLayout(names.slice(0, 4));
-    const long = sponsorRowLayout([...names, "Widework"]);
+    const short = sponsorRowLayout(names.slice(0, -1));
+    const long = sponsorRowLayout(names);
 
-    expect(short.scale).toBe(1);
-    expect(long.scale).toBeLessThan(1);
+    expect(long.scale).toBeLessThan(short.scale);
     expect(long.slots.at(-1)!.labelEndX).toBeLessThanOrEqual(sponsorRowGeometry.rightEdge + 0.001);
   });
 

--- a/apps/fumadocs/src/lib/sponsors.ts
+++ b/apps/fumadocs/src/lib/sponsors.ts
@@ -57,9 +57,19 @@ export const sponsors: readonly Sponsor[] = [
     href: "https://zernio.com",
     logo: "/landing/sponsors/zernio.svg",
   },
+  {
+    name: "Customer.io",
+    href: "https://github.com/customerio",
+    logo: "/landing/sponsors/customerio.svg",
+  },
+  {
+    name: "Context.dev",
+    href: "https://context.dev",
+    logo: "/landing/sponsors/context-dev.svg",
+  },
 ];
 
 // Keep the sponsor count plus the open slots a multiple of the five-column
 // landing grid, so the last row stays full instead of leaving one orphan tile.
-export const openSponsorSlots = [1] as const;
+export const openSponsorSlots = [1, 2, 3, 4] as const;
 export const sponsorHref = "https://github.com/sponsors/opencoredev";


### PR DESCRIPTION
## What changed

- Add Context.dev and Customer.io to the landing page sponsor grid.
- Add four open spots to complete the third five-column row.
- Update the social-image layout test for the larger sponsor list.

## Testing

- `bun test apps/fumadocs/src/lib/sponsors.test.ts apps/fumadocs/scripts/og/sponsor-row.test.ts`
- `bunx oxlint apps/fumadocs/src/lib/sponsors.ts apps/fumadocs/scripts/og/sponsor-row.test.ts`
- `git diff --check`
- Checked the three-row sponsor grid in the local browser.