### PR TITLE
docs(site): correct Lettr pricing tiers

### DIFF
--- a/apps/fumadocs/src/lib/adapter-pricing.test.ts
+++ b/apps/fumadocs/src/lib/adapter-pricing.test.ts
@@ -48,6 +48,38 @@ describe("adapter pricing", () => {
     });
   });
 
+  test("Lettr uses published volume tiers", () => {
+    const row = adapterPricing.find((entry) => entry.provider.key === "lettr");
+
+    expect(row).toBeDefined();
+    expect(getPrice(row!, 1_000)).toMatchObject({ kind: "money", currency: "USD", cents: 0 });
+    expect(getPrice(row!, 50_000)).toMatchObject({
+      kind: "money",
+      currency: "USD",
+      cents: 1_500,
+    });
+    expect(getPrice(row!, 100_000)).toMatchObject({
+      kind: "money",
+      currency: "USD",
+      cents: 3_000,
+    });
+    expect(getPrice(row!, 250_000)).toMatchObject({
+      kind: "money",
+      currency: "USD",
+      cents: 25_000,
+    });
+    expect(getPrice(row!, 500_000)).toMatchObject({
+      kind: "money",
+      currency: "USD",
+      cents: 25_000,
+    });
+    expect(getPrice(row!, 1_000_000)).toMatchObject({
+      kind: "money",
+      currency: "USD",
+      cents: 45_000,
+    });
+  });
+
   test("searches by provider name and filters selected-volume status", () => {
     expect(
       getAdapterPricingRows({ query: "SeQuEnZy" }).map((row) => row.provider.key),

--- a/apps/fumadocs/src/lib/adapter-pricing.ts
+++ b/apps/fumadocs/src/lib/adapter-pricing.ts
@@ -77,8 +77,8 @@ const pricingByProvider = {
   lettr: {
     model: "Plan + volume tiers",
     sources: [{ label: "Lettr pricing", href: "https://lettr.com/pricing" }],
-    note: "Free includes 3K. Pro is $15 through 100K. Business is $110 through 200K. Higher published volumes are custom.",
-    prices: [usd(0), usd(15), usd(15), custom, custom, custom],
+    note: "Free includes 3K. Published tiers are 50K at $15, 100K at $30, 200K at $110, 500K at $250, and 1M at $450. The 250K column uses the 500K tier.",
+    prices: [usd(0), usd(15), usd(30), usd(250), usd(250), usd(450)],
   },
   lettermint: {
     model: "Plan + overage · EUR",


### PR DESCRIPTION
## Why

Lettr's published tiers are 3K free, 50K at $15, 100K at $30, 200K at $110, 500K at $250, and 1M at $450. The compare table treated Pro as $15 through 100K and marked 250K+ as custom.

## What changed

- 1K stays free, 50K stays $15, 100K is $30
- 250K and 500K use the $250 tier (200K does not cover 250K)
- 1M is $450
- Test locks those six cells

## Testing

- `bun test src/lib/adapter-pricing.test.ts` in `apps/fumadocs`
