### PR TITLE
fix(site): link Customer.io sponsor website

### DIFF
--- a/apps/fumadocs/src/lib/sponsors.ts
+++ b/apps/fumadocs/src/lib/sponsors.ts
@@ -59,7 +59,7 @@ export const sponsors: readonly Sponsor[] = [
   },
   {
     name: "Customer.io",
-    href: "https://github.com/customerio",
+    href: "https://customer.io",
     logo: "/landing/sponsors/customerio.svg",
   },
   {


### PR DESCRIPTION
Customer.io now links to its website instead of its GitHub organization.

Testing: `bun test apps/fumadocs/src/lib/sponsors.test.ts` and `bunx oxlint apps/fumadocs/src/lib/sponsors.ts`.