### PR TITLE
fix(site): keep crash pages out of Google snippets

### DIFF
--- a/apps/fumadocs/src/components/recovery-page.test.ts
+++ b/apps/fumadocs/src/components/recovery-page.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
 
-import { classifyRecoveryError, getErrorMessage } from "./recovery-page";
+import {
+  AppErrorPage,
+  NotFoundPage,
+  RootRecoveryShell,
+  classifyRecoveryError,
+  getErrorMessage,
+  recoveryRobots,
+} from "./recovery-page";
 
 describe("recovery page helpers", () => {
   test("classifies stale chunk load failures", () => {
@@ -38,5 +46,46 @@ describe("recovery page helpers", () => {
     const namelessError = new Error();
     namelessError.name = "";
     expect(getErrorMessage(namelessError)).toBe("Unknown error");
+  });
+});
+
+describe("recovery page markup", () => {
+  test("error page renders without a fumadocs provider and stays off the default TanStack copy", () => {
+    const html = renderToStaticMarkup(
+      AppErrorPage({
+        error: new Error("You need to wrap your application inside FrameworkProvider"),
+        reset: () => undefined,
+      }),
+    );
+
+    expect(html).not.toContain("Something went wrong");
+    expect(html).not.toContain("Show Error");
+    expect(html).toContain('name="robots"');
+    expect(html).toContain(recoveryRobots);
+    expect(html).toContain("The docs could not finish loading.");
+  });
+
+  test("not-found page is noindex and does not use the default error copy", () => {
+    const html = renderToStaticMarkup(NotFoundPage());
+
+    expect(html).not.toContain("Something went wrong");
+    expect(html).not.toContain("Show Error");
+    expect(html).toContain(recoveryRobots);
+    expect(html).toContain("That docs route is not here.");
+  });
+
+  test("root recovery shell ships a titled noindex document", () => {
+    const html = renderToStaticMarkup(
+      RootRecoveryShell({
+        children: "recovery",
+        stylesheetHref: "/app.css",
+      }),
+    );
+
+    expect(html).toContain("<title>Email SDK</title>");
+    expect(html).toContain('name="robots"');
+    expect(html).toContain(recoveryRobots);
+    expect(html).toContain('href="/app.css"');
+    expect(html).not.toContain("Untitled");
   });
 });

--- a/apps/fumadocs/src/components/recovery-page.tsx
+++ b/apps/fumadocs/src/components/recovery-page.tsx
@@ -1,5 +1,6 @@
 import type { ErrorComponentProps, NotFoundRouteProps } from "@tanstack/react-router";
-import { HomeLayout } from "fumadocs-ui/layouts/home";
+import type { ReactNode } from "react";
+
 import {
   ArrowRight,
   BookOpen,
@@ -11,9 +12,7 @@ import {
   ShieldCheck,
   TriangleAlert,
 } from "@/components/icon";
-import type { ReactNode } from "react";
-
-import { baseOptions } from "@/lib/layout.shared";
+import { appDescription, appName } from "@/lib/shared";
 
 type RecoveryKind = "chunk" | "dom" | "not-found" | "runtime";
 
@@ -23,6 +22,8 @@ type RecoveryCopy = {
   description: string;
   note: string;
 };
+
+export const recoveryRobots = "noindex, follow";
 
 const helpLinks = [
   {
@@ -68,6 +69,31 @@ export function AppErrorPage({ error, reset }: ErrorComponentProps) {
       onRetry={kind === "chunk" ? undefined : reset}
       status={kind === "chunk" ? "Reload needed" : "Runtime error"}
     />
+  );
+}
+
+export function RootRecoveryShell({
+  children,
+  stylesheetHref,
+}: {
+  children: ReactNode;
+  stylesheetHref: string;
+}) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta content="width=device-width, initial-scale=1" name="viewport" />
+        <title>{appName}</title>
+        <meta content={recoveryRobots} name="robots" />
+        <meta content={appDescription} name="description" />
+        <link href={stylesheetHref} rel="stylesheet" />
+        <link href="/favicon.ico" rel="icon" sizes="any" />
+      </head>
+      <body className="flex min-h-screen flex-col bg-fd-background text-fd-foreground">
+        {children}
+      </body>
+    </html>
   );
 }
 
@@ -144,6 +170,16 @@ function getRecoveryCopy(kind: RecoveryKind): RecoveryCopy {
   };
 }
 
+function RecoveryHead() {
+  return (
+    <>
+      <title>{appName}</title>
+      <meta content={recoveryRobots} name="robots" />
+      <meta content={appDescription} name="description" />
+    </>
+  );
+}
+
 function RecoveryLayout({
   copy,
   details,
@@ -158,8 +194,22 @@ function RecoveryLayout({
   status: string;
 }) {
   return (
-    <HomeLayout {...baseOptions()}>
-      <main className="min-h-[calc(100vh-4rem)] border-b border-fd-border bg-fd-background text-fd-foreground">
+    <div className="flex min-h-screen flex-col bg-fd-background text-fd-foreground">
+      <RecoveryHead />
+      <header className="border-b border-fd-border">
+        <div className="mx-auto flex w-full max-w-5xl items-center gap-3 px-6 py-4 md:px-10">
+          <img
+            alt=""
+            aria-hidden="true"
+            className="size-8 shrink-0 object-contain"
+            src="/logo.png"
+          />
+          <a className="text-sm font-medium" href="/">
+            {appName}
+          </a>
+        </div>
+      </header>
+      <main className="min-h-[calc(100vh-4rem)] border-b border-fd-border">
         <section className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-6 py-14 md:px-10 md:py-20">
           <div className="max-w-3xl">
             <div className="inline-flex items-center gap-2 rounded-md border border-fd-border bg-fd-muted px-2.5 py-1 text-xs font-medium text-fd-muted-foreground">
@@ -245,6 +295,6 @@ function RecoveryLayout({
           </a>
         </section>
       </main>
-    </HomeLayout>
+    </div>
   );
 }

--- a/apps/fumadocs/src/routes/__root.tsx
+++ b/apps/fumadocs/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import {
   Outlet,
   Scripts,
   type ErrorComponentProps,
+  type NotFoundRouteProps,
 } from "@tanstack/react-router";
 import { Analytics } from "@vercel/analytics/react";
 import { RootProvider } from "fumadocs-ui/provider/tanstack";
@@ -56,10 +57,10 @@ function RootErrorComponent(props: ErrorComponentProps) {
   );
 }
 
-function RootNotFoundComponent() {
+function RootNotFoundComponent(props: NotFoundRouteProps) {
   return (
     <RootRecoveryShell stylesheetHref={appCss}>
-      <NotFoundPage />
+      <NotFoundPage {...props} />
       <Scripts />
     </RootRecoveryShell>
   );

--- a/apps/fumadocs/src/routes/__root.tsx
+++ b/apps/fumadocs/src/routes/__root.tsx
@@ -1,8 +1,15 @@
-import { createRootRoute, HeadContent, Outlet, Scripts } from "@tanstack/react-router";
+import {
+  createRootRoute,
+  HeadContent,
+  Outlet,
+  Scripts,
+  type ErrorComponentProps,
+} from "@tanstack/react-router";
 import { Analytics } from "@vercel/analytics/react";
 import { RootProvider } from "fumadocs-ui/provider/tanstack";
 import * as React from "react";
 
+import { AppErrorPage, NotFoundPage, RootRecoveryShell } from "@/components/recovery-page";
 import SearchDialog from "@/components/search";
 import { StaleBuildNotice } from "@/components/stale-build-notice";
 import { chunkLoadGuardScript } from "@/lib/chunk-load-guard";
@@ -13,6 +20,8 @@ import { initPostHog } from "@/lib/posthog";
 import appCss from "@/styles/app.css?url";
 
 export const Route = createRootRoute({
+  errorComponent: RootErrorComponent,
+  notFoundComponent: RootNotFoundComponent,
   head: () => ({
     meta: siteMeta,
     links: [
@@ -37,6 +46,24 @@ export const Route = createRootRoute({
   }),
   component: RootComponent,
 });
+
+function RootErrorComponent(props: ErrorComponentProps) {
+  return (
+    <RootRecoveryShell stylesheetHref={appCss}>
+      <AppErrorPage {...props} />
+      <Scripts />
+    </RootRecoveryShell>
+  );
+}
+
+function RootNotFoundComponent() {
+  return (
+    <RootRecoveryShell stylesheetHref={appCss}>
+      <NotFoundPage />
+      <Scripts />
+    </RootRecoveryShell>
+  );
+}
 
 function RootComponent() {
   React.useEffect(() => {

--- a/apps/fumadocs/src/routes/sitemap[.]xml.ts
+++ b/apps/fumadocs/src/routes/sitemap[.]xml.ts
@@ -38,7 +38,7 @@ function getSitemapEntries() {
   const entries: SitemapEntry[] = [
     {
       loc: `${siteUrl}/`,
-      lastmod: "2026-06-01",
+      lastmod: "2026-08-24",
       changefreq: "weekly",
       priority: "1.0",
     },
@@ -62,7 +62,7 @@ function getSitemapEntries() {
     },
     {
       loc: `${siteUrl}/contact`,
-      lastmod: "2026-06-01",
+      lastmod: "2026-08-24",
       changefreq: "monthly",
       priority: "0.5",
     },


### PR DESCRIPTION
## Why
Google indexed email-sdk.dev/contact as Untitled with the snippet Something went wrong! Show Error. A root-route crash fell through to TanStack default error UI, and the custom recovery page crashed too because it used fumadocs HomeLayout.

## What changed
- Render a standalone recovery document that does not use fumadocs.
- Mark crash and not-found pages noindex, follow.
- Set root errorComponent and notFoundComponent.
- Bump sitemap lastmod for / and /contact.

## Testing
- bun test src/components/recovery-page.test.ts (7 pass)
- bunx oxlint on the touched files